### PR TITLE
Add guidance on where to configure the logger

### DIFF
--- a/docs/features/sinks/azure-application-insights.md
+++ b/docs/features/sinks/azure-application-insights.md
@@ -86,7 +86,7 @@ var host = Host.CreateDefaultBuilder()
                .Build();
 ```
 
-If the InstrumentationKey is stored as a secret in -for instance- Azure KeyVault, the `ISecretProvider` from [Arcus.Security](https://github.com/arcus-azure/arcus.security) can be used to retrieve the InstrumentationKey.
+If the InstrumentationKey is stored as a secret in -for instance- Azure Key Vault, the `ISecretProvider` from [Arcus Security](https://github.com/arcus-azure/arcus.security) can be used to retrieve the instrumentationKey.
 
 ```csharp
 using Serilog.Configuration;

--- a/docs/features/sinks/azure-application-insights.md
+++ b/docs/features/sinks/azure-application-insights.md
@@ -59,7 +59,9 @@ ILogger logger = loggerConfig.CreateLogger();
 
 ### Q: Where can I initialize the logger in an ASP.NET Core application or other hosted service?
 
-The Application Insights instrumentation key is typically available via the configuration or via an `ISecreteProvider`.  It's best if the Logger is created and assigned to the Serilog `Log.Logger` as soon as possible.  The easiest place to do that in an ASP.NET application  is in the `ConfigureServices` method of the `Program` class.
+The Azure Application Insights instrumentation key is typically available via the configuration or `ISecreteProvider`.  It's best if the logger is created and assigned to the Serilog `Log.Logger` as soon as possible.
+
+The easiest place to do that in an ASP.NET application is in the `ConfigureServices` method of the `Program` class.
 
 Another place where the logger can be initialized is in the `ConfigureAppConfiguration` method of the `IHostBuilder`:
 

--- a/docs/features/sinks/azure-application-insights.md
+++ b/docs/features/sinks/azure-application-insights.md
@@ -57,4 +57,66 @@ if(string.IsNullOrEmpty(key) == false)
 ILogger logger = loggerConfig.CreateLogger();
 ```
 
+### Q: Where can I initialize the logger in an ASP.NET Core application or other hosted service?
+
+The Application Insights instrumentation key is typically available via the configuration or via an `ISecreteProvider`.  It's best if the Logger is created and assigned to the Serilog `Log.Logger` as soon as possible.  The easiest place to do that in an ASP.NET application  is in the `ConfigureServices` method of the `Program` class.
+
+Another place where the logger can be initialized is in the `ConfigureAppConfiguration` method of the `IHostBuilder`:
+
+```csharp
+var host = Host.CreateDefaultBuilder()
+               .ConfigureAppConfiguration((context, configBuilder) =>
+               {
+                   var config = configBuilder.Build();
+
+                   var instrumentationKey = config["ApplicationInsights:InstrumentationKey"];
+
+                   var logConfiguration = new LoggerConfiguration()
+                                           .Enrich.FromLogContext()
+                                           .WriteTo.Console();
+
+                    var appInsightsInstrumentationKey = builtConfig["ApplicationInsights:InstrumentationKey"];
+
+                    if (!String.IsNullOrWhiteSpace(appInsightsInstrumentationKey))
+                    {
+                        logConfiguration.WriteTo.AzureApplicationInsights(appInsightsInstrumentationKey);
+                    }
+
+                    Log.Logger = logConfiguration.CreateLogger();
+               })
+               .UseSerilog()
+               .Build();
+```
+
+Or, if the Application Insights' instrumentation key is stored in a secretstore and you're making use of Arcus.Security:
+
+```csharp
+var host = Host.CreateDefaultBuilder()
+               .ConfigureSecretStore((context, config, builder) =>
+               {
+                   // Configure the secretstore here
+               })
+               .ConfigureServices((context, services) =>
+               {
+                   var serviceProvider = services.BuildServiceProvider();
+
+                   var secretProvider = services.GetService<ISecretProvider>();
+
+                   var instrumentationKey = secretProvider.GetRawSecretAsync("ApplicationInsights:InstrumentationKey").GetAwaiter().GetResult();
+
+                   var logConfiguration = new LoggerConfiguration()
+                                           .Enrich.FromLogContext()
+                                           .WriteTo.Console();
+
+                    if (!String.IsNullOrWhiteSpace(appInsightsInstrumentationKey))
+                    {
+                        logConfiguration.WriteTo.AzureApplicationInsights(appInsightsInstrumentationKey);
+                    }
+
+                    Log.Logger = logConfiguration.CreateLogger();
+               })
+               .UseSerilog()
+               .Build();
+```
+
 [&larr; back](/)

--- a/docs/preview/features/sinks/azure-application-insights.md
+++ b/docs/preview/features/sinks/azure-application-insights.md
@@ -57,4 +57,63 @@ if(string.IsNullOrEmpty(key) == false)
 ILogger logger = loggerConfig.CreateLogger();
 ```
 
+### Q: Where can I initialize the logger in an ASP.NET Core application or other hosted service?
+
+Simply use the `UseSerilog` extension method on `IHostBuilder` which accepts an `Action<HostBuilderContext, IServiceProvider, LoggerConfiguration>`.  This Action gives you access to the configuration and the configured services:
+
+```csharp
+using Serilog.Configuration;
+
+...
+
+var host = Host.CreateDefaultBuilder()
+               .ConfigureAppConfiguration((context, configBuilder) =>
+               {
+                   // App specific configuration
+               })
+               .UseSerilog((context, serviceProvider, loggerConfig) =>
+               {
+                    loggerConf.Enrich.FromLogContext()
+                              .WriteTo.Console();
+
+                    string instrumentationKey = context.Configuration["ApplicationInsights:InstrumentationKey"];
+
+                    if (!String.IsNullOrWhiteSpace(instrumentationKey))
+                    {
+                        loggerConfiguration.WriteTo.AzureApplicationInsights(instrumentationKey, LogEventLevel.Information);
+                    }
+               })
+               .Build();
+```
+
+If the InstrumentationKey is stored as a secret in -for instance- Azure KeyVault, the `ISecretProvider` from [Arcus.Security](https://github.com/arcus-azure/arcus.security) can be used to retrieve the InstrumentationKey.
+
+```csharp
+using Serilog.Configuration;
+using Arcus.Security.Core;
+
+...
+
+var host = Host.CreateDefaultBuilder()
+               .ConfigureSecretStore((context, config, builder) =>
+               {
+                   // Configure the secretstore here
+               })
+               .UseSerilog((context, serviceProvider, loggerConfig) =>
+               {
+                    loggerConf.Enrich.FromLogContext()
+                              .WriteTo.Console();
+
+                    var secretProvider = serviceProvider.GetService<ISecretProvider>();
+
+                    var instrumentationKey = secretProvider.GetRawSecretAsync("ApplicationInsights:InstrumentationKey").GetAwaiter().GetResult();
+
+                    if (!String.IsNullOrWhiteSpace(instrumentationKey))
+                    {
+                        loggerConfiguration.WriteTo.AzureApplicationInsights(instrumentationKey, LogEventLevel.Information);
+                    }
+               })
+               .Build();
+```
+
 [&larr; back](/)


### PR DESCRIPTION
Added some guidance in the Q&A section of the documentation on how to use / configure the logger.

Closes #168 