### PR TITLE
Improve guidance documentation

### DIFF
--- a/docs/guidance/use-with-dotnet-and-functions.md
+++ b/docs/guidance/use-with-dotnet-and-functions.md
@@ -38,8 +38,8 @@ namespace Arcus.Samples.AzureFunction
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            var serviceProvider = builder.Services.BuildServiceProvider();
-            var config = serviceProvider.GetRequiredService<IConfiguration>();
+            var config = builder.GetContext().Configuration;
+
             var instrumentationKey = config.GetValue<string>("APPINSIGHTS_INSTRUMENTATIONKEY");
 
             var logger = new LoggerConfiguration()


### PR DESCRIPTION
The latest FunctionsHostBuilder has a method GetContext that can give
you access to the Configuration.  No need to build a ServiceProvider to
require the configuration anymore.