### PR TITLE
Automatically assign Context.Operation.Id with correlation info

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -15,6 +15,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     public abstract class CustomTelemetryConverter<TEntry> : TelemetryConverterBase
         where TEntry : ITelemetry, ISupportProperties
     {
+        private readonly OperationContextConverter _operationContextConverter = new OperationContextConverter();
         private readonly CloudContextConverter _cloudContextConverter = new CloudContextConverter();
 
         /// <summary>
@@ -28,6 +29,8 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
             AssignTelemetryContextProperties(logEvent, telemetryEntry);
             _cloudContextConverter.EnrichWithAppInfo(logEvent, telemetryEntry);
+            _operationContextConverter.EnrichWithCorrelationInfo(telemetryEntry);
+
             ForwardPropertiesToTelemetryProperties(logEvent, telemetryEntry, formatProvider);
             RemoveIntermediaryProperties(logEvent);
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -29,9 +29,9 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
             AssignTelemetryContextProperties(logEvent, telemetryEntry);
             _cloudContextConverter.EnrichWithAppInfo(logEvent, telemetryEntry);
-            _operationContextConverter.EnrichWithCorrelationInfo(telemetryEntry);
 
             ForwardPropertiesToTelemetryProperties(logEvent, telemetryEntry, formatProvider);
+            _operationContextConverter.EnrichWithCorrelationInfo(telemetryEntry);
             RemoveIntermediaryProperties(logEvent);
 
             return new List<ITelemetry> {telemetryEntry};

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -1,0 +1,30 @@
+﻿using Arcus.Observability.Telemetry.Core;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
+{
+    /// <summary>
+    /// Represents a conversion from the Operation-related logging information to the Application Insights <see cref="OperationContext"/> instance.
+    /// </summary>
+    public class OperationContextConverter
+    {
+        /// <summary>
+        /// Enrich the given <paramref name="telemetryEntry"/> with the Operation-related information.
+        /// </summary>
+        /// <param name="telemetryEntry">The telemetry instance to enrich.</param>
+        public void EnrichWithCorrelationInfo<TEntry>(TEntry telemetryEntry) where TEntry : ITelemetry, ISupportProperties
+        {
+            if (telemetryEntry?.Context?.Operation == null)
+            {
+                return;
+            }
+
+            if (telemetryEntry.Properties.TryGetValue(ContextProperties.Correlation.OperationId, out string correlationId))
+            {
+                telemetryEntry.Context.Operation.Id = correlationId;
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
@@ -12,6 +12,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     /// </summary>
     public class TraceTelemetryConverter : ApplicationInsightsSink.TelemetryConverters.TraceTelemetryConverter
     {
+        private readonly OperationContextConverter _operationContextConverter = new OperationContextConverter();
         private readonly CloudContextConverter _cloudContextConverter = new CloudContextConverter();
 
         /// <summary>
@@ -25,7 +26,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 _cloudContextConverter.EnrichWithAppInfo(logEvent, telemetry);
 
-                yield return telemetry;
+                var traceTelemetry = telemetry as TraceTelemetry;
+                _operationContextConverter.EnrichWithCorrelationInfo(traceTelemetry);
+
+                yield return traceTelemetry;
             }
         }
     }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/OperationContextConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/OperationContextConverterTests.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
+using Microsoft.ApplicationInsights.DataContracts;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog
+{
+    [Trait("Category", "Unit")]
+    public class OperationContextConverterTests
+    {
+        [Fact]
+        public void EnrichWithCorrelationInfo_TraceWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new TraceTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_TraceWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new TraceTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_EventWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new EventTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_EventWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new EventTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_MetricWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new MetricTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_MetricWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new MetricTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_DependencyWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new DependencyTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_DependencyWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new DependencyTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_RequestWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new RequestTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_RequestWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new RequestTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_ExceptionWithOperationId_OperationIdSetOnContext()
+        {
+            // Arrange
+            var operationId = Guid.NewGuid().ToString();
+            var traceTelemetry = new ExceptionTelemetry();
+            traceTelemetry.Properties.Add(ContextProperties.Correlation.OperationId, operationId);
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationId, traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithCorrelationInfo_ExceptionWithoutOperationId_NoOperationIdSetOnContext()
+        {
+            // Arrange
+            var traceTelemetry = new ExceptionTelemetry();
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithCorrelationInfo(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+    }
+}


### PR DESCRIPTION
Automatically assign Context.Operation.Id with correlation info

Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Relates to https://github.com/arcus-azure/arcus.observability/issues/69