### PR TITLE
Feature - register the IAppVersion as service

### DIFF
--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -244,6 +244,32 @@ logger.Information("Some event");
 // Output: Some event {version: v0.1.0}
 ```
 
+Or alternatively, you can choose to register the application version yourself.
+
+```csharp
+public void ConfigureServivces(IServiceCollection services)
+{
+    // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
+    services.AddAppVersion<MyApplicationVersion>();
+
+    // Register the `MyApplicationVersion` instance using the service provider.
+    services.AddAppVersion(serviceProvider => 
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
+        return new MyApplicationVersion(logger);
+    });
+}
+```
+
+Once the application version is registered, you can pass along the `IServiceProvider` instead to the Serilog configuration.
+
+```csharp
+IServiceProvider serviceProvider = ...
+ILogger logger = new LoggerConfiguration()
+    .Enrich.WithVersion(serviceProvider)
+    .CreateLogger();
+```
+
 ### Custom Serilog property names
 
 The version enricher allows you to specify the name of the property that will be added to the log event during enrichement.

--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -244,7 +244,7 @@ logger.Information("Some event");
 // Output: Some event {version: v0.1.0}
 ```
 
-Or alternatively, you can choose to register the application version yourself.
+Or alternatively, you can choose to register the application version so you can use it in your application as well.
 
 ```csharp
 public void ConfigureServivces(IServiceCollection services)

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IAppVersion"/> implementation to the application which can be used to retrieve the current application's version.
+        /// </summary>
+        /// <typeparam name="TAppVersion">The type that implements the <see cref="IAppVersion"/> interface.</typeparam>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppVersion"/> implementation to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddAppVersion<TAppVersion>(this IServiceCollection services) where TAppVersion : class, IAppVersion
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
+            return services.AddSingleton<IAppVersion, TAppVersion>();
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAppVersion"/> implementation to the application which can be used to retrieve the current application's version.
+        /// </summary>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppVersion"/> implementation to.</param>
+        /// <param name="createImplementation">The factory function to create the <see cref="IAppVersion"/> implementation.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddAppVersion(
+            this IServiceCollection services,
+            Func<IServiceProvider, IAppVersion> createImplementation)
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
+            Guard.NotNull(createImplementation, nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");
+
+            return services.AddSingleton(createImplementation);
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/DummyAppVersion.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/DummyAppVersion.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Dummy <see cref="IAppVersion"/> implementation.
+    /// </summary>
+    public class DummyAppVersion : IAppVersion
+    {
+        /// <summary>
+        /// Gets the current version of the application.
+        /// </summary>
+        public string GetVersion()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var service = serviceProvider.GetRequiredService<IAppVersion>();
             Assert.NotNull(service);
-            Assert.IsType<StubAppVersion>(service);
+            Assert.IsType<DummyAppVersion>(service);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var service = serviceProvider.GetRequiredService<IAppVersion>();
             Assert.NotNull(service);
-            Assert.IsType<StubAppVersion>(service);
+            Assert.IsType<DummyAppVersion>(service);
         }
 
         [Fact]

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry
+{
+    public class IServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddAppVersion_WithType_RegistersAppVersion()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddAppVersion<DummyAppVersion>();
+
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var service = serviceProvider.GetRequiredService<IAppVersion>();
+            Assert.NotNull(service);
+            Assert.IsType<StubAppVersion>(service);
+        }
+
+        [Fact]
+        public void AddVersion_WithFactoryImplementation_RegistersAppVersion()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddAppVersion(provider => new DummyAppVersion());
+
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var service = serviceProvider.GetRequiredService<IAppVersion>();
+            Assert.NotNull(service);
+            Assert.IsType<StubAppVersion>(service);
+        }
+
+        [Fact]
+        public void AddAppVersion_WithoutFactoryImplementation_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAppVersion(createImplementation: null));
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/StubAppVersion.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/StubAppVersion.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry
+{
+    /// <summary>
+    /// Stubbed implementation of the <see cref="IAppVersion"/>.
+    /// </summary>
+    public class StubAppVersion : IAppVersion
+    {
+        private readonly string _version;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StubAppVersion"/> class.
+        /// </summary>
+        /// <param name="version">The current stubbed application version.</param>
+        public StubAppVersion(string version)
+        {
+            _version = version;
+        }
+
+        /// <summary>
+        /// Gets the current version of the application.
+        /// </summary>
+        public string GetVersion()
+        {
+            return _version;
+        }
+    }
+}


### PR DESCRIPTION
Provide the capability to register the `IAppVersion` in the application services instead of providing the instance yourself. This also includes the dev-friendly registration of this service.

Relates to #143 