### PR TITLE
Feature - provide consumer type to AssemblyAppVersion

### DIFF
--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -234,6 +234,18 @@ logger.Information("Some event");
 The version enricher allows you to specify an `IAppVersion` instance that retrieves your custom application version, which will be used during enrichement.
 By default this is set to the version of the current executing assembly.
 
+**Assembly version as application version**
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // Register the `AssemblyAppVersion` instance to retrieve the application version from the assembly where the passed-along `Startup` type is located.
+    services.AddAssemblyAppVersion<Startup>();
+}
+```
+
+**User-provided version**
+
 ```csharp
 IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
 ILogger logger = new LoggerConfiguration()

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The collection of registered services to add the <see cref="IAppVersion"/> implementation to.</param>
         /// <param name="consumerType">Some random consumer type to have access to the assembly of the executing project.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="consumerType"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAssemblyAppVersion(this IServiceCollection services, Type consumerType)
         {
             Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
@@ -5,6 +5,10 @@ using GuardNet;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> related to Serilog enrichment.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
     public static class IServiceCollectionExtensions
     {
         /// <summary>
@@ -33,6 +37,33 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(createImplementation, nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");
 
             return services.AddSingleton(createImplementation);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAppVersion"/> implementation to the application which uses the current application's assembly version as application version (see: <see cref="AssemblyAppVersion"/>).
+        /// </summary>
+        /// <typeparam name="TConsumerType">Some random consumer type that will be used to retrieve the assembly where the project is running.</typeparam>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppVersion"/> implementation to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddAssemblyAppVersion<TConsumerType>(this IServiceCollection services)
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
+
+            return services.AddSingleton<IAppVersion>(new AssemblyAppVersion(typeof(TConsumerType)));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAppVersion"/> implementation to the application which uses the current application's assembly version as application version (see: <see cref="AssemblyAppVersion"/>).
+        /// </summary>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppVersion"/> implementation to.</param>
+        /// <param name="consumerType">Some random consumer type to have access to the assembly of the executing project.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddAssemblyAppVersion(this IServiceCollection services, Type consumerType)
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
+            Guard.NotNull(consumerType, nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
+
+            return services.AddSingleton<IAppVersion>(new AssemblyAppVersion(consumerType));
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
+++ b/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Tests.Unit/Serilog/AssemblyAppVersionTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/AssemblyAppVersionTests.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog
+{
+    public class AssemblyAppVersionTests
+    {
+        [Fact]
+        public void CreateAppVersion_WithoutConsumerType_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new AssemblyAppVersion(consumerType: null));
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog
+{
+    public class IServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddAssemblyAppVersion_WithoutConsumerType_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddAssemblyAppVersion(consumerType: null));
+        }
+    }
+}


### PR DESCRIPTION
Provides the capability to pass along a custom type to the `AssemblyAppVersion` so we're not limited or restricted to the `Assembly.GetEntryAssembly` call and the consumer is in control _in what_ `Assembly`  the Serilog `VersionEnricher` should look for the application version. Useful for Azure Functions.

Closes #146 