### PR TITLE
Log starttime of dependencies up to the millisecond

### DIFF
--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Extensions.Logging
     /// </summary>
     public static class ILoggerExtensions
     {
-        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
-
         /// <summary>
         ///     Logs an HTTP request
         /// </summary>
@@ -55,7 +53,7 @@ namespace Microsoft.Extensions.Logging
             PathString resourcePath = request.Path;
             var host = $"{request.Scheme}://{request.Host}";
 
-            logger.LogWarning(MessageFormats.RequestFormat, request.Method, host, resourcePath, responseStatusCode, duration, DateTimeOffset.UtcNow.ToString(InvariantDateTimeWithMillisecondsFormat), context);
+            logger.LogWarning(MessageFormats.RequestFormat, request.Method, host, resourcePath, responseStatusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Logging
     /// </summary>
     public static class ILoggerExtensions
     {
-        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
+        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
 
         /// <summary>
         ///     Logs an HTTP request

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Arcus.Observability.Telemetry.Core;
 using GuardNet;
 using Microsoft.AspNetCore.Http;
@@ -10,6 +9,8 @@ namespace Microsoft.Extensions.Logging
 {
     public static class ILoggerExtensions
     {
+        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
+
         // <summary>
         ///     Logs an HTTP request
         /// </summary>
@@ -51,7 +52,7 @@ namespace Microsoft.Extensions.Logging
             PathString resourcePath = request.Path;
             var host = $"{request.Scheme}://{request.Host}";
 
-            logger.LogWarning(MessageFormats.RequestFormat, request.Method, host, resourcePath, responseStatusCode, duration, DateTimeOffset.UtcNow.ToString(CultureInfo.InvariantCulture), context);
+            logger.LogWarning(MessageFormats.RequestFormat, request.Method, host, resourcePath, responseStatusCode, duration, DateTimeOffset.UtcNow.ToString(InvariantDateTimeWithMillisecondsFormat), context);
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -7,11 +7,14 @@ using Microsoft.AspNetCore.Http;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
 {
+    /// <summary>
+    /// Telemetry extensions on the <see cref="ILogger"/> instance to write Application Insights compatible log messages.
+    /// </summary>
     public static class ILoggerExtensions
     {
         private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
 
-        // <summary>
+        /// <summary>
         ///     Logs an HTTP request
         /// </summary>
         /// <param name="logger">Logger to use</param>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
@@ -22,6 +21,8 @@ namespace Microsoft.Extensions.Logging
         
         private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled),
                                       SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
+
+        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff";
 
         /// <summary>
         ///     Logs an HTTP request
@@ -65,7 +66,7 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(CultureInfo.InvariantCulture), context);
+            logger.LogWarning(RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(InvariantDateTimeWithMillisecondsFormat), context);
         }
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -216,7 +217,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
             
-            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -256,7 +257,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -357,7 +358,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -397,7 +398,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -437,7 +438,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -476,7 +477,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -511,7 +512,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -597,7 +598,7 @@ namespace Microsoft.Extensions.Logging
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
             bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
 
-            logger.LogWarning(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -645,7 +646,7 @@ namespace Microsoft.Extensions.Logging
 
             string dependencyName = $"{databaseName}/{tableName}";
 
-            logger.LogWarning(SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(CultureInfo.InvariantCulture), isSuccessful, context);
+            logger.LogWarning(SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -696,7 +697,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(MetricFormat, name, value, timestamp.ToString(CultureInfo.InvariantCulture), context);
+            logger.LogWarning(MetricFormat, name, value, timestamp.ToString(InvariantDateTimeWithMillisecondsFormat), context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
         private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled),
                                       SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
 
-        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff";
+        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
 
         /// <summary>
         ///     Logs an HTTP request
@@ -573,7 +573,7 @@ namespace Microsoft.Extensions.Logging
             context = context ?? new Dictionary<string, object>();
             string data = $"{database}/{container}";
 
-            logger.LogWarning(DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime, isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
         private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled),
                                       SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
 
-        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
+        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
 
         /// <summary>
         ///     Logs an HTTP request

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Extensions.Logging
         private static readonly Regex KeyVaultUriRegex = new Regex(KeyVaultUriPattern, RegexOptions.Compiled),
                                       SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
 
-        private static string InvariantDateTimeWithMillisecondsFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
-
         /// <summary>
         ///     Logs an HTTP request
         /// </summary>
@@ -66,7 +64,7 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(InvariantDateTimeWithMillisecondsFormat), context);
+            logger.LogWarning(RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
         }
 
         /// <summary>
@@ -144,7 +142,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -217,7 +215,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
             
-            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -257,7 +255,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -358,7 +356,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -398,7 +396,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -438,7 +436,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -477,7 +475,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -512,7 +510,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -573,7 +571,7 @@ namespace Microsoft.Extensions.Logging
             context = context ?? new Dictionary<string, object>();
             string data = $"{database}/{container}";
 
-            logger.LogWarning(DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -598,7 +596,7 @@ namespace Microsoft.Extensions.Logging
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
             bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
 
-            logger.LogWarning(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -646,7 +644,7 @@ namespace Microsoft.Extensions.Logging
 
             string dependencyName = $"{databaseName}/{tableName}";
 
-            logger.LogWarning(SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(InvariantDateTimeWithMillisecondsFormat), isSuccessful, context);
+            logger.LogWarning(SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -697,7 +695,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(MetricFormat, name, value, timestamp.ToString(InvariantDateTimeWithMillisecondsFormat), context);
+            logger.LogWarning(MetricFormat, name, value, timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/FormatSpecifiers.cs
+++ b/src/Arcus.Observability.Telemetry.Core/FormatSpecifiers.cs
@@ -1,0 +1,11 @@
+﻿namespace Arcus.Observability.Telemetry.Core
+{
+    public static class FormatSpecifiers
+    {
+        /// <summary>
+        /// A format specifier for converting DateTimeOffset instances to a string representation
+        /// using the highest precision that is available.
+        /// </summary>
+        public static string InvariantTimestampFormat { get; } = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -12,7 +12,7 @@ namespace Serilog.Configuration
         ///     Insights.
         /// </summary>
         /// <remarks>
-        ///     Supported telemetry types are Traces, Dependencies, Events, Requests & Metrics for which we provide extensions on
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on
         ///     <see cref="ILogger" />
         /// </remarks>
         /// <param name="loggerSinkConfiguration">The logger configuration.</param>

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -65,7 +65,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
         protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion)
         {
-            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(7));
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(12));
         }
 
         protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion, TimeSpan timeout)
@@ -76,7 +76,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                                 _outputWriter.WriteLine($"Failed to contact Azure Application Insights. Reason: {exception.Message}");
                                 return true;
                             })
-                                         .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1)))
+                                         .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(3)))
                         .ExecuteAsync(assertion);
         }
 

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -65,7 +65,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
         protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion)
         {
-            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(12));
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(7));
         }
 
         protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion, TimeSpan timeout)

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
@@ -30,7 +30,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<AzureKeyVaultDependencyTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -43,7 +43,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
@@ -44,7 +44,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsDependencyResult> results = 
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
@@ -30,7 +30,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -43,7 +43,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
@@ -44,7 +44,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsDependencyResult> results = 
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
@@ -43,7 +43,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsDependencyResult> results = 
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
@@ -29,7 +29,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -42,7 +42,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
@@ -30,7 +30,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now; // BogusGenerator.Date.RecentOffset(days: 0);
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -43,7 +43,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId,
+                            timespan: "PT15M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -39,7 +39,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Data == dependencyData);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -26,7 +26,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
                 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -39,7 +39,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Data == dependencyData);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
@@ -29,7 +29,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
@@ -25,7 +25,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -38,7 +38,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result => result.Dependency.Type == "Azure Service Bus" && result.Dependency.Target == entityName);
                 });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsDependencyResult> results = 
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
@@ -28,7 +28,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 string operation = BogusGenerator.PickRandom("GET", "UPDATE", "DELETE", "CREATE");
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -41,7 +41,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
@@ -42,7 +42,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsDependencyResult> results = 
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, "PT10M");
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, "PT30M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
@@ -28,7 +28,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
-                DateTimeOffset startTime = BogusGenerator.Date.RecentOffset(days: 0);
+                DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
@@ -41,7 +41,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId);
+                    EventsResults<EventsDependencyResult> results = 
+                        await client.Events.GetDependencyEventsAsync(ApplicationId, "PT10M");
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -46,7 +46,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, new Uri("https://" + "localhost" + "/api/v1/health"));
             var statusCode = HttpStatusCode.OK;
             var response = new HttpResponseMessage(statusCode);
-            var startTime = DateTimeOffset.UtcNow;
             TimeSpan duration = TimeSpan.FromSeconds(5);
             logger.LogRequest(request, response, duration, telemetryContext);
 
@@ -70,7 +69,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
-                Assert.Equal(TruncateToSeconds(startTime), requestTelemetry.Timestamp);
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
@@ -99,7 +97,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             };
             var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, new Uri("https://" + "localhost" + "/api/v1/health"));
             var statusCode = HttpStatusCode.OK;
-            var startTime = DateTimeOffset.UtcNow;
             TimeSpan duration = TimeSpan.FromSeconds(5);
             logger.LogRequest(request, statusCode, duration, telemetryContext);
 
@@ -123,7 +120,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
-                Assert.Equal(TruncateToSeconds(startTime), requestTelemetry.Timestamp);
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
@@ -153,7 +149,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             var statusCode = HttpStatusCode.OK;
             HttpRequest request = CreateStubRequest(HttpMethod.Get, "https", "localhost", "/api/v1/health");
             HttpResponse response = CreateStubResponse(statusCode);
-            var startTime = DateTimeOffset.UtcNow;
             TimeSpan duration = TimeSpan.FromSeconds(5);
             logger.LogRequest(request, response, duration, telemetryContext);
 
@@ -177,7 +172,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
-                Assert.Equal(TruncateToSeconds(startTime), requestTelemetry.Timestamp);
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
@@ -206,7 +200,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             };
             var statusCode = (int)HttpStatusCode.OK;
             HttpRequest request = CreateStubRequest(HttpMethod.Get, "https", "localhost", "/api/v1/health");
-            var startTime = DateTimeOffset.UtcNow;
             TimeSpan duration = TimeSpan.FromSeconds(5);
             logger.LogRequest(request, statusCode, duration, telemetryContext);
 
@@ -230,7 +223,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
-                Assert.Equal(TruncateToSeconds(startTime), requestTelemetry.Timestamp);
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(statusCode.ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
@@ -282,7 +274,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal(dependencyType, dependencyTelemetry.Type);
                 Assert.Equal(dependencyData.ToString(), dependencyTelemetry.Data);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -329,7 +321,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(entityName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -376,7 +368,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(queueName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -423,7 +415,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(topicName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -472,7 +464,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure blob", dependencyTelemetry.Type);
                 Assert.Equal(containerName, dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -520,7 +512,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure table", dependencyTelemetry.Type);
                 Assert.Equal(tableName, dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -568,7 +560,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure Event Hubs", dependencyTelemetry.Type);
                 Assert.Equal(eventHubName, dependencyTelemetry.Target);
                 Assert.Equal(namespaceName, dependencyTelemetry.Data);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -614,7 +606,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure IoT Hub", dependencyTelemetry.Type);
                 Assert.Equal(iotHubName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -663,7 +655,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure DocumentDB", dependencyTelemetry.Type);
                 Assert.Equal($"{database}/{container}", dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -712,7 +704,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("localhost", dependencyTelemetry.Target);
                 Assert.Equal("GET /api/v1/health", dependencyTelemetry.Name);
                 Assert.Null(dependencyTelemetry.Data);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.Equal("200", dependencyTelemetry.ResultCode);
                 Assert.True(dependencyTelemetry.Success);
@@ -760,7 +752,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Server", dependencyTelemetry.Target);
                 Assert.Equal("Database/Users", dependencyTelemetry.Name);
                 Assert.Equal("GET", dependencyTelemetry.Data);
-                Assert.Equal(TruncateToSeconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.Null(dependencyTelemetry.ResultCode);
                 Assert.True(dependencyTelemetry.Success);
@@ -871,7 +863,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var metricTelemetry = Assert.IsType<MetricTelemetry>(telemetry);
                 Assert.Equal(metricName, metricTelemetry.Name);
                 Assert.Equal(metricValue, metricTelemetry.Sum);
-                Assert.Equal(TruncateToSeconds(timestamp), metricTelemetry.Timestamp);
+                Assert.Equal(TruncateToMilliseconds(timestamp), metricTelemetry.Timestamp);
                 AssertOperationContext(metricTelemetry, operationId);
 
                 AssertContainsTelemetryProperty(metricTelemetry, "Capacity", "0.45");
@@ -994,10 +986,10 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             Assert.Contains(telemetry.Properties, prop => prop.Equals(new KeyValuePair<string, string>(key, value)));
         }
 
-        private static DateTimeOffset TruncateToSeconds(DateTimeOffset dateTimeOffset)
+        private static DateTimeOffset TruncateToMilliseconds(DateTimeOffset dateTimeOffset)
         {
             return new DateTimeOffset(
-                dateTimeOffset.Year, dateTimeOffset.Month, dateTimeOffset.Day, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second, dateTimeOffset.Offset);
+                dateTimeOffset.Year, dateTimeOffset.Month, dateTimeOffset.Day, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second, dateTimeOffset.Millisecond, dateTimeOffset.Offset);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -274,7 +274,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal(dependencyType, dependencyTelemetry.Type);
                 Assert.Equal(dependencyData.ToString(), dependencyTelemetry.Data);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -321,7 +321,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(entityName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -368,7 +368,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(queueName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -415,7 +415,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure Service Bus", dependencyTelemetry.Type);
                 Assert.Equal(topicName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -464,7 +464,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure blob", dependencyTelemetry.Type);
                 Assert.Equal(containerName, dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -512,7 +512,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure table", dependencyTelemetry.Type);
                 Assert.Equal(tableName, dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -560,7 +560,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure Event Hubs", dependencyTelemetry.Type);
                 Assert.Equal(eventHubName, dependencyTelemetry.Target);
                 Assert.Equal(namespaceName, dependencyTelemetry.Data);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -606,7 +606,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
                 Assert.Equal("Azure IoT Hub", dependencyTelemetry.Type);
                 Assert.Equal(iotHubName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -655,7 +655,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Azure DocumentDB", dependencyTelemetry.Type);
                 Assert.Equal($"{database}/{container}", dependencyTelemetry.Data);
                 Assert.Equal(accountName, dependencyTelemetry.Target);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.True(dependencyTelemetry.Success);
 
@@ -704,7 +704,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("localhost", dependencyTelemetry.Target);
                 Assert.Equal("GET /api/v1/health", dependencyTelemetry.Name);
                 Assert.Null(dependencyTelemetry.Data);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.Equal("200", dependencyTelemetry.ResultCode);
                 Assert.True(dependencyTelemetry.Success);
@@ -752,7 +752,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal("Server", dependencyTelemetry.Target);
                 Assert.Equal("Database/Users", dependencyTelemetry.Name);
                 Assert.Equal("GET", dependencyTelemetry.Data);
-                Assert.Equal(TruncateToMilliseconds(startTime), dependencyTelemetry.Timestamp);
+                Assert.Equal(startTime, dependencyTelemetry.Timestamp);
                 Assert.Equal(duration, dependencyTelemetry.Duration);
                 Assert.Null(dependencyTelemetry.ResultCode);
                 Assert.True(dependencyTelemetry.Success);
@@ -863,7 +863,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var metricTelemetry = Assert.IsType<MetricTelemetry>(telemetry);
                 Assert.Equal(metricName, metricTelemetry.Name);
                 Assert.Equal(metricValue, metricTelemetry.Sum);
-                Assert.Equal(TruncateToMilliseconds(timestamp), metricTelemetry.Timestamp);
+                Assert.Equal(timestamp, metricTelemetry.Timestamp);
                 AssertOperationContext(metricTelemetry, operationId);
 
                 AssertContainsTelemetryProperty(metricTelemetry, "Capacity", "0.45");
@@ -984,12 +984,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
         private static void AssertContainsTelemetryProperty(ISupportProperties telemetry, string key, string value)
         {
             Assert.Contains(telemetry.Properties, prop => prop.Equals(new KeyValuePair<string, string>(key, value)));
-        }
-
-        private static DateTimeOffset TruncateToMilliseconds(DateTimeOffset dateTimeOffset)
-        {
-            return new DateTimeOffset(
-                dateTimeOffset.Year, dateTimeOffset.Month, dateTimeOffset.Day, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second, dateTimeOffset.Millisecond, dateTimeOffset.Offset);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/LogEventPropertyValueExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/LogEventPropertyValueExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Tests.Core;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Context;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+using Xunit;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Arcus.Observability.Tests.Unit.Serilog
+{
+    public class LogEventPropertyValueExtensionsTests
+    {
+
+        [Fact]
+        public void CanCorrectlyParseDateTimeWithTicksFromString()
+        {
+            var timestamp = DateTimeOffset.Now;
+            string propertyKey = "timestamp";
+
+            var spySink = new InMemoryLogSink();
+            
+            ILogger logger = CreateLogger(
+                spySink, config =>
+                {
+                    config.Enrich.WithProperty(propertyKey, timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat));
+                    return config;
+                });
+
+            logger.LogWarning("test");
+
+            var retrievedTimestamp = spySink.CurrentLogEmits.First().Properties.GetAsDateTimeOffset(propertyKey);
+
+            Assert.Equal(timestamp, retrievedTimestamp);
+            Assert.Equal(timestamp.Ticks, retrievedTimestamp.Ticks);
+        }
+
+        private static ILogger CreateLogger(ILogEventSink sink, Func<LoggerConfiguration, LoggerConfiguration> configureLoggerConfiguration = null)
+        {
+            LoggerConfiguration config = new LoggerConfiguration().WriteTo.Sink(sink);
+            config = configureLoggerConfiguration?.Invoke(config) ?? config;
+            Logger logger = config.CreateLogger();
+
+            var factory = new SerilogLoggerFactory(logger);
+            return factory.CreateLogger<ApplicationInsightsTelemetryConverterTests>();
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/LogEventPropertyValueExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/LogEventPropertyValueExtensionsTests.cs
@@ -17,7 +17,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
 {
     public class LogEventPropertyValueExtensionsTests
     {
-
         [Fact]
         public void CanCorrectlyParseDateTimeWithTicksFromString()
         {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
     {
         private readonly Faker _bogusGenerator = new Faker();
 
-        private string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
+        private string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
 
         [Fact]
         public void LogMetric_ValidArguments_Succeeds()

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -20,6 +20,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
     {
         private readonly Faker _bogusGenerator = new Faker();
 
+        private string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fff zzz";
+
         [Fact]
         public void LogMetric_ValidArguments_Succeeds()
         {
@@ -55,7 +57,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Metric, logMessage);
             Assert.Contains(metricName, logMessage);
             Assert.Contains(metricValue.ToString(CultureInfo.InvariantCulture), logMessage);
-            Assert.Contains(timestamp.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(timestamp.ToString(ExpectedDateTimeFormat), logMessage);
         }
 
         [Fact]
@@ -116,7 +118,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -142,7 +144,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -167,7 +169,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -194,7 +196,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -218,7 +220,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(vaultUri, logMessage);
             Assert.Contains(secretName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -243,7 +245,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
             Assert.Contains(vaultUri, logMessage);
             Assert.Contains(secretName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -361,7 +363,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(searchServiceName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -387,7 +389,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(searchServiceName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -410,7 +412,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(entityType.ToString(), logMessage);
             Assert.Contains(entityName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -436,7 +438,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(entityType.ToString(), logMessage);
             Assert.Contains(entityName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -459,7 +461,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(ServiceBusEntityType.Queue.ToString(), logMessage);
             Assert.Contains(queueName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -484,7 +486,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(ServiceBusEntityType.Queue.ToString(), logMessage);
             Assert.Contains(queueName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -507,7 +509,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(ServiceBusEntityType.Topic.ToString(), logMessage);
             Assert.Contains(topicName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -532,7 +534,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
             Assert.Contains(ServiceBusEntityType.Topic.ToString(), logMessage);
             Assert.Contains(topicName, logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -561,7 +563,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -585,7 +587,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(containerName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -612,7 +614,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(containerName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -636,7 +638,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -663,7 +665,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -687,7 +689,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(namespaceName, logMessage);
             Assert.Contains(eventHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -714,7 +716,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(namespaceName, logMessage);
             Assert.Contains(eventHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -737,7 +739,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -763,7 +765,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -789,7 +791,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -818,7 +820,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -844,7 +846,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(database, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -873,7 +875,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(database, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -905,7 +907,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -935,7 +937,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -967,7 +969,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1096,7 +1098,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
             Assert.Contains(request.Method.ToString(), logMessage);
             Assert.Contains(((int) statusCode).ToString(), logMessage);
-            Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
         }
@@ -1123,7 +1125,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
                 Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
                 Assert.Contains(request.Method.ToString(), logMessage);
                 Assert.Contains(((int)statusCode).ToString(), logMessage);
-                Assert.Contains(startTime.ToString(CultureInfo.InvariantCulture), logMessage);
+                Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
                 var isSuccessful = (int)statusCode >= 200 && (int)statusCode < 300;
                 Assert.Contains($"Successful: {isSuccessful}", logMessage); 
             }


### PR DESCRIPTION
When dependencies are tracked, the starttime of the dependency is converted to a string using the InvariantCulture format provider.  However, this provider only converts the datetime to a string with a precision up to the second.
There doesn't seem to be any built-in format provider that converts dates to strings with millisecond precision, so we've specified our own.

closes #180 