### PR TITLE
Docs - add missing 'using's to the feature docs

### DIFF
--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/preview/features/making-telemetry-more-powerful.md
+++ b/docs/preview/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/preview/features/sinks/azure-application-insights.md
+++ b/docs/preview/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)
@@ -46,6 +52,9 @@ By doing this, we allow you to fail fast and avoid running your application with
 If you want to optionally use our sink when there is an instrumentation key, we recommend using this simple pattern:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 var loggerConfig =  new LoggerConfiguration()
     .MinimumLevel.Debug();
 

--- a/docs/preview/features/telemetry-enrichment.md
+++ b/docs/preview/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -43,6 +45,8 @@ logger.Information("Some event");
 Or, alternatively one can choose to use the Kubernetes information which our [Application Insights](./sinks/azure-application-insights) sink will prioritize above the `MachineName` when determining the telemetry `Cloud.RoleInstance`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .Enrich.WithKubernetesInfo()
@@ -58,6 +62,8 @@ The application enricher allows you to specify the name of the log property that
 By default this is set to `ComponentName`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName(
         componentName: "My application component", 
@@ -86,6 +92,9 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(serviceProvider)
@@ -97,6 +106,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -113,6 +125,9 @@ The correlation information enricher allows you to specify the names of the log 
 This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(
@@ -141,6 +156,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -201,6 +218,8 @@ The Kubernetes enricher allows you to specify the names of the log properties th
 By default the node name is set to `NodeName`, the pod name to `PodName`, and the namespace to `Namespace`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo(
         nodeNamePropertyName: "MyNodeName",
@@ -224,6 +243,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();
@@ -240,16 +261,24 @@ By default this is set to the version of the current executing assembly.
 **Assembly version as application version**
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Register the `AssemblyAppVersion` instance to retrieve the application version from the assembly where the passed-along `Startup` type is located.
-    services.AddAssemblyAppVersion<Startup>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Register the `AssemblyAppVersion` instance to retrieve the application version from the assembly where the passed-along `Startup` type is located.
+        services.AddAssemblyAppVersion<Startup>();
+    }
 }
 ```
 
 **User-provided version**
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Serilog;
+
 IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(appVersion)
@@ -262,23 +291,32 @@ logger.Information("Some event");
 Or alternatively, you can choose to register the application version so you can use it in your application as well.
 
 ```csharp
-public void ConfigureServivces(IServiceCollection services)
-{
-    // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
-    services.AddAppVersion<MyApplicationVersion>();
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
-    // Register the `MyApplicationVersion` instance using the service provider.
-    services.AddAppVersion(serviceProvider => 
+public class Startup
+{
+    public void ConfigureServivces(IServiceCollection services)
     {
-        var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
-        return new MyApplicationVersion(logger);
-    });
+        // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
+        services.AddAppVersion<MyApplicationVersion>();
+
+        // Register the `MyApplicationVersion` instance using the service provider.
+        services.AddAppVersion(serviceProvider => 
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
+            return new MyApplicationVersion(logger);
+        });
+    }
 }
 ```
 
 Once the application version is registered, you can pass along the `IServiceProvider` instead to the Serilog configuration.
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(serviceProvider)
@@ -291,6 +329,8 @@ The version enricher allows you to specify the name of the property that will be
 By default this is set to `version`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(propertyName: "MyVersion")
     .CreateLogger();

--- a/docs/preview/features/telemetry-filter.md
+++ b/docs/preview/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -55,6 +55,8 @@ We allow you to measure Azure Blob Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -74,6 +76,8 @@ Here is how you can report a dependency call:
 **Cosmos SQL**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -91,6 +95,8 @@ We allow you to measure Azure Event Hubs dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -110,6 +116,8 @@ We allow you to measure Azure IoT Hub dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -135,6 +143,8 @@ PM > Install-Package Arcus.Observability.Telemetry.IoT
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -154,6 +164,8 @@ We allow you to measure Azure Key vault dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new StopWatch();
 
 // Start measuring
@@ -171,6 +183,8 @@ We allow you to measure Azure Search depdendencies for cognetive services.
 Here is how you can report an Azure Search dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -187,6 +201,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -206,6 +222,8 @@ We allow you to measure Azure Table Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -221,6 +239,8 @@ logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "orders
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Create request
@@ -244,6 +264,8 @@ logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: st
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -270,6 +292,8 @@ PM > Install-Package Arcus.Observability.Telemetry.Sql
 **Example**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
@@ -289,6 +313,8 @@ logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessf
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -309,6 +335,8 @@ Measuring dependencies means you need to keep track of how long the action took 
 Here's a small example:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 var startTime = DateTimeOffset.UtcNow;
 durationMeasurement.Start();
@@ -324,6 +352,9 @@ logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: 
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 // Start measuring
 using (var measurement = DependencyMeasurement.Start())
 {
@@ -363,6 +394,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -374,6 +407,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 loger.LogSecurityEvent("Invalid Order");
 // Output: "Events Invalid Order (Context: )"
 ```
@@ -385,6 +420,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
 // Output: "Metric Invoice Received: 133.37 (Context: )"
 ```
@@ -406,6 +443,8 @@ PM > Install-Package Arcus.Observability.Telemetry.AspNetCore
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/preview/guidance/use-with-dotnet-and-functions.md
+++ b/docs/preview/guidance/use-with-dotnet-and-functions.md
@@ -67,6 +67,10 @@ namespace Arcus.Samples.AzureFunction
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 
 ```csharp
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 public class DockerHubMetricScraperFunction
 {
     private readonly DockerHubClient _dockerHubClient;

--- a/docs/v0.1.0/features/correlation.md
+++ b/docs/v0.1.0/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v0.1.0/features/sinks/azure-application-insights.md
+++ b/docs/v0.1.0/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)

--- a/docs/v0.1.0/features/telemetry-enrichment.md
+++ b/docs/v0.1.0/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -57,6 +59,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -67,6 +71,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -93,6 +100,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -158,6 +167,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();

--- a/docs/v0.1.0/features/telemetry-filter.md
+++ b/docs/v0.1.0/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters -Version 0.1.
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v0.1.0/features/writing-different-telemetry-types.md
+++ b/docs/v0.1.0/features/writing-different-telemetry-types.md
@@ -42,6 +42,9 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Namespace", "azure.servicebus.namespace" }
@@ -60,6 +63,9 @@ _logger.LogServiceBusQueueDependency(queueName: "ordersqueue", isSuccessful: tru
 Or alternatively one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Namespace", "azure.servicebus.namespace" }
@@ -80,6 +86,8 @@ Note that we have an `LogServiceBusTopicDependency` to log dependency logs for a
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Tenant", "Contoso"},
@@ -107,6 +115,9 @@ _logger.LogHttpDependency(request, response.StatusCode, startTime, durationMeasu
 Or alternatively one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Tenant", "Contoso"},
@@ -134,6 +145,8 @@ using (var measurement = DependencyMeasurement.Start())
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Catalog", "Products"},
@@ -155,6 +168,9 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 Or alternatively, one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Catalog", "Products"},
@@ -177,6 +193,8 @@ using (var measurement = DependencyMeasurement.Start("get-products"))
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Subject", "Your order is being processed!" },
@@ -197,6 +215,9 @@ _logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime:
 Or alternatively, one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Subject", "Your order is being processed!" },
@@ -228,6 +249,8 @@ logger.LogEvent("Order Created");
 Contextual information is essential, that's why we provide an overload to give more information about the event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -246,6 +269,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around security event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -263,6 +288,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around metric
 var telemetryContext = new Dictionary<string, object>
 {
@@ -283,6 +310,8 @@ Requests allow you to keep track of the HTTP requests that are performed against
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v0.1.1/features/correlation.md
+++ b/docs/v0.1.1/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v0.1.1/features/sinks/azure-application-insights.md
+++ b/docs/v0.1.1/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)

--- a/docs/v0.1.1/features/telemetry-enrichment.md
+++ b/docs/v0.1.1/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -57,6 +59,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -67,6 +71,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -93,6 +100,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -158,6 +167,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();

--- a/docs/v0.1.1/features/telemetry-filter.md
+++ b/docs/v0.1.1/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters -Version 0.1.
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v0.1.1/features/writing-different-telemetry-types.md
+++ b/docs/v0.1.1/features/writing-different-telemetry-types.md
@@ -42,6 +42,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Namespace", "azure.servicebus.namespace" }
@@ -60,6 +62,9 @@ _logger.LogServiceBusQueueDependency(queueName: "ordersqueue", isSuccessful: tru
 Or alternatively one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Namespace", "azure.servicebus.namespace" }
@@ -80,6 +85,8 @@ Note that we have an `LogServiceBusTopicDependency` to log dependency logs for a
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Tenant", "Contoso"},
@@ -107,6 +114,9 @@ _logger.LogHttpDependency(request, response.StatusCode, startTime, durationMeasu
 Or alternatively one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Tenant", "Contoso"},
@@ -134,6 +144,8 @@ using (var measurement = DependencyMeasurement.Start())
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Catalog", "Products"},
@@ -155,6 +167,9 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 Or alternatively, one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Catalog", "Products"},
@@ -177,6 +192,8 @@ using (var measurement = DependencyMeasurement.Start("get-products"))
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Subject", "Your order is being processed!" },
@@ -197,6 +214,9 @@ _logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime:
 Or alternatively, one can use our `DependencyMeasurement` model to manage the timing for you:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Subject", "Your order is being processed!" },
@@ -221,6 +241,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -228,6 +250,8 @@ logger.LogEvent("Order Created");
 Contextual information is essential, that's why we provide an overload to give more information about the event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -246,6 +270,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around security event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -263,6 +289,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around metric
 var telemetryContext = new Dictionary<string, object>
 {
@@ -283,6 +311,8 @@ Requests allow you to keep track of the HTTP requests that are performed against
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v0.2.0/features/correlation.md
+++ b/docs/v0.2.0/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -47,16 +52,22 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
     }
 }
 ```
@@ -66,11 +77,16 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
     }
 }
 ```
@@ -78,11 +94,16 @@ public class OrderService
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
     }
 }
 ```
@@ -143,29 +164,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v0.2.0/features/making-telemetry-more-powerful.md
+++ b/docs/v0.2.0/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/v0.2.0/features/sinks/azure-application-insights.md
+++ b/docs/v0.2.0/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)

--- a/docs/v0.2.0/features/telemetry-enrichment.md
+++ b/docs/v0.2.0/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -57,6 +59,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -67,6 +71,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -93,6 +100,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -158,6 +167,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();

--- a/docs/v0.2.0/features/telemetry-filter.md
+++ b/docs/v0.2.0/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v0.2.0/features/writing-different-telemetry-types.md
+++ b/docs/v0.2.0/features/writing-different-telemetry-types.md
@@ -53,6 +53,8 @@ We allow you to measure Azure Blob Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -72,6 +74,8 @@ Here is how you can report a dependency call:
 **Cosmos SQL**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -89,6 +93,8 @@ We allow you to measure Azure Event Hubs dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -106,6 +112,8 @@ We allow you to measure Azure IoT Hub dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -123,6 +131,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -142,6 +152,8 @@ We allow you to measure Azure Table Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -157,6 +169,8 @@ _logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "order
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Create request
@@ -180,6 +194,8 @@ _logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: s
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -196,6 +212,8 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
@@ -215,6 +233,8 @@ _logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccess
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -235,6 +255,8 @@ Measuring dependencies means you need to keep track of how long the action took 
 Here's a small example:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 var startTime = DateTimeOffset.UtcNow;
 durationMeasurement.Start();
@@ -250,6 +272,9 @@ _logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime:
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 // Start measuring
 using (var measurement = DependencyMeasurement.Start())
 {
@@ -269,6 +294,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -280,6 +307,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 loger.LogSecurityEvent("Invalid Order");
 // Output: "Events Invalid Order (Context: )"
 ```
@@ -291,6 +320,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
 // Output: "Metric Invoice Received: 133.37 (Context: )"
 ```
@@ -302,6 +333,8 @@ Requests allow you to keep track of the HTTP requests that are performed against
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v0.3/features/correlation.md
+++ b/docs/v0.3/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v0.3/features/making-telemetry-more-powerful.md
+++ b/docs/v0.3/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/v0.3/features/sinks/azure-application-insights.md
+++ b/docs/v0.3/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)

--- a/docs/v0.3/features/telemetry-enrichment.md
+++ b/docs/v0.3/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -42,6 +44,8 @@ logger.Information("This event will be enriched with the application component's
 Or, alternatively one can choose to use the Kubernetes information.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .Enrich.WithKubernetesInfo()
@@ -68,6 +72,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -78,6 +84,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -104,6 +113,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -169,6 +180,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();

--- a/docs/v0.3/features/telemetry-filter.md
+++ b/docs/v0.3/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v0.3/features/writing-different-telemetry-types.md
+++ b/docs/v0.3/features/writing-different-telemetry-types.md
@@ -53,6 +53,8 @@ We allow you to measure Azure Blob Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -72,6 +74,8 @@ Here is how you can report a dependency call:
 **Cosmos SQL**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -89,6 +93,8 @@ We allow you to measure Azure Event Hubs dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -108,6 +114,8 @@ We allow you to measure Azure IoT Hub dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -133,6 +141,8 @@ PM > Install-Package Arcus.Observability.Telemetry.IoT
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -150,6 +160,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -169,6 +181,8 @@ We allow you to measure Azure Table Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -184,6 +198,8 @@ _logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "order
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Create request
@@ -207,6 +223,8 @@ _logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: s
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -223,6 +241,8 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
@@ -242,6 +262,8 @@ _logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccess
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -262,6 +284,8 @@ Measuring dependencies means you need to keep track of how long the action took 
 Here's a small example:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 var startTime = DateTimeOffset.UtcNow;
 durationMeasurement.Start();
@@ -277,6 +301,9 @@ _logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime:
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 // Start measuring
 using (var measurement = DependencyMeasurement.Start())
 {
@@ -292,6 +319,8 @@ using (var measurement = DependencyMeasurement.Start())
 Failures during the interaction with the tracked dependency can be controlled by passing `isSuccessful`:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string dependencyName = "SendGrid";
 object dependencyData = "https://my.sendgrid.uri";
 
@@ -316,6 +345,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -327,6 +358,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 loger.LogSecurityEvent("Invalid Order");
 // Output: "Events Invalid Order (Context: )"
 ```
@@ -338,6 +371,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
 // Output: "Metric Invoice Received: 133.37 (Context: )"
 ```
@@ -349,6 +384,8 @@ Requests allow you to keep track of the HTTP requests that are performed against
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v0.3/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v0.3/guidance/use-with-dotnet-and-functions.md
@@ -67,6 +67,10 @@ namespace Arcus.Samples.AzureFunction
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 
 ```csharp
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 public class DockerHubMetricScraperFunction
 {
     private readonly DockerHubClient _dockerHubClient;

--- a/docs/v0.4/features/correlation.md
+++ b/docs/v0.4/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v0.4/features/making-telemetry-more-powerful.md
+++ b/docs/v0.4/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/v0.4/features/sinks/azure-application-insights.md
+++ b/docs/v0.4/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)
@@ -46,6 +52,9 @@ By doing this, we allow you to fail fast and avoid running your application with
 If you want to optionally use our sink when there is an instrumentation key, we recommend using this simple pattern:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 var loggerConfig =  new LoggerConfiguration()
     .MinimumLevel.Debug();
 

--- a/docs/v0.4/features/telemetry-enrichment.md
+++ b/docs/v0.4/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -43,6 +45,8 @@ logger.Information("Some event");
 Or, alternatively one can choose to use the Kubernetes information which our [Application Insights](./sinks/azure-application-insights) sink will prioritize above the `MachineName` when determining the telemetry `Cloud.RoleInstance`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .Enrich.WithKubernetesInfo()
@@ -58,6 +62,8 @@ The application enricher allows you to specify the name of the log property that
 By default this is set to `ComponentName`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName(
         componentName: "My application component", 
@@ -86,6 +92,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -96,6 +104,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -112,6 +123,8 @@ The correlation information enricher allows you to specify the names of the log 
 This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(
         operationIdPropertyName: "MyOperationId",
@@ -138,6 +151,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -198,6 +213,8 @@ The Kubernetes enricher allows you to specify the names of the log properties th
 By default the node name is set to `NodeName`, the pod name to `PodName`, and the namespace to `Namespace`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo(
         nodeNamePropertyName: "MyNodeName",
@@ -221,6 +238,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();
@@ -235,6 +254,9 @@ The version enricher allows you to specify an `IAppVersion` instance that retrie
 By default this is set to the version of the current executing assembly.
 
 ```csharp
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Serilog;
+
 IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(appVersion)
@@ -250,6 +272,8 @@ The version enricher allows you to specify the name of the property that will be
 By default this is set to `version`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(propertyName: "MyVersion")
     .CreateLogger();

--- a/docs/v0.4/features/telemetry-filter.md
+++ b/docs/v0.4/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v0.4/features/writing-different-telemetry-types.md
+++ b/docs/v0.4/features/writing-different-telemetry-types.md
@@ -54,6 +54,8 @@ We allow you to measure Azure Blob Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -73,6 +75,8 @@ Here is how you can report a dependency call:
 **Cosmos SQL**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -90,6 +94,8 @@ We allow you to measure Azure Event Hubs dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -109,6 +115,8 @@ We allow you to measure Azure IoT Hub dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -134,6 +142,8 @@ PM > Install-Package Arcus.Observability.Telemetry.IoT
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -151,6 +161,8 @@ We allow you to measure Azure Search depdendencies for cognetive services.
 Here is how you can report an Azure Search dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -167,6 +179,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -186,6 +200,8 @@ We allow you to measure Azure Table Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -201,6 +217,8 @@ _logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "order
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Create request
@@ -224,6 +242,8 @@ _logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: s
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -240,6 +260,8 @@ _logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-pr
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
@@ -259,6 +281,8 @@ _logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccess
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -279,6 +303,8 @@ Measuring dependencies means you need to keep track of how long the action took 
 Here's a small example:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 var startTime = DateTimeOffset.UtcNow;
 durationMeasurement.Start();
@@ -294,6 +320,9 @@ _logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime:
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 // Start measuring
 using (var measurement = DependencyMeasurement.Start())
 {
@@ -309,6 +338,8 @@ using (var measurement = DependencyMeasurement.Start())
 Failures during the interaction with the tracked dependency can be controlled by passing `isSuccessful`:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string dependencyName = "SendGrid";
 object dependencyData = "https://my.sendgrid.uri";
 
@@ -333,6 +364,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -344,6 +377,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 loger.LogSecurityEvent("Invalid Order");
 // Output: "Events Invalid Order (Context: )"
 ```
@@ -355,6 +390,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
 // Output: "Metric Invoice Received: 133.37 (Context: )"
 ```
@@ -366,6 +403,8 @@ Requests allow you to keep track of the HTTP requests that are performed against
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v0.4/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v0.4/guidance/use-with-dotnet-and-functions.md
@@ -67,6 +67,10 @@ namespace Arcus.Samples.AzureFunction
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 
 ```csharp
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 public class DockerHubMetricScraperFunction
 {
     private readonly DockerHubClient _dockerHubClient;

--- a/docs/v1.0/features/correlation.md
+++ b/docs/v1.0/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v1.0/features/making-telemetry-more-powerful.md
+++ b/docs/v1.0/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/v1.0/features/sinks/azure-application-insights.md
+++ b/docs/v1.0/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)
@@ -46,6 +52,9 @@ By doing this, we allow you to fail fast and avoid running your application with
 If you want to optionally use our sink when there is an instrumentation key, we recommend using this simple pattern:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 var loggerConfig =  new LoggerConfiguration()
     .MinimumLevel.Debug();
 

--- a/docs/v1.0/features/telemetry-enrichment.md
+++ b/docs/v1.0/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -43,6 +45,8 @@ logger.Information("Some event");
 Or, alternatively one can choose to use the Kubernetes information which our [Application Insights](./sinks/azure-application-insights) sink will prioritize above the `MachineName` when determining the telemetry `Cloud.RoleInstance`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .Enrich.WithKubernetesInfo()
@@ -58,6 +62,8 @@ The application enricher allows you to specify the name of the log property that
 By default this is set to `ComponentName`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName(
         componentName: "My application component", 
@@ -86,6 +92,8 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo()
     .CreateLogger();
@@ -96,6 +104,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Correlation;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -112,6 +123,8 @@ The correlation information enricher allows you to specify the names of the log 
 This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(
         operationIdPropertyName: "MyOperationId",
@@ -138,6 +151,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -198,6 +213,8 @@ The Kubernetes enricher allows you to specify the names of the log properties th
 By default the node name is set to `NodeName`, the pod name to `PodName`, and the namespace to `Namespace`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo(
         nodeNamePropertyName: "MyNodeName",
@@ -221,6 +238,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();
@@ -237,16 +256,24 @@ By default this is set to the version of the current executing assembly.
 **Assembly version as application version**
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Register the `AssemblyAppVersion` instance to retrieve the application version from the assembly where the passed-along `Startup` type is located.
-    services.AddAssemblyAppVersion<Startup>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Register the `AssemblyAppVersion` instance to retrieve the application version from the assembly where the passed-along `Startup` type is located.
+        services.AddAssemblyAppVersion<Startup>();
+    }
 }
 ```
 
 **User-provided version**
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Serilog;
+
 IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(appVersion)
@@ -259,23 +286,31 @@ logger.Information("Some event");
 Or alternatively, you can choose to register the application version so you can use it in your application as well.
 
 ```csharp
-public void ConfigureServivces(IServiceCollection services)
-{
-    // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
-    services.AddAppVersion<MyApplicationVersion>();
+using Microsoft.Extensions.DependencyInjection;
 
-    // Register the `MyApplicationVersion` instance using the service provider.
-    services.AddAppVersion(serviceProvider => 
+public class Startup
+{
+    public void ConfigureServivces(IServiceCollection services)
     {
-        var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
-        return new MyApplicationVersion(logger);
-    });
+        // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
+        services.AddAppVersion<MyApplicationVersion>();
+
+        // Register the `MyApplicationVersion` instance using the service provider.
+        services.AddAppVersion(serviceProvider => 
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
+            return new MyApplicationVersion(logger);
+        });
+    }
 }
 ```
 
 Once the application version is registered, you can pass along the `IServiceProvider` instead to the Serilog configuration.
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(serviceProvider)
@@ -288,6 +323,8 @@ The version enricher allows you to specify the name of the property that will be
 By default this is set to `version`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(propertyName: "MyVersion")
     .CreateLogger();

--- a/docs/v1.0/features/telemetry-filter.md
+++ b/docs/v1.0/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v1.0/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v1.0/guidance/use-with-dotnet-and-functions.md
@@ -67,6 +67,10 @@ namespace Arcus.Samples.AzureFunction
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 
 ```csharp
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 public class DockerHubMetricScraperFunction
 {
     private readonly DockerHubClient _dockerHubClient;

--- a/docs/v2.0/features/correlation.md
+++ b/docs/v2.0/features/correlation.md
@@ -28,13 +28,18 @@ It uses the the Microsoft dependency injection mechanism to register an `ICorrel
 **Example**
 
 ```csharp
-public class Startup
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        // Adds operation and transaction correlation to the application,
-        // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
-        services.AddCorrelation();
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Adds operation and transaction correlation to the application,
+            // using the `DefaultCorrelationInfoAccessor` as `ICorrelationInfoAccessor` that stores the `CorrelationInfo` model internally.
+            services.AddCorrelation();
+        }
     }
 }
 ```
@@ -46,17 +51,23 @@ The reason is because some applications require a custom `CorrelationInfo` model
 **Example**
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
-{
-    public string OrderId { get; }
-}
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Observability.Correlation;
 
-public class Startup
+namespace Application
 {
-    public void ConfigureService(IServiceCollection services)
+    public class OrderCorrelationInfo : CorrelationInfo
     {
-        services.AddCorrelation<OrderCorrelationInfo>();
-	}
+        public string OrderId { get; }
+    }
+
+    public class Startup
+    {
+        public void ConfigureService(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo>();
+        }
+    }
 }
 ```
 
@@ -65,24 +76,34 @@ public class Startup
 When a part of the application needs access to the correlation information, you can inject one of the two interfaces:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor accessor)
+    public class OrderService
     {
-         CorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor accessor)
+        {
+             CorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
 Or, alternatively when using custom correlation:
 
 ```csharp
-public class OrderService
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+    public class OrderService
     {
-         OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
-	}
+        public OrderService(ICorrelationInfoAccessor<OrderCorrelationInfo> accessor)
+        {
+             OrderCorrelationInfo correlationInfo = accessor.CorrelationInfo;
+        }
+    }
 }
 ```
 
@@ -142,29 +163,44 @@ We also provide a way to provide custom configuration options when the applicati
 For example, with a custom correlation model:
 
 ```csharp
-public class OrderCorrelationInfo : CorrelationInfo
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public string OrderId { get; }
+    public class OrderCorrelationInfo : CorrelationInfo
+    {
+        public string OrderId { get; }
+    }
 }
 ```
 
 We could introduce an `OrderCorrelationInfoOptions` model:
 
 ```csharp
-public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+using Arcus.Observability.Correlation;
+
+namespace Application
 {
-    public bool IncludeOrderId { get; set; }
+    public class OrderCorrelationInfoOptions : CorrelationInfoOptions
+    {
+        public bool IncludeOrderId { get; set; }
+    }
 }
 ```
 
 This custom options model can then be included when registering the correlation:
 
 ```csharp
-public class Startup
+using Microsoft.Excentions.DependencyInjection;
+
+namespace Application
 {
-    public void ConfigureServices(IServiceCollection services)
+    public class Startup
     {
-        services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCorrelation<OrderCorrelationInfo, OrderCorrelationInfoOptions>(options => options.IncludeOrderId = true);
+        }
     }
 }
 ```

--- a/docs/v2.0/features/making-telemetry-more-powerful.md
+++ b/docs/v2.0/features/making-telemetry-more-powerful.md
@@ -10,6 +10,8 @@ layout: default
 In order to make telemetry more powerful we **highly recommend providing contextual information around what the situation is of your application**. That's why every telemetry type that you can write, allows you to provide context in the form of a dictionary.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Provide context around event
 var telemetryContext = new Dictionary<string, object>
 {
@@ -30,6 +32,8 @@ We support this for all [telemetry types that you can write](/features/writing-d
 Let's use an example - When measuring a metric you get an understanding of the count, in our case the number of orders received:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Orders Received", 133);
 // Log output: "Metric Orders Received: 133 (Context: )"
 ```
@@ -40,6 +44,8 @@ If we output this to Azure Application Insights as a metric similar to our examp
 However, you can very easily provide additional context, allowing you to get an understanding of the number of orders received and annotate it with the vendor information.
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var telemetryContext = new Dictionary<string, object>
 {
     { "Customer", "Contoso"},

--- a/docs/v2.0/features/sinks/azure-application-insights.md
+++ b/docs/v2.0/features/sinks/azure-application-insights.md
@@ -20,6 +20,9 @@ The Azure Application Insights sink is an extension of the [official Application
 You can easily configure the sink by providing the Azure Application Insights key:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>")
@@ -29,6 +32,9 @@ ILogger logger = new LoggerConfiguration()
 Alternatively, you can override the default minimum log level to reduce amount of telemetry being tracked :
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)
@@ -46,6 +52,9 @@ By doing this, we allow you to fail fast and avoid running your application with
 If you want to optionally use our sink when there is an instrumentation key, we recommend using this simple pattern:
 
 ```csharp
+using Serilog;
+using Serilog.Configuration;
+
 var loggerConfig =  new LoggerConfiguration()
     .MinimumLevel.Debug();
 

--- a/docs/v2.0/features/telemetry-enrichment.md
+++ b/docs/v2.0/features/telemetry-enrichment.md
@@ -32,6 +32,8 @@ Value: `My application component`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .CreateLogger();
@@ -43,6 +45,8 @@ logger.Information("Some event");
 Or, alternatively one can choose to use the Kubernetes information which our [Application Insights](./sinks/azure-application-insights) sink will prioritize above the `MachineName` when determining the telemetry `Cloud.RoleInstance`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName("My application component")
     .Enrich.WithKubernetesInfo()
@@ -58,6 +62,8 @@ The application enricher allows you to specify the name of the log property that
 By default this is set to `ComponentName`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithComponentName(
         componentName: "My application component", 
@@ -86,6 +92,9 @@ Value: `0477E377-414D-47CD-8756-BCBE3DBE3ACB`
 **Usage**
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(serviceProvider)
@@ -97,6 +106,9 @@ logger.Information("This event will be enriched with the correlation information
 Or alternatively, with a custom `ICorrelationInfoAccessor`:
 
 ```csharp
+using Arcus.Observability.Colleration;
+using Serilog;
+
 ICorrelationInfoAccessor myCustomAccessor = ...
 
 ILogger logger = new LoggerConfiguration()
@@ -113,6 +125,9 @@ The correlation information enricher allows you to specify the names of the log 
 This is available on all extension overloads. By default the operation ID is set to `OperationId` and the transaction ID to `TransactionId`.
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithCorrelationInfo(
@@ -141,6 +156,8 @@ that adds several machine information from the environment (variables).
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo()
     .CreateLogger();
@@ -201,6 +218,8 @@ The Kubernetes enricher allows you to specify the names of the log properties th
 By default the node name is set to `NodeName`, the pod name to `PodName`, and the namespace to `Namespace`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithKubernetesInfo(
         nodeNamePropertyName: "MyNodeName",
@@ -224,6 +243,8 @@ Value: `1.0.0-preview`
 **Usage**
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion()
     .CreateLogger();
@@ -250,6 +271,9 @@ public void ConfigureServices(IServiceCollection services)
 **User-provided version**
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Serilog;
+
 IAppVersion appVersion = new MyCustomAppVersion("v0.1.0");
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(appVersion)
@@ -262,23 +286,32 @@ logger.Information("Some event");
 Or alternatively, you can choose to register the application version so you can use it in your application as well.
 
 ```csharp
-public void ConfigureServivces(IServiceCollection services)
-{
-    // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
-    services.AddAppVersion<MyApplicationVersion>();
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
-    // Register the `MyApplicationVersion` instance using the service provider.
-    services.AddAppVersion(serviceProvider => 
+public class Startup
+{
+    public void ConfigureServivces(IServiceCollection services)
     {
-        var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
-        return new MyApplicationVersion(logger);
-    });
+        // Register the `MyApplicationVersion` instance to the registered services (using empty constructor).
+        services.AddAppVersion<MyApplicationVersion>();
+
+        // Register the `MyApplicationVersion` instance using the service provider.
+        services.AddAppVersion(serviceProvider => 
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<MyApplicationVersion>>();
+            return new MyApplicationVersion(logger);
+        });
+    }
 }
 ```
 
 Once the application version is registered, you can pass along the `IServiceProvider` instead to the Serilog configuration.
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
 IServiceProvider serviceProvider = ...
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(serviceProvider)
@@ -291,6 +324,8 @@ The version enricher allows you to specify the name of the property that will be
 By default this is set to `version`.
 
 ```csharp
+using Serilog;
+
 ILogger logger = new LoggerConfiguration()
     .Enrich.WithVersion(propertyName: "MyVersion")
     .CreateLogger();

--- a/docs/v2.0/features/telemetry-filter.md
+++ b/docs/v2.0/features/telemetry-filter.md
@@ -18,6 +18,11 @@ PM > Install-Package Arcus.Observability.Telemetry.Serilog.Filters
 This [Serilog filter](https://github.com/serilog/serilog/wiki/Enrichment) allows you to filter out different a specific type of telemetry.
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Serilog.Core;
+using Serilog.Configuration;
+
 ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>")
     .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))

--- a/docs/v2.0/features/writing-different-telemetry-types.md
+++ b/docs/v2.0/features/writing-different-telemetry-types.md
@@ -55,6 +55,8 @@ We allow you to measure Azure Blob Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -74,6 +76,8 @@ Here is how you can report a dependency call:
 **Cosmos SQL**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -91,6 +95,8 @@ We allow you to measure Azure Event Hubs dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -110,6 +116,8 @@ We allow you to measure Azure IoT Hub dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -135,6 +143,8 @@ PM > Install-Package Arcus.Observability.Telemetry.IoT
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -154,6 +164,8 @@ We allow you to measure Azure Key vault dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new StopWatch();
 
 // Start measuring
@@ -171,6 +183,8 @@ We allow you to measure Azure Search depdendencies for cognetive services.
 Here is how you can report an Azure Search dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -187,6 +201,8 @@ We allow you to measure Azure Service Bus dependencies for both queues & topics.
 Here is how you can report an Azure Service Bus Queue dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -206,6 +222,8 @@ We allow you to measure Azure Table Storage dependencies.
 Here is how you can report a dependency call:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -221,6 +239,8 @@ logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "orders
 Here is how you can report a HTTP dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Create request
@@ -244,6 +264,8 @@ logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: st
 Here is how you can report a SQL dependency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -270,6 +292,8 @@ PM > Install-Package Arcus.Observability.Telemetry.Sql
 **Example**
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
@@ -289,6 +313,8 @@ logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessf
 Here is how you can areport a custom depenency:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -309,6 +335,8 @@ Measuring dependencies means you need to keep track of how long the action took 
 Here's a small example:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 var durationMeasurement = new Stopwatch();
 var startTime = DateTimeOffset.UtcNow;
 durationMeasurement.Start();
@@ -324,6 +352,9 @@ logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: 
 However, by using `DependencyMeasurement.Start()` we take care of the measuring aspect:
 
 ```csharp
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Extensions.Logging;
+
 // Start measuring
 using (var measurement = DependencyMeasurement.Start())
 {
@@ -339,6 +370,8 @@ using (var measurement = DependencyMeasurement.Start())
 Failures during the interaction with the tracked dependency can be controlled by passing `isSuccessful`:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 string dependencyName = "SendGrid";
 object dependencyData = "https://my.sendgrid.uri";
 
@@ -363,6 +396,8 @@ Events allow you to report custom events which are a great way to track business
 Here is how you can report an `Order Created` event:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogEvent("Order Created");
 // Output: "Events Order Created (Context: )"
 ```
@@ -374,6 +409,8 @@ Some events are considered "security events" when they relate to possible malici
 Here is how an invalid `Order` can be reported:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 loger.LogSecurityEvent("Invalid Order");
 // Output: "Events Invalid Order (Context: )"
 ```
@@ -385,6 +422,8 @@ Metrics allow you to report custom metrics which allow you to give insights on a
 Here is how you can report an `Invoice Received` metric:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
 // Output: "Metric Invoice Received: 133.37 (Context: )"
 ```
@@ -406,6 +445,8 @@ PM > Install-Package Arcus.Observability.Telemetry.AspNetCore
 Here is how you can keep track of requests:
 
 ```csharp
+using Microsoft.Extensions.Logging;
+
 // Determine calling tenant
 string tenantName = "Unknown";
 if (httpContext.Request?.Headers?.ContainsKey("X-Tenant") == true)

--- a/docs/v2.0/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v2.0/guidance/use-with-dotnet-and-functions.md
@@ -67,6 +67,10 @@ namespace Arcus.Samples.AzureFunction
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 
 ```csharp
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 public class DockerHubMetricScraperFunction
 {
     private readonly DockerHubClient _dockerHubClient;


### PR DESCRIPTION
Add `using` statements to all the feature docs pseudo code samples to make sure that consumers know where the functionality is located.

Relates to https://github.com/arcus-azure/arcus/issues/107 