### PR TITLE
Feature - move IAppVersion & AssemblyAppVersion to Core

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using GuardNet;
 
-namespace Arcus.Observability.Telemetry.Serilog.Enrichers
+namespace Arcus.Observability.Telemetry.Core
 {
     /// <summary>
     /// Represents an <see cref="IAppVersion"/> implementation that uses the assembly version as application version.

--- a/src/Arcus.Observability.Telemetry.Core/IAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Core/IAppVersion.cs
@@ -1,7 +1,7 @@
-﻿namespace Arcus.Observability.Telemetry.Serilog.Enrichers
+﻿namespace Arcus.Observability.Telemetry.Core
 {
     /// <summary>
-    /// Represents a way to retrieve the version of an application during the enrichment in the <see cref="VersionEnricher"/>.
+    /// Represents a way to retrieve the version of an application during the enrichment.
     /// </summary>
     public interface IAppVersion
     {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using GuardNet;
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Observability.Telemetry.Core;
 using GuardNet;
 using Serilog.Core;
 using Serilog.Events;

--- a/src/Arcus.Observability.Tests.Unit/Serilog/AssemblyAppVersionTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/AssemblyAppVersionTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.Observability.Telemetry.Core;
 using Xunit;
 
 namespace Arcus.Observability.Tests.Unit.Serilog

--- a/src/Arcus.Observability.Tests.Unit/Serilog/VersionEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/VersionEnricherTests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Reflection;
-using System.Reflection.Emit;
+using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.Observability.Tests.Core;
 using Arcus.Observability.Tests.Unit.Serilog;
 using Arcus.Observability.Tests.Unit.Telemetry;
-using Bogus;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Serilog;

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/DummyAppVersion.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/DummyAppVersion.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.Observability.Telemetry.Core;
 
 namespace Arcus.Observability.Tests.Unit.Telemetry
 {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/IServiceCollectionExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.Observability.Telemetry.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/StubAppVersion.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/StubAppVersion.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
+﻿using Arcus.Observability.Telemetry.Core;
 
 namespace Arcus.Observability.Tests.Unit.Telemetry
 {


### PR DESCRIPTION
Moves the `IAppVersion` and `AssemblyAppVersion` types to the telemtry Core project.

Closes #145 