### PR TITLE
Feature - make Serilog property names of the enrichers configurable

### DIFF
--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -36,10 +36,11 @@ ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
 
-logger.Information("This event will be enriched with the application component's name and by default the environment's machine name");
+logger.Information("Some event");
+// Output: Some event {ComponentName: My application component, MachineName: MyComputer}
 ```
 
-Or, alternatively one can choose to use the Kubernetes information.
+Or, alternatively one can choose to use the Kubernetes information which our [Application Insights](./sinks/azure-application-insights) sink will prioritize above the `MachineName` when determining the telemetry `Cloud.RoleInstance`.
 
 ```csharp
 ILogger logger = new LoggerConfiguration()
@@ -47,7 +48,24 @@ ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
 
-logger.Information("This event will be enriched with the application component's name and the Kubernetes information on the environment")
+logger.Information("Some event");
+// Output: Some event {ComponentName: My application component, MachineName: MachineName: MyComputer, PodName: demo-app}
+```
+
+### Custom Serilog property names
+
+The application enricher allows you to specify the name of the log property that will be added to the log event during enrichment.
+By default this is set to `ComponentName`.
+
+```csharp
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithComponentName(
+        componentName: "My application component", 
+        propertyName: "MyComponentName")
+    .CreateLogger();
+
+logger.Information("Some event");
+// Output: Some event {MyComponentName: My application component, MachineName: MyComputer}
 ```
 
 ## Correlation Enricher
@@ -88,6 +106,22 @@ logger.Information("This event will be enriched with the correlation information
 // Output: This event will be enriched with the correlation information {OperationId: 52EE2C00-53EE-476E-9DAB-C1234EB4AD0B, TransactionId: 0477E377-414D-47CD-8756-BCBE3DBE3ACB}
 ```
 
+### Custom Serilog property names
+
+The correlation information enricher allows you to specify the names of the log properties that will be added to the log event during enrichment.
+This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
+
+```csharp
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithCorrelationInfo(
+        operationIdPropertyName: "MyOperationId",
+        transactionIdPropertyName: "MyTransactionId")
+    .CreateLogger();
+
+logger.Information("Some event");
+// Output: Some event {MyOperationId: 52EE2C00-53EE-476E-9DAB-C1234EB4AD0B, MyTransactionId: 0477E377-414D-47CD-8756-BCBE3DBE3ACB}
+```
+
 ## Kubernetes Enricher
 
 The `Arcus.Observability.Telemetry.Serilog.Enrichers` library provides a [Kubernetes](https://kubernetes.io/) [Serilog enricher](https://github.com/serilog/serilog/wiki/Enrichment) 
@@ -108,7 +142,8 @@ ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
 
-logger.Information("This event will be enriched with the Kubernetes environment information");
+logger.Information("Some event");
+// Output: Some event {NodeName: demo-cluster, PodName: demo-app, Namespace: demo}
 ```
 
 Here is an example of a Kubernetes YAML that provides the required environment variables:
@@ -157,6 +192,23 @@ spec:
              fieldPath: metadata.namespace
 ```
 
+### Custom Serilog property names
+
+The Kubernetes enricher allows you to specify the names of the log properties that will be added to the log event during enrichment.
+By default the node name is set to `NodeName`, the pod name to `PodName`, and the namespace to `Namespace`.
+
+```csharp
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithKubernetesInfo(
+        nodeNamePropertyName: "MyNodeName",
+        podNamePropertyName: "MyPodName",
+        namespacePropertyName: "MyNamespace")
+    .CreateLogger();
+
+logger.Information("Some event");
+// Output: Some event {MyNodeName: demo-cluster, MyPodName: demo-app, MyNamespace: demo}
+```
+
 ## Version Enricher
 
 The `Arcus.Observability.Telemetry.Serilog.Enrichers` library provides a [Serilog enricher](https://github.com/serilog/serilog/wiki/Enrichment) 
@@ -173,7 +225,22 @@ ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();
 
-logger.Information("This event will be enriched with the runtime assembly product version");
+logger.Information("Some event");
+// Output: Some event {version: 1.0.0-preview}
+```
+
+### Custom Serilog property names
+
+The version enricher allows you to specify the name of the property that will be added to the log event during enrichement.
+By default this is set to `version`.
+
+```csharp
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithVersion(propertyName: "MyVersion")
+    .CreateLogger();
+
+logger.Information("Some event");
+// Output: Some event {MyVersion: 1.0.0-preview}
 ```
 
 [&larr; back](/)

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using GuardNet;
 using Serilog.Configuration;
-using Serilog.Core;
-using Serilog.Events;
 
 // ReSharper disable once CheckNamespace
 namespace Serilog
@@ -18,11 +17,15 @@ namespace Serilog
         /// Adds the <see cref="VersionEnricher"/> to the logger enrichment configuration which adds the current runtime version (i.e. 'version' = '1.0.0').
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
-        public static LoggerConfiguration WithVersion(this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        /// <param name="propertyName">The name of the property to enrich the log event with the current runtime version.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithVersion(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName = VersionEnricher.DefaultPropertyName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
+            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
 
-            return enrichmentConfiguration.With<VersionEnricher>();
+            return enrichmentConfiguration.With(new VersionEnricher(propertyName));
         }
 
         /// <summary>
@@ -30,46 +33,83 @@ namespace Serilog
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="componentName">The name of the application component.</param>
-        public static LoggerConfiguration WithComponentName(this LoggerEnrichmentConfiguration enrichmentConfiguration, string componentName)
+        /// <param name="propertyName">The name of the property to enrich the log event with the <paramref name="componentName"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="componentName"/> or <paramref name="propertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithComponentName(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            string componentName, 
+            string propertyName = ApplicationEnricher.ComponentName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Application component name cannot be blank");
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Require an enrichment configuration to add the application component enricher");
+            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank application component name");
+            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
 
-            return enrichmentConfiguration.With(new ApplicationEnricher(componentName));
+            return enrichmentConfiguration.With(new ApplicationEnricher(componentName, propertyName));
         }
 
         /// <summary>
         /// Adds the <see cref="KubernetesEnricher"/> to the logger enrichment configuration which adds Kubernetes information from the environment.
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
-        public static LoggerConfiguration WithKubernetesInfo(this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        /// <param name="nodeNamePropertyName">The name of the property to enrich the log event with the Kubernetes node name.</param>
+        /// <param name="podNamePropertyName">The name of the property to enrich the log event with the Kubernetes pod name.</param>
+        /// <param name="namespacePropertyName">The name of the property to enrich the log event with the Kubernetes namespace.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="nodeNamePropertyName"/>, <paramref name="podNamePropertyName"/>, or <paramref name="namespacePropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithKubernetesInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            string nodeNamePropertyName = ContextProperties.Kubernetes.NodeName,
+            string podNamePropertyName = ContextProperties.Kubernetes.PodName,
+            string namespacePropertyName = ContextProperties.Kubernetes.Namespace)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the Kubernetes enricher");
+            Guard.NotNullOrWhitespace(nodeNamePropertyName, nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
+            Guard.NotNullOrWhitespace(podNamePropertyName, nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
+            Guard.NotNullOrWhitespace(namespacePropertyName, nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
 
-            return enrichmentConfiguration.With<KubernetesEnricher>();
+            return enrichmentConfiguration.With(new KubernetesEnricher(nodeNamePropertyName, podNamePropertyName, namespacePropertyName));
         }
 
         /// <summary>
         /// Adds the <see cref="DefaultCorrelationInfoAccessor"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
-        public static LoggerConfiguration WithCorrelationInfo(this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithCorrelationInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
-            return WithCorrelationInfo(enrichmentConfiguration, DefaultCorrelationInfoAccessor.Instance);
+            return WithCorrelationInfo(enrichmentConfiguration, DefaultCorrelationInfoAccessor.Instance, operationIdPropertyName, transactionIdPropertyName);
         }
 
         /// <summary>
         /// Adds the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
-        public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(this LoggerEnrichmentConfiguration enrichmentConfiguration) 
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
-            return WithCorrelationInfo(enrichmentConfiguration, DefaultCorrelationInfoAccessor<TCorrelationInfo>.Instance);
+            return WithCorrelationInfo(enrichmentConfiguration, DefaultCorrelationInfoAccessor<TCorrelationInfo>.Instance, operationIdPropertyName, transactionIdPropertyName);
         }
 
         /// <summary>
@@ -77,12 +117,22 @@ namespace Serilog
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="correlationInfoAccessor">The accessor implementation for the <see cref="CorrelationInfo"/> model.</param>
-        public static LoggerConfiguration WithCorrelationInfo(this LoggerEnrichmentConfiguration enrichmentConfiguration, ICorrelationInfoAccessor correlationInfoAccessor)
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithCorrelationInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            ICorrelationInfoAccessor correlationInfoAccessor,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
-            return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor);
+            return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName);
         }
 
         /// <summary>
@@ -91,15 +141,23 @@ namespace Serilog
         /// <typeparam name="TCorrelationInfo">The type of the custom <see cref="CorrelationInfo"/> model.</typeparam>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="correlationInfoAccessor">The accessor implementation for the <typeparamref name="TCorrelationInfo"/> model.</param>
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
         public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
             this LoggerEnrichmentConfiguration enrichmentConfiguration, 
-            ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor) 
+            ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId) 
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
-            return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor));
+            return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName));
         }
 
         /// <summary>
@@ -108,13 +166,14 @@ namespace Serilog
         /// <typeparam name="TCorrelationInfo">The type of the custom <see cref="CorrelationInfo"/> model.</typeparam>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="correlationInfoEnricher">The custom correlation enricher implementation for the <typeparamref name="TCorrelationInfo"/> model.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or the <paramref name="correlationInfoEnricher"/> is <c>null</c>.</exception>
         public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
             this LoggerEnrichmentConfiguration enrichmentConfiguration, 
             CorrelationInfoEnricher<TCorrelationInfo> correlationInfoEnricher) 
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration));
-            Guard.NotNull(correlationInfoEnricher, nameof(correlationInfoEnricher));
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(correlationInfoEnricher, nameof(correlationInfoEnricher), "Requires an correlation enricher to enrich the log events with correlation information");
 
             return enrichmentConfiguration.With(correlationInfoEnricher);
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -10,13 +11,31 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
     /// </summary>
     public class VersionEnricher : ILogEventEnricher
     {
-        private readonly string _assemblyVersion;
+        /// <summary>
+        /// Gets the default property name that the <see cref="VersionEnricher"/> will use when the version gets enriched on the log event.
+        /// </summary>
+        public const string DefaultPropertyName = "version";
+
+        private readonly string _propertyName, _assemblyVersion;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionEnricher"/> class.
         /// </summary>
-        public VersionEnricher()
+        public VersionEnricher() : this(DefaultPropertyName)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionEnricher"/> class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to enrich the log event with the current runtime version.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
+        public VersionEnricher(string propertyName)
+        {
+            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            
+            _propertyName = propertyName;
+
             var executingAssembly = Assembly.GetEntryAssembly();
             if (executingAssembly == null)
             {
@@ -39,7 +58,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         {
             if (!String.IsNullOrWhiteSpace(_assemblyVersion))
             {
-                var versionProperty = propertyFactory.CreateProperty("version", _assemblyVersion);
+                var versionProperty = propertyFactory.CreateProperty(_propertyName, _assemblyVersion);
                 logEvent.AddPropertyIfAbsent(versionProperty);
             }
         }

--- a/src/Arcus.Observability.Tests.Core/Arcus.Observability.Tests.Core.csproj
+++ b/src/Arcus.Observability.Tests.Core/Arcus.Observability.Tests.Core.csproj
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Arcus.Observability.Tests.Core/InMemoryLogSink.cs
+++ b/src/Arcus.Observability.Tests.Core/InMemoryLogSink.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Arcus.Observability.Tests.Unit.Serilog
+namespace Arcus.Observability.Tests.Core
 {
     /// <summary>
     /// Represents a logging sink that collects the emitted log events in-memory.

--- a/src/Arcus.Observability.Tests.Integration/Serilog/KubernetesEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/KubernetesEnricherTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.Observability.Tests.Core;
+using Serilog;
+using Serilog.Events;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Integration.Serilog
+{
+    [Trait("Category", "Integration")]
+    public class KubernetesEnricherTests
+    {
+        private const string NodeNameVariable = "KUBERNETES_NODE_NAME",
+                             PodNameVariable = "KUBERNETES_POD_NAME",
+                             NamespaceVariable = "KUBERNETES_NAMESPACE";
+
+        [Fact]
+        public void LogEvent_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string nodeName = $"node-{Guid.NewGuid()}";
+            string podName = $"pod-{Guid.NewGuid()}";
+            string @namespace = $"namespace-{Guid.NewGuid()}";
+
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.With<KubernetesEnricher>()
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(NodeNameVariable, nodeName))
+            using (TemporaryEnvironmentVariable.Create(PodNameVariable, podName))
+            using (TemporaryEnvironmentVariable.Create(NamespaceVariable, @namespace))
+            {
+                // Act
+                logger.Information("This log event should be enriched with Kubernetes information");
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+            
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.NodeName, nodeName), "Log event should contain node name property");
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.PodName, podName), "Log event should contain pod name property");
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.Namespace, @namespace), "Log event should contain namespace property");
+        }
+
+        [Fact]
+        public void LogEventWithNodeNameProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expectedNodeName = $"node-{Guid.NewGuid()}";
+            string ignoredNodeName = $"node-{Guid.NewGuid()}";
+
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithKubernetesInfo()
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(NodeNameVariable, ignoredNodeName))
+            {
+                // Act
+                logger.Information("This log even already has a Kubernetes NodeName {NodeName}", expectedNodeName);
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.NodeName, expectedNodeName), "Log event should contain node name property");
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.PodName);
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.Namespace);
+        }
+
+        [Fact]
+        public void LogEventWithPodNameProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expectedPodName = $"pod-{Guid.NewGuid()}";
+            string ignoredPodName = $"pod-{Guid.NewGuid()}";
+
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.With<KubernetesEnricher>()
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(PodNameVariable, ignoredPodName))
+            {
+                // Act
+                logger.Information("This log even already has a Kubernetes PodName {PodName}", expectedPodName);
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.PodName, expectedPodName), "Log event should contain pod name property");
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.NodeName);
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.Namespace);
+        }
+
+        [Fact]
+        public void LogEventWithNamespaceProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expectedNamespace = $"namespace-{Guid.NewGuid()}";
+            string ignoredNamespace = $"namespace-{Guid.NewGuid()}";
+
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.With<KubernetesEnricher>()
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(NamespaceVariable, ignoredNamespace))
+            {
+                // Act
+                logger.Information("This log even already has a Kubernetes Namespace {Namespace}", expectedNamespace);
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.Namespace, expectedNamespace), "Log event should contain namespace property");
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.NodeName);
+            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.PodName);
+        }
+
+        [Fact]
+        public void LogEventWithCustomNodeNamePropertyName_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expected = $"node-{Guid.NewGuid()}";
+            string propertyName = $"node-name-{Guid.NewGuid():N}";
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithKubernetesInfo(nodeNamePropertyName: propertyName)
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(NodeNameVariable, expected))
+            {
+                // Act
+                logger.Information("This log event should contain the custom configured Kubernetes property");
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+            Assert.True(logEvent.ContainsProperty(propertyName, expected), $"Log event contain property '{propertyName}' with value '{expected}'");
+        }
+
+        [Fact]
+        public void LogEventWithCustomPodNamePropertyName_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expected = $"pod-{Guid.NewGuid()}";
+            string propertyName = $"pod-name-{Guid.NewGuid():N}";
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithKubernetesInfo(podNamePropertyName: propertyName)
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(PodNameVariable, expected))
+            {
+                // Act
+                logger.Information("This log event should contain the custom configured Kubernetes property");
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+            Assert.True(logEvent.ContainsProperty(propertyName, expected), $"Log event contain property '{propertyName}' with value '{expected}'");
+        }
+
+        [Fact]
+        public void LogEventWithCustomNamespacePropertyName_WithKubernetesEnricher_HasEnvironmentInformation()
+        {
+            // Arrange
+            string expected = $"namespace-{Guid.NewGuid()}";
+            string propertyName = $"namespace-name-{Guid.NewGuid():N}";
+            var spy = new InMemoryLogSink();
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithKubernetesInfo(namespacePropertyName: propertyName)
+                .WriteTo.Sink(spy)
+                .CreateLogger();
+
+            using (TemporaryEnvironmentVariable.Create(NamespaceVariable, expected))
+            {
+                // Act
+                logger.Information("This log event should contain the custom configured Kubernetes property");
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+            Assert.True(logEvent.ContainsProperty(propertyName, expected), $"Log event contain property '{propertyName}' with value '{expected}'");
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Blanks.cs
+++ b/src/Arcus.Observability.Tests.Unit/Blanks.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Arcus.Observability.Tests.Unit
+{
+    /// <summary>
+    /// Represents a test data class with only blank values.
+    /// </summary>
+    public class Blanks : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { null };
+            yield return new object[] { String.Empty };
+            yield return new object[] { " " };
+            yield return new object[] { "       " };
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
+using Arcus.Observability.Tests.Core;
 using Bogus;
 using Bogus.DataSets;
 using Microsoft.ApplicationInsights.Channel;

--- a/src/Arcus.Observability.Tests.Unit/Serilog/KubernetesEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/KubernetesEnricherTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
-using Arcus.Observability.Tests.Core;
 using Serilog;
-using Serilog.Events;
 using Xunit;
 
 namespace Arcus.Observability.Tests.Unit.Serilog
@@ -11,123 +8,73 @@ namespace Arcus.Observability.Tests.Unit.Serilog
     [Trait("Category", "Unit")]
     public class KubernetesEnricherTests
     {
-        [Fact]
-        public void LogEvent_WithKubernetesEnricher_HasEnvironmentInformation()
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithKubernetesInfo_WithBlankNodeName_Throws(string nodeNamePropertyName)
         {
             // Arrange
-            const string kubernetesNodeName = "KUBERNETES_NODE_NAME",
-                         kubernetesPodName = "KUBERNETES_POD_NAME",
-                         kubernetesNamespace = "KUBERNETES_NAMESPACE";
+            var configuration = new LoggerConfiguration();
 
-            string nodeName = $"node-{Guid.NewGuid()}";
-            string podName = $"pod-{Guid.NewGuid()}";
-            string @namespace = $"namespace-{Guid.NewGuid()}";
-
-            var spy = new InMemoryLogSink();
-            ILogger logger = new LoggerConfiguration()
-                .Enrich.With<KubernetesEnricher>()
-                .WriteTo.Sink(spy)
-                .CreateLogger();
-
-            using (TemporaryEnvironmentVariable.Create(kubernetesNodeName, nodeName))
-            using (TemporaryEnvironmentVariable.Create(kubernetesPodName, podName))
-            using (TemporaryEnvironmentVariable.Create(kubernetesNamespace, @namespace))
-            {
-                // Act
-                logger.Information("This log event should be enriched with Kubernetes information");
-            }
-
-            // Assert
-            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
-            Assert.NotNull(logEvent);
-            
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.NodeName, nodeName), "Log event should contain node name property");
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.PodName, podName), "Log event should contain pod name property");
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.Namespace, @namespace), "Log event should contain namespace property");
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithKubernetesInfo(nodeNamePropertyName: nodeNamePropertyName));
         }
 
-        [Fact]
-        public void LogEventWithNodeNameProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithKubernetesInfo_WithBlankPodName_Throws(string podNamePropertyName)
         {
             // Arrange
-            string expectedNodeName = $"node-{Guid.NewGuid()}";
-            string ignoredNodeName = $"node-{Guid.NewGuid()}";
+            var configuration = new LoggerConfiguration();
 
-            var spy = new InMemoryLogSink();
-            ILogger logger = new LoggerConfiguration()
-                .Enrich.WithKubernetesInfo()
-                .WriteTo.Sink(spy)
-                .CreateLogger();
-
-            using (TemporaryEnvironmentVariable.Create("KUBERNETES_NODE_NAME", ignoredNodeName))
-            {
-                // Act
-                logger.Information("This log even already has a Kubernetes NodeName {NodeName}", expectedNodeName);
-            }
-
-            // Assert
-            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
-            Assert.NotNull(logEvent);
-
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.NodeName, expectedNodeName), "Log event should contain node name property");
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.PodName);
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.Namespace);
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithKubernetesInfo(podNamePropertyName: podNamePropertyName));
         }
 
-        [Fact]
-        public void LogEventWithPodNameProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithKubernetesInfo_WithBlankNamespace_Throws(string namespacePropertyName)
         {
             // Arrange
-            string expectedPodName = $"pod-{Guid.NewGuid()}";
-            string ignoredPodName = $"pod-{Guid.NewGuid()}";
+            var configuration = new LoggerConfiguration();
 
-            var spy = new InMemoryLogSink();
-            ILogger logger = new LoggerConfiguration()
-                .Enrich.With<KubernetesEnricher>()
-                .WriteTo.Sink(spy)
-                .CreateLogger();
-
-            using (TemporaryEnvironmentVariable.Create("KUBERNETES_POD_NAME", ignoredPodName))
-            {
-                // Act
-                logger.Information("This log even already has a Kubernetes PodName {PodName}", expectedPodName);
-            }
-
-            // Assert
-            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
-            Assert.NotNull(logEvent);
-
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.PodName, expectedPodName), "Log event should contain pod name property");
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.NodeName);
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.Namespace);
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithKubernetesInfo(namespacePropertyName: namespacePropertyName));
         }
 
-        [Fact]
-        public void LogEventWithNamespaceProperty_WithKubernetesEnricher_HasEnvironmentInformation()
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateEnricher_WithBlankNodeName_Throws(string nodeNamePropertyName)
         {
-            // Arrange
-            string expectedNamespace = $"namespace-{Guid.NewGuid()}";
-            string ignoredNamespace = $"namespace-{Guid.NewGuid()}";
+            Assert.ThrowsAny<ArgumentException>(
+                () => new KubernetesEnricher(
+                    nodeNamePropertyName: nodeNamePropertyName,
+                    podNamePropertyName: "some valid ignored value",
+                    namespacePropertyName: "some other valid ignored value"));
+        }
 
-            var spy = new InMemoryLogSink();
-            ILogger logger = new LoggerConfiguration()
-                .Enrich.With<KubernetesEnricher>()
-                .WriteTo.Sink(spy)
-                .CreateLogger();
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateEnricher_WithBlankPodName_Throws(string podNamePropertyName)
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new KubernetesEnricher(
+                    nodeNamePropertyName: "some valid ignored value",
+                    podNamePropertyName: podNamePropertyName,
+                    namespacePropertyName: "some other valid ignored value"));
+        }
 
-            using (TemporaryEnvironmentVariable.Create("KUBERNETES_NAMESPACE", ignoredNamespace))
-            {
-                // Act
-                logger.Information("This log even already has a Kubernetes Namespace {Namespace}", expectedNamespace);
-            }
-
-            // Assert
-            LogEvent logEvent = Assert.Single(spy.CurrentLogEmits);
-            Assert.NotNull(logEvent);
-
-            Assert.True(logEvent.ContainsProperty(ContextProperties.Kubernetes.Namespace, expectedNamespace), "Log event should contain namespace property");
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.NodeName);
-            Assert.DoesNotContain(logEvent.Properties, prop => prop.Key == ContextProperties.Kubernetes.PodName);
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateEnricher_WithBlankNamespace_Throws(string namespacePropertyName)
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new KubernetesEnricher(
+                    nodeNamePropertyName: "some valid ignored value",
+                    podNamePropertyName: "some other valid ignored value",
+                    namespacePropertyName: namespacePropertyName));
         }
     }
 }


### PR DESCRIPTION
The Serilog property names were hard-coded in the initial version but right now we should think about making them configurable so the naming conventions in a certain project about the log properties can be uphold.

Closes #141 