### PR TITLE
Feature - track Azure Key Vault dependency

### DIFF
--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -38,6 +38,7 @@ We provide support for the following dependencies:
 - [Azure Cosmos DB](#measuring-azure-cosmos-db-dependencies)
 - [Azure Event Hubs](#measuring-azure-event-hubs-dependencies)
 - [Azure IoT Hub](#measuring-azure-iot-hub-dependencies)
+- [Azure Key Vault](#measuring-azure-key-vault-dependencies)
 - [Azure Search](#measuring-azure-search-dependencies)
 - [Azure Service Bus](#measuring-azure-service-bus-dependencies)
 - [Azure Table Storage](#measuring-azure-table-storage-dependencies)
@@ -60,7 +61,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogBlobStorageDependency(accountName: "multimedia", containerName: "images", isSuccessful: true, startTime, durationMeasurement.Elapsed);
+logger.LogBlobStorageDependency(accountName: "multimedia", containerName: "images", isSuccessful: true, startTime, durationMeasurement.Elapsed);
 // Output: "Dependency Azure blob multimedia named images in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -79,7 +80,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogCosmosSqlDependency(accountName: "administration", database: "docs", container: "purchases", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogCosmosSqlDependency(accountName: "administration", database: "docs", container: "purchases", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure DocumentDB docs/purchases named administration in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -96,7 +97,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogEventHubsDependency(namespaceName: "be.sensors.contoso", eventHubName: "temperature", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogEventHubsDependency(namespaceName: "be.sensors.contoso", eventHubName: "temperature", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure Event Hubs be.sensors.contoso named temerature in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -115,7 +116,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.logger.LogIotHubDependency(iotHubName: "sensors", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogIotHubDependency(iotHubName: "sensors", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure IoT Hub named sensors in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -140,8 +141,27 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.logger.LogIotHubDependency(iotHubConnectionString: "Hostname=sensors;", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogIotHubDependency(iotHubConnectionString: "Hostname=sensors;", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure IoT Hub named sensors in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+```
+
+### Measuring Azure Key Vault dependencies
+
+We allow you to measure Azure Key vault dependencies.
+
+**Example**
+
+Here is how you can report a dependency call:
+
+```csharp
+var durationMeasurement = new StopWatch();
+
+// Start measuring
+durationMeasurement.Start();
+var startTime = DateTimeOffset.UtcNow;
+
+logger.AzureKeyVaultDependency(vaultUri: "https://my-secret-store.vault.azure.net", operationName: "get secret", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+// Output: "Dependency Azure key vault get secret named https://my-secret-store.vault.azure.net in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
 ### Measuring Azure Search dependencies
@@ -157,7 +177,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogAzureSearchDependency(searchServiceName: "orders-search", operationName: "get-orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogAzureSearchDependency(searchServiceName: "orders-search", operationName: "get-orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure Search get-orders named orders-search in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 
 ### Measuring Azure Service Bus dependencies
@@ -173,7 +193,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogServiceBusQueueDependency(queueName: "ordersqueue", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogServiceBusQueueDependency(queueName: "ordersqueue", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure Service Bus Queue named ordersqueue in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -192,7 +212,7 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-_logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure table orders named orderAccount in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -215,7 +235,7 @@ var startTime = DateTimeOffset.UtcNow;
 // Send request to dependant service
 var response = await httpClient.SendAsync(request);
 
-_logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "HTTP Dependency requestbin.net for POST /r/ujxglouj completed with 200 in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
@@ -233,7 +253,7 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-_logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
 ```
 
@@ -260,7 +280,7 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-_logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessful: true, measurement: measurement);
+logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessful: true, measurement: measurement);
 // Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
 ```
 
@@ -278,7 +298,7 @@ durationMeasurement.Start();
 string dependencyName = "SendGrid";
 object dependencyData = "http://my.sendgrid.uri/"
 
-_logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency SendGrid http://my.sendgrid.uri/ in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
 ```
 
@@ -298,7 +318,7 @@ durationMeasurement.Start();
 /// Track dependency
 string dependencyName = "SendGrid";
 object dependencyData = "https://my.sendgrid.uri/";
-_logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed, context: telemetryContext);
+logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed, context: telemetryContext);
 ```
 
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
@@ -312,7 +332,7 @@ using (var measurement = DependencyMeasurement.Start())
     // Track dependency
     string dependencyName = "SendGrid";
     object dependencyData = "https://my.sendgrid.uri/";
-    _logger.LogDependency(dependencyName, dependencyData, isSuccessful: true, startTime: measurement, context: telemetryContext);
+    logger.LogDependency(dependencyName, dependencyData, isSuccessful: true, startTime: measurement, context: telemetryContext);
 }
 ```
 
@@ -327,12 +347,12 @@ try
     // Interact with SendGrid...
     // Done!
 
-    _logger.LogDependency(dependencyName, dependencyData, isSuccessful: true, startTime: measurement, context: telemetryContext);
+    logger.LogDependency(dependencyName, dependencyData, isSuccessful: true, startTime: measurement, context: telemetryContext);
 }
 catch (Exception exception)
 {
-    _logger.LogError(exception, "Failed to interact with SendGrid");
-    _logger.LogDependency(dependencyName, dependencyData, isSuccessful: false, startTime: measurement, context: telemetryContext);
+    logger.LogError(exception, "Failed to interact with SendGrid");
+    logger.LogDependency(dependencyName, dependencyData, isSuccessful: false, startTime: measurement, context: telemetryContext);
 }
 ```
 

--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -160,7 +160,7 @@ var durationMeasurement = new StopWatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-logger.AzureKeyVaultDependency(vaultUri: "https://my-secret-store.vault.azure.net", operationName: "get secret", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.AzureKeyVaultDependency(vaultUri: "https://my-secret-store.vault.azure.net", secretName: "ServiceBus-ConnectionString", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: "Dependency Azure key vault get secret named https://my-secret-store.vault.azure.net in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -86,9 +86,11 @@ namespace Microsoft.Extensions.Logging
             + ContextProperties.MetricTracking.Timestamp
             + "} (Context: {@" + ContextProperties.TelemetryContext + "})";
 
-        private const string KeyVaultUriPattern = "^https:\\/\\/[0-9a-zA-Z\\-]{3,24}\\.vault.azure.net(\\/)?$";
-
-        private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled);
+        private const string KeyVaultUriPattern = "^https:\\/\\/[0-9a-zA-Z\\-]{3,24}\\.vault.azure.net(\\/)?$",
+                             SecretNamePattern = "^[a-zA-Z][a-zA-Z0-9\\-]{0,126}$";
+        
+        private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled),
+                                      SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
 
         /// <summary>
         ///     Logs an HTTP request
@@ -262,29 +264,34 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The logger to use.</param>
         /// <param name="vaultUri">The URI pointing to the Azure Key Vault resource.</param>
-        /// <param name="operationName">The kind of operation which gets to be executed on the Azure Key Vault.</param>
+        /// <param name="secretName">The secret that is being used within the Azure Key Vault resource.</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="operationName"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the <paramref name="secretName"/> is not in the correct format.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="vaultUri"/> is not in the correct format.</exception>
         public static void LogAzureKeyVaultDependency(
             this ILogger logger,
             string vaultUri,
-            string operationName,
+            string secretName,
             bool isSuccessful,
             DependencyMeasurement measurement,
             Dictionary<string, object> context = null)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
             Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name of the operation executed on Azure Key Vault");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
+            Guard.For<FormatException>(
+                () => !SecretNameRegex.IsMatch(secretName), 
+                "Requires a Azure Key Vault secret name in the correct format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
             Guard.For<UriFormatException>(
                 () => !KeyVaultUriRegex.IsMatch(vaultUri),
                 "Requires the Azure Key Vault host to be in the right format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
 
             context = context ?? new Dictionary<string, object>();
-            LogAzureKeyVaultDependency(logger, vaultUri, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
+            LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
@@ -292,17 +299,19 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The logger to use.</param>
         /// <param name="vaultUri">The URI pointing to the Azure Key Vault resource.</param>
-        /// <param name="operationName">The kind of operation which gets to be executed on the Azure Key Vault.</param>
+        /// <param name="secretName">The secret that is being used within the Azure Key Vault resource.</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="operationName"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the <paramref name="secretName"/> is not in the correct format.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="vaultUri"/> is not in the correct format.</exception>
         public static void LogAzureKeyVaultDependency(
             this ILogger logger,
             string vaultUri,
-            string operationName,
+            string secretName,
             bool isSuccessful,
             DateTimeOffset startTime,
             TimeSpan duration,
@@ -310,14 +319,17 @@ namespace Microsoft.Extensions.Logging
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
             Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name of the operation executed on Azure Key Vault");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
+            Guard.For<FormatException>(
+                () => !SecretNameRegex.IsMatch(secretName), 
+                "Requires a Azure Key Vault secret name in the correct format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
             Guard.For<UriFormatException>(
                 () => !KeyVaultUriRegex.IsMatch(vaultUri),
                 "Requires the Azure Key Vault host to be in the right format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
 
             context = context ?? new Dictionary<string, object>();
-
-            logger.LogWarning(DependencyFormat, "Azure key vault", operationName, vaultUri, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            
+            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
@@ -23,7 +23,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         {
             // Arrange
             string vaultUri = $"https://{BogusGenerator.Commerce.ProductName().Replace(" ", "")}.vault.azure.net";
-            string operationName = "get secret";
+            string secretName = "MySecret";
 
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
@@ -35,7 +35,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
                 // Act
-                logger.LogAzureKeyVaultDependency(vaultUri, operationName, isSuccessful, startTime, duration, telemetryContext);
+                logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, startTime, duration, telemetryContext);
             }
 
             // Assert
@@ -49,7 +49,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     {
                         return result.Dependency.Type == "Azure key vault"
                                && result.Dependency.Target == vaultUri
-                               && result.Dependency.Data == operationName;
+                               && result.Dependency.Data == secretName;
                     });
                 });
             }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights
+{
+    public class AzureKeyVaultDependencyTests : ApplicationInsightsSinkTests
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsSinkTests"/> class.
+        /// </summary>
+        public AzureKeyVaultDependencyTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+        [Fact]
+        public async Task LogAzureKeyVaultDependency_SinksToApplicationInsights_ResutsInAzureKeyVaultDependencyTelemetry()
+        {
+            // Arrange
+            string vaultUri = $"https://{BogusGenerator.Commerce.ProductName().Replace(" ", "")}.vault.azure.net";
+            string operationName = "get secret";
+
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory())
+            {
+                ILogger logger = loggerFactory.CreateLogger<AzureKeyVaultDependencyTests>();
+
+                bool isSuccessful = BogusGenerator.PickRandom(true, false);
+                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                TimeSpan duration = BogusGenerator.Date.Timespan();
+                Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+                // Act
+                logger.LogAzureKeyVaultDependency(vaultUri, operationName, isSuccessful, startTime, duration, telemetryContext);
+            }
+
+            // Assert
+            using (IApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    Assert.NotEmpty(results.Value);
+                    Assert.Contains(results.Value, result =>
+                    {
+                        return result.Dependency.Type == "Azure key vault"
+                               && result.Dependency.Target == vaultUri
+                               && result.Dependency.Data == operationName;
+                    });
+                });
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/InvalidAzureKeyVaultSecretsNames.cs
+++ b/src/Arcus.Observability.Tests.Unit/InvalidAzureKeyVaultSecretsNames.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Arcus.Observability.Tests.Unit
+{
+    /// <summary>
+    /// Represents invalid Azure Key Vault secret names.
+    /// </summary>
+    public class InvalidAzureKeyVaultSecretNames : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { "Secret.With.Dots" };
+            yield return new object[] { "secret-with-%" };
+            yield return new object[] { "4secret-starting-with-number" };
+            yield return new object[] { "secret-over-126-chars-rULfPJou27VPdaN4DNHO7KLO2nMP0s357XnRcfWUiqmPVnuaK7mqUVPAfKlCzUf1bTfhpOtPX82kAMfV96P8G7pD8SQvxnLOHR3alksdjfaksdfjP6v86e" };
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -199,6 +199,124 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogAzureKeyVaultDependency_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string vaultUri = $"https://{_bogusGenerator.Commerce.ProductName().Replace(" ", "")}.vault.azure.net";
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act
+            logger.LogAzureKeyVaultDependency(vaultUri, operationName, isSuccessful, startTime, duration);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(vaultUri, logMessage);
+            Assert.Contains(operationName, logMessage);
+            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogAzureKeyVaultDependencyDependencyMeasurement_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string vaultUri = $"https://{_bogusGenerator.Commerce.ProductName().Replace(" ", "")}.vault.azure.net";
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DependencyMeasurement measurement = DependencyMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogAzureKeyVaultDependency(vaultUri, operationName, isSuccessful, measurement);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(vaultUri, logMessage);
+            Assert.Contains(operationName, logMessage);
+            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogAzureKeyVaultDependency_WithoutVaultUri_Fails(string vaultUri)
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency(vaultUri, "get secret", isSuccessful: true, DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5)));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogAzureKeyVaultDependency_WithoutOperationName_Fails(string operationName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency("https://my-vault.vault.azure.net", operationName, isSuccessful: true, startTime: DateTimeOffset.UtcNow, duration: TimeSpan.FromSeconds(value: 5)));
+        }
+
+        [Fact]
+        public void LogAzureKeyVaultDependency_WithoutMatchingVaultUri_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency("https://vault-without-vault.azure.net-suffix", "get secret", isSuccessful: true, startTime: DateTimeOffset.UtcNow, duration: TimeSpan.FromSeconds(5)));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogAzureKeyVaultDependencyDependencyMeasurement_WithoutVaultUri_Fails(string vaultUri)
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency(vaultUri, "get secret", isSuccessful: true, measurement: DependencyMeasurement.Start()));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogAzureKeyVaultDependency_WithoutOperationNameDependencyMeasurement_Fails(string operationName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency("https://my-vault.vault.azure.net", operationName, isSuccessful: true, measurement: DependencyMeasurement.Start()));
+        }
+
+        [Fact]
+        public void LogAzureKeyVaultDependencyDependencyMeasurement_WithoutMatchingVaultUri_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogAzureKeyVaultDependency("https://vault-without-vault.azure.net-suffix", "get secret", isSuccessful: true, measurement: DependencyMeasurement.Start()));
+        }
+
+        [Fact]
         public void LogAzureSearchDependency_ValidArguments_Succeeds()
         {
             // Arrange

--- a/src/Arcus.Observability.Tests.Unit/ValidAzureKeyVaultSecretNames.cs
+++ b/src/Arcus.Observability.Tests.Unit/ValidAzureKeyVaultSecretNames.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Arcus.Observability.Tests.Unit
+{
+    /// <summary>
+    /// Represents valid Azure Key Vault secret names.
+    /// </summary>
+    public class ValidAzureKeyVaultSecretNames : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { "Secret-with-dashes" };
+            yield return new object[] { "s3cret-w1th-numbers" };
+            yield return new object[] { "e" };
+            yield return new object[] { "secret-with-126-chars-rULfPJou27VPdaN4DNHO7KLO2nMP0s357XnRcfWUiqmPVnuaK7mqUVPAfKlCzUf1bTfhpOtPX82kAMfV96P8G7pD8SQvxnLOHR3P6v86" };
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
Adds a new telemetry extension to track Azure Key Vault dependencies in Application Insights.
This one can be used, later, within the tracking of the secret store (which now uses the general dependency tracking).

Closes #157 