### PR TITLE
FIX: use EntryAssembly to retrieve version in enricher

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog/VersionEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog/VersionEnricher.cs
@@ -17,7 +17,7 @@ namespace Arcus.Observability.Telemetry.Serilog
         /// </summary>
         public VersionEnricher()
         {
-            var executingAssembly = Assembly.GetExecutingAssembly();
+            var executingAssembly = Assembly.GetEntryAssembly();
             if (executingAssembly == null)
             {
                 throw new InvalidOperationException(


### PR DESCRIPTION
Closes #26 