### PR TITLE
Feature - use 'Context' instead of 'EventDescription' as property name

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -35,7 +35,7 @@ namespace Arcus.Observability.Telemetry.Core
             public const string EventName = "EventName";
             
             [Obsolete("Use " + nameof(ContextProperties) + "." + nameof(TelemetryContext) + " instead")]
-            public const string EventDescription = "EventDescription";
+            public const string EventContext = "EventDescription";
         }
 
         public static class General

--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -1,8 +1,12 @@
-﻿#pragma warning disable 1591
+﻿using System;
+
+#pragma warning disable 1591
 namespace Arcus.Observability.Telemetry.Core
 {
     public static class ContextProperties
     {
+        public const string TelemetryContext = "Context";
+
         public static class Correlation
         {
             public const string OperationId = "OperationId";
@@ -29,7 +33,9 @@ namespace Arcus.Observability.Telemetry.Core
         public static class EventTracking
         {
             public const string EventName = "EventName";
-            public const string EventContext = "EventDescription";
+            
+            [Obsolete("Use " + nameof(ContextProperties) + "." + nameof(TelemetryContext) + " instead")]
+            public const string EventDescription = "EventDescription";
         }
 
         public static class General

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.RequestTracking.ResponseStatusCode + "} in {"
             + ContextProperties.RequestTracking.RequestDuration + "} at {"
             + ContextProperties.RequestTracking.RequestTime + "} - (Context: {@"
-            + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.TelemetryContext + "})";
 
         private const string DependencyFormat =
             MessagePrefixes.Dependency + " {"
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.DependencyTracking.Duration + "} at {"
             + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
             + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.TelemetryContext + "})";
 
         private const string DependencyWithoutDataFormat =
             MessagePrefixes.Dependency + " {"
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.DependencyTracking.Duration + "} at {"
             + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
             + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.TelemetryContext + "})";
 
         private const string ServiceBusDependencyFormat =
             MessagePrefixes.Dependency + " {"
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.DependencyTracking.Duration + "} at {"
             + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
             + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.TelemetryContext + "})";
 
         private const string HttpDependencyFormat =
             MessagePrefixes.DependencyViaHttp + " {"
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.DependencyTracking.Duration + "} at {"
             + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
             + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.TelemetryContext + "})";
 
         private const string SqlDependencyFormat =
             MessagePrefixes.DependencyViaSql + " {" 
@@ -70,19 +70,21 @@ namespace Microsoft.Extensions.Logging
             + "} in {" + ContextProperties.DependencyTracking.Duration
             + "} at {" + ContextProperties.DependencyTracking.StartTime
             + "} (Successful: {" + ContextProperties.DependencyTracking.IsSuccessful
-            + "} - Context: {@" + ContextProperties.EventTracking.EventContext + "})";
+            + "} - Context: {@" + ContextProperties.TelemetryContext + "})";
 
         private const string EventFormat = 
             MessagePrefixes.Event + " {" 
-            + ContextProperties.EventTracking.EventName 
-            + "} (Context: {@" + ContextProperties.EventTracking.EventContext + "})";
+            + ContextProperties.EventTracking.EventName
+#pragma warning disable 618 // Use 'ContextProperties.TelemetryContext' once we remove 'EventDescription'.
+            + "} (Context: {@" + ContextProperties.EventTracking.EventDescription + "})";
+#pragma warning restore 618
 
         private const string MetricFormat =
             MessagePrefixes.Metric + " {" 
             + ContextProperties.MetricTracking.MetricName + "}: {" 
             + ContextProperties.MetricTracking.MetricValue + "} at {"
             + ContextProperties.MetricTracking.Timestamp
-            + "} (Context: {@" + ContextProperties.EventTracking.EventContext + "})";
+            + "} (Context: {@" + ContextProperties.TelemetryContext + "})";
 
         /// <summary>
         ///     Logs an HTTP request

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Logging
             MessagePrefixes.Event + " {" 
             + ContextProperties.EventTracking.EventName
 #pragma warning disable 618 // Use 'ContextProperties.TelemetryContext' once we remove 'EventDescription'.
-            + "} (Context: {@" + ContextProperties.EventTracking.EventDescription + "})";
+            + "} (Context: {@" + ContextProperties.EventTracking.EventContext + "})";
 #pragma warning restore 618
 
         private const string MetricFormat =

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -34,7 +34,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             logEvent.RemovePropertyIfPresent(ContextProperties.TelemetryContext);
 
 #pragma warning disable 618 // Until we remove the obsolete 'EventDescription'.
-            logEvent.RemovePropertyIfPresent(ContextProperties.EventTracking.EventDescription);
+            logEvent.RemovePropertyIfPresent(ContextProperties.EventTracking.EventContext);
 #pragma warning restore 618
 
             ForwardPropertiesToTelemetryProperties(logEvent, telemetryEntry, formatProvider);
@@ -53,7 +53,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.TelemetryContext);
 
 #pragma warning disable 618 // Until we remove obsolete 'EventDescription'.
-            AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.EventTracking.EventDescription);
+            AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.EventTracking.EventContext);
 #pragma warning restore 618
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -31,12 +31,16 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             _cloudContextConverter.EnrichWithAppInfo(logEvent, telemetryEntry);
 
             RemoveIntermediaryProperties(logEvent);
-            logEvent.RemovePropertyIfPresent(ContextProperties.EventTracking.EventContext);
+            logEvent.RemovePropertyIfPresent(ContextProperties.TelemetryContext);
+
+#pragma warning disable 618 // Until we remove the obsolete 'EventDescription'.
+            logEvent.RemovePropertyIfPresent(ContextProperties.EventTracking.EventDescription);
+#pragma warning restore 618
 
             ForwardPropertiesToTelemetryProperties(logEvent, telemetryEntry, formatProvider);
             _operationContextConverter.EnrichWithCorrelationInfo(telemetryEntry);
 
-            return new List<ITelemetry> {telemetryEntry};
+            return new List<ITelemetry> { telemetryEntry };
         }
 
         /// <summary>
@@ -46,10 +50,19 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="telemetry">The destination telemetry instance to add the properties to.</param>
         protected void AssignTelemetryContextProperties(LogEvent logEvent, ISupportProperties telemetry)
         {
-            var eventContextFound = logEvent.Properties.TryGetAsDictionary(ContextProperties.EventTracking.EventContext, out var eventContext);
-            if (eventContextFound)
+            AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.TelemetryContext);
+
+#pragma warning disable 618 // Until we remove obsolete 'EventDescription'.
+            AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.EventTracking.EventDescription);
+#pragma warning restore 618
+        }
+
+        private static void AssignContextPropertiesFromDictionaryProperty(LogEvent logEvent, ISupportProperties telemetry, string propertyName)
+        {
+            bool contextFound = logEvent.Properties.TryGetAsDictionary(propertyName, out IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> context);
+            if (contextFound)
             {
-                foreach (KeyValuePair<ScalarValue, LogEventPropertyValue> contextProperty in eventContext)
+                foreach (KeyValuePair<ScalarValue, LogEventPropertyValue> contextProperty in context)
                 {
                     var value = contextProperty.Value.ToDecentString();
                     telemetry.Properties.Add(contextProperty.Key.ToDecentString(), value);

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -63,7 +63,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -116,7 +116,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
             AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -167,7 +167,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -214,7 +214,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -261,7 +261,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -308,7 +308,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -356,7 +356,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -404,7 +404,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -452,7 +452,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -499,7 +499,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -547,7 +547,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -595,7 +595,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -643,7 +643,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
             AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -687,7 +687,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
 
             // Assert
             AssertDoesNotContainLogProperty(logEvent, EventTracking.EventName);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var eventTelemetry = Assert.IsType<EventTelemetry>(telemetry);
@@ -756,7 +756,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             AssertDoesNotContainLogProperty(logEvent, MetricTracking.MetricName);
             AssertDoesNotContainLogProperty(logEvent, MetricTracking.MetricValue);
             AssertDoesNotContainLogProperty(logEvent, MetricTracking.Timestamp);
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventContext);
+            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
             Assert.Collection(telemetries, telemetry =>
             {
                 var metricTelemetry = Assert.IsType<MetricTelemetry>(telemetry);


### PR DESCRIPTION
* Uses `Context` instead of `EventDescription` in the message template
* Deprecate the use of `ContextProperties.EventTracking.EventContext`.
* Update log event > telemtry conversion with this deprecation to use both properties to enrich the telemetry context.

Closes #114 