### PR TITLE
Feature - move SQL dependency tracking to sep project

### DIFF
--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -239,6 +239,16 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
 
+**Installation**
+
+This feature requires to install our NuGet package
+
+```shell
+PM > Install-Package Arcus.Observability.Telemetry.Sql
+```
+
+**Example**
+
 ```csharp
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
@@ -253,6 +263,8 @@ var products = await _repository.GetProducts();
 _logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessful: true, measurement: measurement);
 // Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
 ```
+
+
 
 ### Measuring custom dependencies
 

--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -264,8 +264,6 @@ _logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccess
 // Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
 ```
 
-
-
 ### Measuring custom dependencies
 
 Here is how you can areport a custom depenency:

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
@@ -595,45 +594,6 @@ namespace Microsoft.Extensions.Logging
             bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
 
             logger.LogInformation(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
-        }
-
-        /// <summary>	
-        ///     Logs a SQL dependency	
-        /// </summary>	
-        /// <param name="logger">Logger to use</param>	
-        /// <param name="connectionString">SQL connection string</param>	
-        /// <param name="tableName">Name of table</param>	
-        /// <param name="operationName">Name of the operation that was performed</param>	
-        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>	
-        /// <param name="measurement">Measuring the latency to call the SQL dependency</param>	
-        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        [Obsolete("Will be moved to separate package 'Arcus.Observability.Telemetry.Sql' in the future")]
-        public static void LogSqlDependency(this ILogger logger, string connectionString, string tableName, string operationName, DependencyMeasurement measurement, bool isSuccessful, Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(measurement, nameof(measurement));
-
-            LogSqlDependency(logger, connectionString, tableName, operationName, measurement.StartTime, measurement.Elapsed, isSuccessful, context);
-        }
-
-        /// <summary>	
-        ///     Logs a SQL dependency	
-        /// </summary>	
-        /// <param name="logger">Logger to use</param>	
-        /// <param name="connectionString">SQL connection string</param>	
-        /// <param name="tableName">Name of table</param>	
-        /// <param name="operationName">Name of the operation that was performed</param>	
-        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>	
-        /// <param name="duration">Duration of the operation</param>	
-        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>	
-        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        [Obsolete("Will be moved to separate package 'Arcus.Observability.Telemetry.Sql' in the future")]
-        public static void LogSqlDependency(this ILogger logger, string connectionString, string tableName, string operationName, DateTimeOffset startTime, TimeSpan duration, bool isSuccessful, Dictionary<string, object> context = null)
-        {
-            Guard.NotNullOrEmpty(connectionString, nameof(connectionString));
-            var connection = new SqlConnectionStringBuilder(connectionString);
-
-            LogSqlDependency(logger, connection.DataSource, connection.InitialCatalog, tableName, operationName, isSuccessful, startTime, duration, context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -5,7 +5,7 @@
     <PackageId>Arcus.Observability.Telemetry.Sql</PackageId>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides capability to improve Sql telemetry with Serilog in applications</Description>
+    <Description>Provides capability to improve SQL telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageId>Arcus.Observability.Telemetry.Sql</PackageId>
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <Description>Provides capability to improve Sql telemetry with Serilog in applications</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>Azure;Observability;Telemetry;Serilog;Sql</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Arcus.Observability.Telemetry.Sql</AssemblyName>
+    <RootNamespace>Arcus.Observability.Telemetry.Sql</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Extensions related to the tracking of SQL dependencies.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class ILoggerExtensions
+    {
+        /// <summary>
+        ///     Logs a SQL dependency
+        /// </summary>	
+        /// <param name="logger">Logger to use</param>
+        /// <param name="connectionString">SQL connection string</param>
+        /// <param name="tableName">Name of table</param>
+        /// <param name="operationName">Name of the operation that was performed</param>	
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="measurement">Measuring the latency to call the SQL dependency</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        public static void LogSqlDependency(this ILogger logger, string connectionString, string tableName, string operationName, DependencyMeasurement measurement, bool isSuccessful, Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger));
+            Guard.NotNull(measurement, nameof(measurement));
+
+            LogSqlDependency(logger, connectionString, tableName, operationName, measurement.StartTime, measurement.Elapsed, isSuccessful, context);
+        }
+
+        /// <summary>
+        ///     Logs a SQL dependency
+        /// </summary>
+        /// <param name="logger">Logger to use</param>
+        /// <param name="connectionString">SQL connection string</param>
+        /// <param name="tableName">Name of table</param>	
+        /// <param name="operationName">Name of the operation that was performed</param>
+        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        public static void LogSqlDependency(this ILogger logger, string connectionString, string tableName, string operationName, DateTimeOffset startTime, TimeSpan duration, bool isSuccessful, Dictionary<string, object> context = null)
+        {
+            Guard.NotNullOrEmpty(connectionString, nameof(connectionString));
+            var connection = new SqlConnectionStringBuilder(connectionString);
+
+            logger.LogSqlDependency(connection.DataSource, connection.InitialCatalog, tableName, operationName, isSuccessful, startTime, duration, context);
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
+++ b/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Filters\Arcus.Observability.Telemetry.Serilog.Filters.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights\Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Enrichers\Arcus.Observability.Telemetry.Serilog.Enrichers.csproj" />
+    <ProjectReference Include="..\Arcus.Observability.Telemetry.Sql\Arcus.Observability.Telemetry.Sql.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Tests.Core\Arcus.Observability.Tests.Core.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.sln
+++ b/src/Arcus.Observability.sln
@@ -21,9 +21,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Observability.Telemet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Observability.Tests.Core", "Arcus.Observability.Tests.Core\Arcus.Observability.Tests.Core.csproj", "{DC18426F-4D03-4DBD-8D92-224C026BFADC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Observability.Telemetry.IoT", "Arcus.Observability.Telemetry.IoT\Arcus.Observability.Telemetry.IoT.csproj", "{E4A6624B-C1A4-4956-9FC2-E77D6C634717}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Observability.Telemetry.IoT", "Arcus.Observability.Telemetry.IoT\Arcus.Observability.Telemetry.IoT.csproj", "{E4A6624B-C1A4-4956-9FC2-E77D6C634717}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Observability.Telemetry.AzureFunctions", "Arcus.Observability.Telemetry.AzureFunctions\Arcus.Observability.Telemetry.AzureFunctions.csproj", "{C6C0ED5D-94B4-4CD2-B17A-E72432AC4883}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Observability.Telemetry.AzureFunctions", "Arcus.Observability.Telemetry.AzureFunctions\Arcus.Observability.Telemetry.AzureFunctions.csproj", "{C6C0ED5D-94B4-4CD2-B17A-E72432AC4883}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Observability.Telemetry.Sql", "Arcus.Observability.Telemetry.Sql\Arcus.Observability.Telemetry.Sql.csproj", "{9EFD7715-304C-42AB-BC2B-40CED0E14050}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +73,10 @@ Global
 		{C6C0ED5D-94B4-4CD2-B17A-E72432AC4883}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6C0ED5D-94B4-4CD2-B17A-E72432AC4883}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6C0ED5D-94B4-4CD2-B17A-E72432AC4883}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EFD7715-304C-42AB-BC2B-40CED0E14050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EFD7715-304C-42AB-BC2B-40CED0E14050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EFD7715-304C-42AB-BC2B-40CED0E14050}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EFD7715-304C-42AB-BC2B-40CED0E14050}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Move the SQL package together with the related dependency tracking extensions to a seperate project.

Closes #131 