### PR TITLE
Feature - inject custom application version in Serilog version enricher

### DIFF
--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -212,7 +212,7 @@ logger.Information("Some event");
 ## Version Enricher
 
 The `Arcus.Observability.Telemetry.Serilog.Enrichers` library provides a [Serilog enricher](https://github.com/serilog/serilog/wiki/Enrichment) 
-that adds the current runtime assembly version of the product to the log event as a log property with the name `version`.
+that adds (by default) the current runtime assembly version of the product to the log event as a log property with the name `version`.
 
 **Example**
 Name: `version`
@@ -227,6 +227,21 @@ ILogger logger = new LoggerConfiguration()
 
 logger.Information("Some event");
 // Output: Some event {version: 1.0.0-preview}
+```
+
+### Custom application version
+
+The version enricher allows you to specify an `IAppVersion` instance that retrieves your custom application version, which will be used during enrichement.
+By default this is set to the version of the current executing assembly.
+
+```csharp
+IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithVersion(appVersion)
+    .CreateLogger();
+
+logger.Information("Some event");
+// Output: Some event {version: v0.1.0}
 ```
 
 ### Custom Serilog property names

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/AssemblyAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/AssemblyAppVersion.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reflection;
+
+namespace Arcus.Observability.Telemetry.Serilog.Enrichers
+{
+    /// <summary>
+    /// Represents an <see cref="IAppVersion"/> implementation that uses the assembly version as application version.
+    /// </summary>
+    /// <seealso cref="IAppVersion"/>
+    public class AssemblyAppVersion : IAppVersion
+    {
+        private readonly Assembly _executingAssembly;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssemblyAppVersion"/> class.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when the process executable in the default application domain cannot be retrieved.</exception>
+        public AssemblyAppVersion()
+        {
+            var executingAssembly = Assembly.GetEntryAssembly();
+            if (executingAssembly == null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot enrich the log events with a 'Version' because the version of the current executing runtime couldn't be determined");
+            }
+
+            _executingAssembly = executingAssembly;
+        }
+
+        /// <summary>
+        /// Gets the current version of the application.
+        /// </summary>
+        public string GetVersion()
+        {
+            return _executingAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? _executingAssembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version
+                ?? _executingAssembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -14,18 +14,39 @@ namespace Serilog
     public static class LoggerEnrichmentConfigurationExtensions
     {
         /// <summary>
-        /// Adds the <see cref="VersionEnricher"/> to the logger enrichment configuration which adds the current runtime version (i.e. 'version' = '1.0.0').
+        /// Adds the <see cref="VersionEnricher"/> to the logger enrichment configuration which adds the current runtime version (i.e. 'version' = '1.0.0') of the assembly.
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="propertyName">The name of the property to enrich the log event with the current runtime version.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the process executable in the default application domain cannot be retrieved.</exception>
         public static LoggerConfiguration WithVersion(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName = VersionEnricher.DefaultPropertyName)
         {
             Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
             Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
 
             return enrichmentConfiguration.With(new VersionEnricher(propertyName));
+        }
+
+        /// <summary>
+        /// Adds the <see cref="VersionEnricher"/> to the logger enrichment configuration which adds the current application version retrieved via the given <paramref name="appVersion"/>.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="appVersion">The instance to retrieve the current application version.</param>
+        /// <param name="propertyName">The name of the property to enrich the log event with the current application version.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="appVersion"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithVersion(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            IAppVersion appVersion,
+            string propertyName = VersionEnricher.DefaultPropertyName)
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
+            Guard.NotNull(appVersion, nameof(appVersion), "Requires an application version implementation to enrich the log event with the application version");
+            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+
+            return enrichmentConfiguration.With(new VersionEnricher(appVersion, propertyName));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/IAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/IAppVersion.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Observability.Telemetry.Serilog.Enrichers
+{
+    /// <summary>
+    /// Represents a way to retrieve the version of an application during the enrichment in the <see cref="VersionEnricher"/>.
+    /// </summary>
+    public interface IAppVersion
+    {
+        /// <summary>
+        /// Gets the current version of the application.
+        /// </summary>
+        string GetVersion();
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/VersionEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/VersionEnricherTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.Observability.Tests.Core;
+using Moq;
 using Serilog;
 using Serilog.Events;
 using Xunit;
@@ -56,6 +57,80 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             Assert.True(Version.TryParse(value.ToString().Trim('\"'), out Version result));
         }
 
+        [Fact]
+        public void LogEvent_WithCustomAppVersion_HasCustomVersion()
+        {
+            // Arrange
+            var spy = new InMemoryLogSink();
+            string expected = $"version-{Guid.NewGuid()}";
+            var stubAppVersion = new Mock<IAppVersion>();
+            stubAppVersion.Setup(v => v.GetVersion()).Returns(expected);
+            ILogger logger =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(spy)
+                    .Enrich.WithVersion(stubAppVersion.Object)
+                    .CreateLogger();
+
+            // Act
+            logger.Information("This log event will be enriched with a custom application version");
+
+            // Assert
+            LogEvent emit = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(emit);
+            (string key, LogEventPropertyValue value) = Assert.Single(emit.Properties);
+            Assert.Equal(VersionEnricher.DefaultPropertyName, key);
+            Assert.Equal(expected, value.ToDecentString());
+        }
+
+        [Fact]
+        public void LogEvent_WithCustomAppVersionAndCustomPropertyName_HasCustomVersion()
+        {
+            // Arrange
+            var spy = new InMemoryLogSink();
+            string propertyName = $"version-name-{Guid.NewGuid()}";
+            string expected = $"version-{Guid.NewGuid()}";
+            var stubAppVersion = new Mock<IAppVersion>();
+            stubAppVersion.Setup(v => v.GetVersion()).Returns(expected);
+            ILogger logger =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(spy)
+                    .Enrich.WithVersion(stubAppVersion.Object, propertyName)
+                    .CreateLogger();
+
+            // Act
+            logger.Information("This log event will be enriched with a custom application version on a custom property");
+
+            // Assert
+            LogEvent emit = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(emit);
+            (string key, LogEventPropertyValue value) = Assert.Single(emit.Properties);
+            Assert.Equal(propertyName, key);
+            Assert.Equal(expected, value.ToDecentString());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogEvent_WithCustomAppVersionReturningBlankVersion_DoesntAddVersionProperty(string version)
+        {
+            // Arrange
+            var spy = new InMemoryLogSink();
+            var stubAppVersion = new Mock<IAppVersion>();
+            stubAppVersion.Setup(v => v.GetVersion()).Returns(version);
+            ILogger logger =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(spy)
+                    .Enrich.WithVersion(stubAppVersion.Object)
+                    .CreateLogger();
+
+            // Act
+            logger.Information("This log event will not be enriched with an custom application version because the version is blank");
+
+            // Assert
+            LogEvent emit = Assert.Single(spy.CurrentLogEmits);
+            Assert.NotNull(emit);
+            Assert.Empty(emit.Properties);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void WithVersion_WithBlankPropertyName_Throws(string propertyName)
@@ -69,9 +144,67 @@ namespace Arcus.Observability.Tests.Unit.Serilog
 
         [Theory]
         [ClassData(typeof(Blanks))]
-        public void CreatesEnricher_WithBlankPropertyName_Throws(string propertyName)
+        public void WithVersion_WithAppVersionAndBlankPropertyName_Throws(string propertyName)
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+            var appVersion = Mock.Of<IAppVersion>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => configuration.Enrich.WithVersion(appVersion, propertyName));
+        }
+
+        [Fact]
+        public void WithVersion_WithoutAppVersion_Throws()
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithVersion(appVersion: null));
+        }
+
+        [Fact]
+        public void WithVersion_WithoutAppVersionAndPropertyName_Throws()
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithVersion(appVersion: null, propertyName: "some-property-name"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateEnricher_WithBlankPropertyName_Throws(string propertyName)
         {
             Assert.ThrowsAny<ArgumentException>(() => new VersionEnricher(propertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateEnricher_WithAppVersionAndBlankPropertyName_Throws(string propertyName)
+        {
+            // Arrange
+            var appVersion = Mock.Of<IAppVersion>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => new VersionEnricher(appVersion, propertyName));
+        }
+
+        [Fact]
+        public void CreateEnricher_WithoutAppVersion_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new VersionEnricher(appVersion: null));
+        }
+
+        [Fact]
+        public void CreateEnricher_WithoutAppVersionAndCustomPropertyName_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new VersionEnricher(appVersion: null, propertyName: "some-property-name"));
         }
     }
 }


### PR DESCRIPTION
Provides a custom `IAppVersion` interface to inject your own custom application version while enriching the log events with the `VersionEnricher`. Existing functionality to use the current runtime version of the assembly is moved to an `AssemblyAppVersion` instance and is still the default.

Closes #143 