### PR TITLE
Test - use custom dimensions in integration tests

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
@@ -11,9 +11,20 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
     /// </summary>
     public class KubernetesEnricher : ILogEventEnricher
     {
-        private const string NodeNameVariable = "KUBERNETES_NODE_NAME",
-                             PodNameVariable = "KUBERNETES_POD_NAME",
-                             NamespaceVariable = "KUBERNETES_NAMESPACE";
+        /// <summary>
+        /// Gets the default Kubernetes node name environment variable name.
+        /// </summary>
+        public const string NodeNameVariable = "KUBERNETES_NODE_NAME";
+
+        /// <summary>
+        /// Gets the default Kubernetes pod name environment variable name.
+        /// </summary>
+        public const string PodNameVariable = "KUBERNETES_POD_NAME";
+
+        /// <summary>
+        /// Gets the default Kubernetes namespace environment variable name.
+        /// </summary>
+        public const string NamespaceVariable = "KUBERNETES_NAMESPACE";
 
         private readonly string _nodeNamePropertyName, _podNamePropertyName, _namespacePropertyName;
 

--- a/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
+++ b/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Arcus.Testing.Logging" Version="0.1.0" />
     <PackageReference Include="Bogus" Version="29.0.1" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.ApplicationInsights" Version="0.9.0-preview" />
+    <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Polly" Version="7.2.0" />

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Bogus;
 using Microsoft.Azure.ApplicationInsights;
+using Microsoft.Azure.ApplicationInsights.Query;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -31,7 +32,14 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         {
             _outputWriter = outputWriter;
             _instrumentationKey = Configuration.GetValue<string>("ApplicationInsights:InstrumentationKey");
+            
+            ApplicationId = Configuration.GetValue<string>("ApplicationInsights:ApplicationId");
         }
+
+        /// <summary>
+        /// Gets the ID of the application that has access to the Azure Application Insights resource.
+        /// </summary>
+        protected string ApplicationId { get; }
 
         protected ILoggerFactory CreateLoggerFactory(Action<LoggerConfiguration> configureLogging = null)
         {
@@ -75,10 +83,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         protected ApplicationInsightsDataClient CreateApplicationInsightsClient()
         {
             var clientCredentials = new ApiKeyClientCredentials(Configuration.GetValue<string>("ApplicationInsights:ApiKey"));
-            var client = new ApplicationInsightsDataClient(clientCredentials)
-            {
-                AppId = Configuration.GetValue<string>("ApplicationInsights:ApplicationId")
-            };
+            var client = new ApplicationInsightsDataClient(clientCredentials);
 
             return client;
         }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,7 +43,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -43,7 +43,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,7 +39,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Data == dependencyData);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventTests.cs
@@ -142,18 +142,14 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         public async Task LogEventWithKubernetesInfo_SinksToApplicationInsights_ResultsInTelemetryWithKubernetesInfo()
         {
             // Arrange
-            const string kubernetesNodeName = "KUBERNETES_NODE_NAME",
-                         kubernetesPodName = "KUBERNETES_POD_NAME",
-                         kubernetesNamespace = "KUBERNETES_NAMESPACE";
-
             string nodeName = $"node-{Guid.NewGuid()}";
             string podName = $"pod-{Guid.NewGuid()}";
             string @namespace = $"namespace-{Guid.NewGuid()}";
             var message = "This message will have Kubernetes information";
 
-            using (TemporaryEnvironmentVariable.Create(kubernetesNodeName, nodeName))
-            using (TemporaryEnvironmentVariable.Create(kubernetesPodName, podName))
-            using (TemporaryEnvironmentVariable.Create(kubernetesNamespace, @namespace))
+            using (TemporaryEnvironmentVariable.Create(KubernetesEnricher.NodeNameVariable, nodeName))
+            using (TemporaryEnvironmentVariable.Create(KubernetesEnricher.PodNameVariable, podName))
+            using (TemporaryEnvironmentVariable.Create(KubernetesEnricher.NamespaceVariable, @namespace))
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithKubernetesInfo()))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -171,11 +167,11 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     Assert.Contains(traceEvents.Value, trace =>
                     {
                         return message == trace.Trace.Message
-                               && trace.CustomDimensions.TryGetValue(kubernetesNodeName, out string actualNodeName)
+                               && trace.CustomDimensions.TryGetValue(ContextProperties.Kubernetes.NodeName, out string actualNodeName)
                                && nodeName == actualNodeName
-                               && trace.CustomDimensions.TryGetValue(kubernetesPodName, out string actualPodName)
+                               && trace.CustomDimensions.TryGetValue(ContextProperties.Kubernetes.PodName, out string actualPodName)
                                && podName == actualPodName
-                               && trace.CustomDimensions.TryGetValue(kubernetesNamespace, out string actualNamespace)
+                               && trace.CustomDimensions.TryGetValue(ContextProperties.Kubernetes.Namespace, out string actualNamespace)
                                && @namespace == actualNamespace;
                     });
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventTests.cs
@@ -106,8 +106,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         public async Task LogEventWithCorrelationInfo_SinksToApplicationInsights_ResultsInTelemetryWithCorrelationInfo()
         {
             // Arrange
-            var message = "Message 1/2 that will be correlated";
-            
+            string message = "Message that will be correlated";
             string operationId = $"operation-{Guid.NewGuid()}";
             string transactionId = $"transaction-{Guid.NewGuid()}";
             

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ExceptionTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ExceptionTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -35,7 +35,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsExceptionResult> results = await client.GetExceptionEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsExceptionResult> results = await client.Events.GetExceptionEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.Contains(results.Value, result => result.Exception.OuterMessage == exception.Message);
                 });
             }
@@ -61,7 +61,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsExceptionResult> results = await client.GetExceptionEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsExceptionResult> results = await client.Events.GetExceptionEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Exception.OuterMessage == exception.Message && result.Cloud.RoleName == componentName);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpDependencyTests.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -48,7 +48,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {
@@ -89,7 +89,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/IoTHubTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/IoTHubTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
@@ -41,7 +41,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/MetricTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/MetricTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,7 +40,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                         id: Guid.NewGuid().ToString(), 
                         parameters: new MetricsPostBodySchemaParameters("customMetrics/" + metricName));
 
-                    IList<MetricsResultsItem> results = await client.GetMetricsAsync(new List<MetricsPostBodySchema> { bodySchema });
+                    IList<MetricsResultsItem> results = await client.Metrics.GetMultipleAsync(ApplicationId, new List<MetricsPostBodySchema> { bodySchema });
                     Assert.NotEmpty(results);
                 });
             }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/RequestTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/RequestTests.cs
@@ -4,8 +4,8 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -46,7 +46,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.GetRequestEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Request.Url == $"{requestUri.Scheme}://{requestUri.Host}{requestUri.AbsolutePath}");
                 });
@@ -78,7 +78,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.GetRequestEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Request.Url == $"{requestUri.Scheme}://{requestUri.Host}{requestUri.AbsolutePath}");
                 });
@@ -112,7 +112,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.GetRequestEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Request.Url == requestUri.ToString());
                 });
@@ -144,7 +144,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.GetRequestEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Request.Url == requestUri.ToString());
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -38,7 +38,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Dependency.Type == "Azure Service Bus" && result.Dependency.Target == entityName);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,7 +41,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,7 +41,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.GetDependencyEventsAsync();
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TraceTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TraceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApplicationInsights;
-using Microsoft.Azure.ApplicationInsights.Models;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -33,7 +33,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsTraceResult> results = await client.GetTraceEventsAsync(filter: OnlyLastHourFilter);
+                    EventsResults<EventsTraceResult> results = await client.Events.GetTraceEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
                     Assert.Contains(results.Value, result => result.Trace.Message.Contains(message));
                 });
             }


### PR DESCRIPTION
Since there's a new version released of the Azure SDK Application Insights package to retrieve also the custom dimensions of tracked events, we can finally test our Serilog enrichers thorougly.

Clloses #93 