### PR TITLE
Fix - set correlation info throughout async operations

### DIFF
--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -86,8 +86,9 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
-    .Enrich.WithCorrelationInfo()
+    .Enrich.WithCorrelationInfo(serviceProvider)
     .CreateLogger();
 
 logger.Information("This event will be enriched with the correlation information");
@@ -112,8 +113,10 @@ The correlation information enricher allows you to specify the names of the log 
 This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
 
 ```csharp
+IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(
+        serviceProvider,
         operationIdPropertyName: "MyOperationId",
         transactionIdPropertyName: "MyTransactionId")
     .CreateLogger();

--- a/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessor.cs
+++ b/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessor.cs
@@ -1,4 +1,6 @@
-﻿namespace Arcus.Observability.Correlation 
+﻿using System;
+
+namespace Arcus.Observability.Correlation 
 {
     /// <summary>
     /// Default <see cref="ICorrelationInfoAccessor"/> implementation to access the <see cref="CorrelationInfo"/> in the current context.
@@ -8,13 +10,14 @@
         /// <summary>
         /// Prevents a new instance of the <see cref="DefaultCorrelationInfoAccessor"/> class from being created.
         /// </summary>
-        private DefaultCorrelationInfoAccessor()
+        public DefaultCorrelationInfoAccessor()
         {
         }
 
         /// <summary>
         /// Gets the default instance for the <see cref="DefaultCorrelationInfoAccessor"/> class.
         /// </summary>
+        [Obsolete("Create a new instance instead of using this static value")]
         public new static DefaultCorrelationInfoAccessor Instance { get; } = new DefaultCorrelationInfoAccessor();
     }
 }

--- a/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessorT.cs
+++ b/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessorT.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 namespace Arcus.Observability.Correlation
 {
@@ -13,7 +14,7 @@ namespace Arcus.Observability.Correlation
         /// <summary>
         /// Prevents a new instance of the <see cref="DefaultCorrelationInfoAccessor"/> class from being created.
         /// </summary>
-        private protected DefaultCorrelationInfoAccessor()
+        public DefaultCorrelationInfoAccessor()
         {
         }
 
@@ -37,6 +38,7 @@ namespace Arcus.Observability.Correlation
         /// <summary>
         /// Gets the default instance for the <see cref="DefaultCorrelationInfoAccessor{TCorrelation}"/> class.
         /// </summary>
+        [Obsolete("Create a new instance instead of using this static value")]
         public static DefaultCorrelationInfoAccessor<TCorrelationInfo> Instance { get; } = new DefaultCorrelationInfoAccessor<TCorrelationInfo>();
     }
 }

--- a/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessorT.cs
+++ b/src/Arcus.Observability.Correlation/DefaultCorrelationInfoAccessorT.cs
@@ -8,7 +8,7 @@ namespace Arcus.Observability.Correlation
     public class DefaultCorrelationInfoAccessor<TCorrelationInfo> : ICorrelationInfoAccessor<TCorrelationInfo> 
         where TCorrelationInfo : CorrelationInfo 
     {
-        private static readonly AsyncLocal<TCorrelationInfo> CorrelationInfoLocalData = new AsyncLocal<TCorrelationInfo>();
+        private TCorrelationInfo _correlationInfo;
 
         /// <summary>
         /// Prevents a new instance of the <see cref="DefaultCorrelationInfoAccessor"/> class from being created.
@@ -22,7 +22,7 @@ namespace Arcus.Observability.Correlation
         /// </summary>
         public TCorrelationInfo GetCorrelationInfo()
         {
-            return CorrelationInfoLocalData.Value;
+            return _correlationInfo;
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace Arcus.Observability.Correlation
         /// <param name="correlationInfo">The correlation model to set.</param>
         public void SetCorrelationInfo(TCorrelationInfo correlationInfo)
         {
-            CorrelationInfoLocalData.Value = correlationInfo;
+            Interlocked.Exchange(ref _correlationInfo, correlationInfo);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services));
 
-            return AddCorrelation(services, DefaultCorrelationInfoAccessor.Instance, configureOptions);
+            return AddCorrelation(services, new DefaultCorrelationInfoAccessor(), configureOptions);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo, TOptions>(
                 services, 
-                serviceProvider => DefaultCorrelationInfoAccessor<TCorrelationInfo>.Instance, 
+                serviceProvider => new DefaultCorrelationInfoAccessor<TCorrelationInfo>(),
                 configureOptions);
         }
 

--- a/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Extensions to set correlation access information on the <see cref="IServiceCollection"/>.
     /// </summary>
+    // ReSharper disable once InconsistentNaming
     public static class IServiceCollectionExtensions
     {
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -136,6 +136,30 @@ namespace Serilog
         }
 
         /// <summary>
+        /// Adds the previously registered <see cref="ICorrelationInfoAccessor"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithCorrelationInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            IServiceProvider serviceProvider,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+
+            var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
+            return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
+        }
+
+        /// <summary>
         /// Adds the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
@@ -155,6 +179,31 @@ namespace Serilog
             Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
             return WithCorrelationInfo(enrichmentConfiguration, DefaultCorrelationInfoAccessor<TCorrelationInfo>.Instance, operationIdPropertyName, transactionIdPropertyName);
+        }
+
+        /// <summary>
+        /// Adds the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
+        /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
+        /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            IServiceProvider serviceProvider,
+            string operationIdPropertyName = ContextProperties.Correlation.OperationId,
+            string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
+            where TCorrelationInfo : CorrelationInfo
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+
+            var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
+            return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -122,6 +122,7 @@ namespace Serilog
         /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(WithCorrelationInfo) + " overload with providing your own default correlation accessor")]
         public static LoggerConfiguration WithCorrelationInfo(
             this LoggerEnrichmentConfiguration enrichmentConfiguration,
             string operationIdPropertyName = ContextProperties.Correlation.OperationId,
@@ -142,6 +143,7 @@ namespace Serilog
         /// <param name="transactionIdPropertyName">The name of the property to enrich the log event with the correlation transaction ID.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationIdPropertyName"/> or <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(WithCorrelationInfo) + " overload with providing your own default correlation accessor")]
         public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
             this LoggerEnrichmentConfiguration enrichmentConfiguration,
             string operationIdPropertyName = ContextProperties.Correlation.OperationId,

--- a/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Correlation
+{
+    public class DefaultCorrelationInfoAccessorTests
+    {
+        [Fact]
+        public async Task SetCorrelationInfo_Twice_UsesMostRecentValue()
+        {
+            // Arrange
+            var firstOperationId = $"operation-{Guid.NewGuid()}";
+            var secondOperationId = $"operation-{Guid.NewGuid()}";
+            var transactionId = $"transaction-{Guid.NewGuid()}";
+            await SetCorrelationInfo(firstOperationId, transactionId);
+
+            // Act
+            await SetCorrelationInfo(secondOperationId, transactionId);
+
+            // Assert
+            CorrelationInfo correlationInfo = DefaultCorrelationInfoAccessor.Instance.GetCorrelationInfo();
+            Assert.Equal(secondOperationId, correlationInfo.OperationId);
+            Assert.Equal(transactionId, correlationInfo.TransactionId);
+        }
+
+        private async Task SetCorrelationInfo(string operationId, string transactionId)
+        {
+            DefaultCorrelationInfoAccessor.Instance.SetCorrelationInfo(
+                new CorrelationInfo(operationId, transactionId));
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/CorrelationInfoEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/CorrelationInfoEnricherTests.cs
@@ -4,6 +4,7 @@ using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.Observability.Tests.Core;
 using Arcus.Observability.Tests.Unit.Correlation;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Serilog;
 using Serilog.Events;
@@ -596,6 +597,40 @@ namespace Arcus.Observability.Tests.Unit.Serilog
 
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void WithCorrelationInfoAccessor_WithServiceProviderWithBlankOperationIdName_Throws(string operationIdPropertyName)
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            services.AddCorrelation();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithCorrelationInfo(
+                    serviceProvider, 
+                    operationIdPropertyName: operationIdPropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithCorrelationInfoAccessor_WithServiceProviderWithBlankTransactionIdName_Throws(string transactionIdPropertyName)
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            services.AddCorrelation();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithCorrelationInfo(
+                    serviceProvider, 
+                    transactionIdPropertyName: transactionIdPropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void WithCorrelationInfoAccessorT_WithBlankOperationIdName_Throws(string operationIdPropertyName)
         {
             // Arrange
@@ -604,7 +639,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => configuration.Enrich.WithCorrelationInfo(
-                    DefaultCorrelationInfoAccessor.Instance, 
+                    DefaultCorrelationInfoAccessor<TestCorrelationInfo>.Instance, 
                     operationIdPropertyName: operationIdPropertyName));
         }
 
@@ -618,8 +653,99 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => configuration.Enrich.WithCorrelationInfo(
-                    DefaultCorrelationInfoAccessor.Instance,
+                    DefaultCorrelationInfoAccessor<TestCorrelationInfo>.Instance,
                     transactionIdPropertyName: transactionIdPropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithCorrelationInfoAccessorT_WithServiceProviderWithBlankOperationIdName_Throws(string operationIdPropertyName)
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            services.AddCorrelation<TestCorrelationInfo>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithCorrelationInfo<TestCorrelationInfo>(
+                    serviceProvider, 
+                    operationIdPropertyName: operationIdPropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithCorrelationInfoAccessorT_WithServiceProviderWithBlankTransactionIdName_Throws(string transactionIdPropertyName)
+        {
+            // Arrange
+            var configuration = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            services.AddCorrelation<TestCorrelationInfo>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => configuration.Enrich.WithCorrelationInfo<TestCorrelationInfo>(
+                    serviceProvider,
+                    transactionIdPropertyName: transactionIdPropertyName));
+        }
+
+        [Fact]
+        public void WithCorrelationAccessor_WithoutServiceProvider_Throws()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => config.Enrich.WithCorrelationInfo(serviceProvider: null));
+        }
+
+        [Fact]
+        public void WithCorrelationAccessorT_WithoutServiceProvider_Throws()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => config.Enrich.WithCorrelationInfo<TestCorrelationInfo>(serviceProvider: null));
+        }
+
+        [Fact]
+        public void WithCorrelationAccessor_WithoutRegisteredCorrelationAccessor_Throws()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(() => config.Enrich.WithCorrelationInfo(serviceProvider));
+        }
+
+        [Fact]
+        public void WithCorrelationAccessorT_WithoutRegisteredCorrelationAccessor_Throws()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(() => config.Enrich.WithCorrelationInfo<TestCorrelationInfo>(serviceProvider));
+        }
+
+        [Fact]
+        public void WithCorrelationAccessorT_WithWrongRegisteredCorrelationAccessor_Throws()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+            var services = new ServiceCollection();
+            services.AddCorrelation();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(() => config.Enrich.WithCorrelationInfo<TestCorrelationInfo>(serviceProvider));
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/CorrelationInfoEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/CorrelationInfoEnricherTests.cs
@@ -15,7 +15,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
     public class CorrelationInfoEnricherTests
     {
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessor_HasOperationIdAndTransactionId()
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessor_HasOperationIdAndTransactionId()
         {
             // Arrange
             string expectedOperationId = $"operation-{Guid.NewGuid()}";
@@ -43,8 +43,37 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 $"Expected to have a log property transaction ID '{ContextProperties.Correlation.TransactionId}' with the value '{expectedTransactionId}'");
         }
 
+         [Fact]
+        public void LogEvent_WithDefaultCorrelationInfoAccessor_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor();
+            correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo(expectedOperationId, expectedTransactionId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.OperationId, expectedOperationId),
+                $"Expected to have a log property operation ID '{ContextProperties.Correlation.OperationId}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.TransactionId, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{ContextProperties.Correlation.TransactionId}' with the value '{expectedTransactionId}'");
+        }
+
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessorWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessorWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
         {
             // Arrange
             string operationIdPropertyName = $"operation-name-{Guid.NewGuid():N}";
@@ -74,7 +103,37 @@ namespace Arcus.Observability.Tests.Unit.Serilog
         }
 
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessorWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
+        public void LogEvent_WithDefaultCorrelationInfoAccessorWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string operationIdPropertyName = $"operation-name-{Guid.NewGuid():N}";
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor();
+            correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo(expectedOperationId, expectedTransactionId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor, operationIdPropertyName: operationIdPropertyName)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(operationIdPropertyName, expectedOperationId),
+                $"Expected to have a log property operation ID '{operationIdPropertyName}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.TransactionId, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{ContextProperties.Correlation.TransactionId}' with the value '{expectedTransactionId}'");
+        }
+
+        [Fact]
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessorWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
         {
             // Arrange
             string transactionIdPropertyName = $"transaction-name-{Guid.NewGuid():N}";
@@ -104,7 +163,37 @@ namespace Arcus.Observability.Tests.Unit.Serilog
         }
 
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessorT_HasOperationIdAndTransactionId()
+        public void LogEvent_WithDefaultCorrelationInfoAccessorWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string transactionIdPropertyName = $"transaction-name-{Guid.NewGuid():N}";
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor();
+            correlationInfoAccessor.SetCorrelationInfo(new CorrelationInfo(expectedOperationId, expectedTransactionId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor, transactionIdPropertyName: transactionIdPropertyName)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.OperationId, expectedOperationId),
+                $"Expected to have a log property operation ID '{ContextProperties.Correlation.OperationId}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(transactionIdPropertyName, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{transactionIdPropertyName}' with the value '{expectedTransactionId}'");
+        }
+
+        [Fact]
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessorT_HasOperationIdAndTransactionId()
         {
             // Arrange
             string expectedOperationId = $"operation-{Guid.NewGuid()}";
@@ -137,7 +226,40 @@ namespace Arcus.Observability.Tests.Unit.Serilog
         }
 
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessorTWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
+        public void LogEvent_WithDefaultCorrelationInfoAccessorT_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+            string expectedTestId = $"test-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor<TestCorrelationInfo>();
+            correlationInfoAccessor.SetCorrelationInfo(new TestCorrelationInfo(expectedOperationId, expectedTransactionId, expectedTestId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.OperationId, expectedOperationId),
+                $"Expected to have a log property operation ID '{ContextProperties.Correlation.OperationId}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.TransactionId, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{ContextProperties.Correlation.TransactionId}' with the value '{expectedTransactionId}'");
+            Assert.False(
+                logEvent.ContainsProperty(TestCorrelationInfoEnricher.TestId, expectedTestId),
+                $"Expected to have a log property test ID '{TestCorrelationInfoEnricher.TestId}' with the value '{expectedTestId}'");
+        }
+
+        [Fact]
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessorTWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
         {
             // Arrange
             string operationIdPropertyName = $"operation-name-{Guid.NewGuid():N}";
@@ -171,7 +293,41 @@ namespace Arcus.Observability.Tests.Unit.Serilog
         }
 
         [Fact]
-        public void LogEvent_WithDefaultCorrelationInfoAccessorTWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
+        public void LogEvent_WithDefaultCorrelationInfoAccessorTWithCustomOperationIdProperty_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string operationIdPropertyName = $"operation-name-{Guid.NewGuid():N}";
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+            string expectedTestId = $"test-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor<TestCorrelationInfo>();
+            correlationInfoAccessor.SetCorrelationInfo(new TestCorrelationInfo(expectedOperationId, expectedTransactionId, expectedTestId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor, operationIdPropertyName: operationIdPropertyName)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(operationIdPropertyName, expectedOperationId),
+                $"Expected to have a log property operation ID '{operationIdPropertyName}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.TransactionId, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{ContextProperties.Correlation.TransactionId}' with the value '{expectedTransactionId}'");
+            Assert.False(
+                logEvent.ContainsProperty(TestCorrelationInfoEnricher.TestId, expectedTestId),
+                $"Expected to have a log property test ID '{TestCorrelationInfoEnricher.TestId}' with the value '{expectedTestId}'");
+        }
+
+        [Fact]
+        public void LogEvent_WithStaticDefaultCorrelationInfoAccessorTWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
         {
             // Arrange
             string transactionIdPropertyName = $"transaction-name-{Guid.NewGuid():N}";
@@ -185,6 +341,40 @@ namespace Arcus.Observability.Tests.Unit.Serilog
 
             ILogger logger = new LoggerConfiguration()
                 .Enrich.WithCorrelationInfo<TestCorrelationInfo>(transactionIdPropertyName: transactionIdPropertyName)
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            // Act
+            logger.Information("This message will be enriched with correlation information");
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.True(
+                logEvent.ContainsProperty(ContextProperties.Correlation.OperationId, expectedOperationId),
+                $"Expected to have a log property operation ID '{ContextProperties.Correlation.OperationId}' with the value '{expectedOperationId}'");
+            Assert.True(
+                logEvent.ContainsProperty(transactionIdPropertyName, expectedTransactionId),
+                $"Expected to have a log property transaction ID '{transactionIdPropertyName}' with the value '{expectedTransactionId}'");
+            Assert.False(
+                logEvent.ContainsProperty(TestCorrelationInfoEnricher.TestId, expectedTestId),
+                $"Expected to have a log property test ID '{TestCorrelationInfoEnricher.TestId}' with the value '{expectedTestId}'");
+        }
+
+        [Fact]
+        public void LogEvent_WithDefaultCorrelationInfoAccessorTWithCustomTransactionIdProperty_HasOperationIdAndTransactionId()
+        {
+            // Arrange
+            string transactionIdPropertyName = $"transaction-name-{Guid.NewGuid():N}";
+            string expectedOperationId = $"operation-{Guid.NewGuid()}";
+            string expectedTransactionId = $"transaction-{Guid.NewGuid()}";
+            string expectedTestId = $"test-{Guid.NewGuid()}";
+
+            var spySink = new InMemoryLogSink();
+            var correlationInfoAccessor = new DefaultCorrelationInfoAccessor<TestCorrelationInfo>();
+            correlationInfoAccessor.SetCorrelationInfo(new TestCorrelationInfo(expectedOperationId, expectedTransactionId, expectedTestId));
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithCorrelationInfo(correlationInfoAccessor, transactionIdPropertyName: transactionIdPropertyName)
                 .WriteTo.Sink(spySink)
                 .CreateLogger();
 


### PR DESCRIPTION
We first uses a different correlation information for each asyhchronous operation, but this is actually wrong as we already use a scoped service for this. We should consider not using the static value for the default correlation info accessor as this would be the same accross requests. So we should create a new accessor for each request instead.

Closes #159 