### PR TITLE
feat: track exceptions more thoroughly

### DIFF
--- a/docs/preview/features/sinks/azure-application-insights.md
+++ b/docs/preview/features/sinks/azure-application-insights.md
@@ -47,10 +47,11 @@ The Azure Application Insights sink has some additional configuration which can 
 
 ### Exceptions
 
-#### Property format
+#### Properties
 
-When tracking exceptions, all the public properties of the exception will be included as [custom dimensions](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#custom-measurements-and-properties-in-analytics).
+When tracking exceptions, one can opt-in to track all the public properties of the exception which will be included as [custom dimensions](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#custom-measurements-and-properties-in-analytics).
 These public properties are formatted with the following pattern: `Exception-{0}` where `{0}` is the place where the public property's name is inserted. 
+
 The value of the property will be the value of the custom dimension so that the custom dimension will be in the form `"Exception-{your-property-name}" = "your-property-value"`.
 
 This property format pattern can be configured, like shown in the following example:
@@ -60,7 +61,14 @@ using Serilog;
 using Serilog.Configuration;
 
 ILogger logger = new LoggerConfiguration()
-    .WriteTo.AzureApplicationInsights("<key>", options => options.Exception.PropertyFormat = "CustomException.{0}")
+    .WriteTo.AzureApplicationInsights("<key>", options =>
+    {
+        // Opt-in to track all the first-level exception properties; inherited properties will not be included.
+        options.Exception.IncludeProperties = true;
+
+        // Property format to track the exception's properties (default: `"Exception-{0}"`)
+        options.Exception.PropertyFormat = "CustomException.{0}");
+    })
     .CreateLogger();
 ```
 

--- a/docs/preview/features/sinks/azure-application-insights.md
+++ b/docs/preview/features/sinks/azure-application-insights.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Azure Application Insights Sink"
 layout: default
 ---
@@ -40,6 +40,45 @@ ILogger logger = new LoggerConfiguration()
     .WriteTo.AzureApplicationInsights("<key>", restrictedToMinimumLevel: LogEventLevel.Warning)
     .CreateLogger();
 ```
+
+## Configuration
+
+The Azure Application Insights sink has some additional configuration which can be changed to influence the tracking.
+
+### Exceptions
+
+#### Property format
+
+When tracking exceptions, all the public properties of the exception will be included as [custom dimensions](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#custom-measurements-and-properties-in-analytics).
+These public properties are formatted with the following pattern: `Exception-{0}` where `{0}` is the place where the public property's name is inserted. 
+The value of the property will be the value of the custom dimension so that the custom dimension will be in the form `"Exception-{your-property-name}" = "your-property-value"`.
+
+This property format pattern can be configured, like shown in the following example:
+
+```csharp
+using Serilog;
+using Serilog.Configuration;
+
+ILogger logger = new LoggerConfiguration()
+    .WriteTo.AzureApplicationInsights("<key>", options => options.Exception.PropertyFormat = "CustomException.{0}")
+    .CreateLogger();
+```
+
+Let's take a custom exception to demonstrate:
+
+```csharp
+public class OrderingException : Exception
+{
+    ...
+
+    // Property to be included in Application Insights.
+    public int OrderNumber { get; }
+}
+```
+
+With this configuration, the custom dimension name for the public properties of this exception will look like this: `"CustomException.OrderNumber"`.
+
+> ⚠️ The property format should be in the correct form in order to be used. It's passed to the `String.Format` eventually which will try to insert the exception's property name.
 
 ## FAQ
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
@@ -11,6 +11,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
     {
         private static readonly Regex PropertyFormatRegex = new Regex(@"[\{\{0\}\}]", RegexOptions.Compiled);
         private string _propertyFormat = "Exception-{0}";
+
+        /// <summary>
+        /// Gets or sets the flag indicating whether or not the properties of the exception should be included as custom dimensions in the exception tracking.
+        /// </summary>
+        /// <remarks>
+        ///     Only the current-level properties are considered during the exception tracking; inherited properties will be excluded.
+        /// </remarks>
+        public bool IncludeProperties { get; set; } = false;
         
         /// <summary>
         /// <para>Gets or sets the string format to track (public) exception properties.</para>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
+{
+    /// <summary>
+    /// User-defined configuration options to influence the behavior of the Azure Application Insights Serilog sink while tracking exceptions.
+    /// </summary>
+    public class ApplicationInsightsSinkExceptionOptions
+    {
+        private static readonly Regex PropertyFormatRegex = new Regex(@"[\{\{0\}\}]", RegexOptions.Compiled);
+        private string _propertyFormat = "Exception-{0}";
+        
+        /// <summary>
+        /// <para>Gets or sets the string format to track (public) exception properties.</para>
+        /// <para>Default: <code>Exception-{0}</code></para>
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that you pass along a valid string format where there's room for a single string argument (`{0}` should be included in the format),
+        ///     otherwise an <see cref="FormatException"/> will be thrown further up the way.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        /// <exception cref="FormatException">
+        ///     Thrown when the <paramref name="value"/> is not in the correct format to be used as a string format to track (public) exception properties.
+        /// </exception>
+        public string PropertyFormat
+        {
+            get => _propertyFormat;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank string format to track (public) exception properties");
+                Guard.For<FormatException>(() => PropertyFormatRegex.Matches(value).Count != 3, "Requires a single occurrence of the substring '{0}' in the exception property format");
+
+                _propertyFormat = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
+{
+    /// <summary>
+    /// User-defined configuration options to influence the behavior of the Azure Application Insights Serilog sink.
+    /// </summary>
+    public class ApplicationInsightsSinkOptions
+    {
+        /// <summary>
+        /// Gets the Application Insights options related to tracking exceptions.
+        /// </summary>
+        public ApplicationInsightsSinkExceptionOptions Exception { get; } = new ApplicationInsightsSinkExceptionOptions();
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters.Dependencies;
+using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters;
@@ -31,6 +32,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
         private ApplicationInsightsTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
+            Guard.NotNull(options, nameof(options), "Requires a set of options to influence how to track to Application Insights");
             _exceptionTelemetryConverter = new ExceptionTelemetryConverter(options.Exception);
         }
         

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters.Dependencies;
 using Microsoft.ApplicationInsights.Channel;
 using Serilog.Events;
@@ -13,7 +14,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     /// </summary>
     public class ApplicationInsightsTelemetryConverter : TelemetryConverterBase
     {
-        private readonly ExceptionTelemetryConverter _exceptionTelemetryConverter = new ExceptionTelemetryConverter();
+        private readonly ExceptionTelemetryConverter _exceptionTelemetryConverter;
         private readonly TraceTelemetryConverter _traceTelemetryConverter = new TraceTelemetryConverter();
         private readonly EventTelemetryConverter _eventTelemetryConverter = new EventTelemetryConverter();
         private readonly MetricTelemetryConverter _metricTelemetryConverter = new MetricTelemetryConverter();
@@ -28,6 +29,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         private readonly SqlDependencyTelemetryConverter _sqlDependencyTelemetryConverter =
             new SqlDependencyTelemetryConverter();
 
+        private ApplicationInsightsTelemetryConverter(ApplicationInsightsSinkOptions options)
+        {
+            _exceptionTelemetryConverter = new ExceptionTelemetryConverter(options.Exception);
+        }
+        
         /// <summary>
         ///     Convert the given <paramref name="logEvent"/> to a series of <see cref="ITelemetry"/> instances.
         /// </summary>
@@ -78,7 +84,16 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// </summary>
         public static ApplicationInsightsTelemetryConverter Create()
         {
-            return new ApplicationInsightsTelemetryConverter();
+            return Create(new ApplicationInsightsSinkOptions());
+        }
+
+        /// <summary>
+        /// Create an instance of the <see cref="ApplicationInsightsTelemetryConverter"/> class.
+        /// </summary>
+        /// <param name="options">The optional user-defined configuration options to influence the tracking behavior to Azure Application Insights.</param>
+        public static ApplicationInsightsTelemetryConverter Create(ApplicationInsightsSinkOptions options)
+        {
+            return new ApplicationInsightsTelemetryConverter(options ?? new ApplicationInsightsSinkOptions());
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
@@ -40,7 +40,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception);
 
             Type exceptionType = logEvent.Exception.GetType();
-            PropertyInfo[] exceptionProperties = exceptionType.GetProperties(BindingFlags.Public);
+            PropertyInfo[] exceptionProperties = exceptionType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             foreach (PropertyInfo exceptionProperty in exceptionProperties)
             {
                 string key = String.Format(_options.PropertyFormat, exceptionProperty.Name);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Reflection;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
+using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -9,6 +12,19 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     /// </summary>
     public class ExceptionTelemetryConverter : CustomTelemetryConverter<ExceptionTelemetry>
     {
+        private readonly ApplicationInsightsSinkExceptionOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionTelemetryConverter" /> class.
+        /// </summary>
+        /// <param name="options">The consumer-configurable options to influence how the exception should be tracked.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        public ExceptionTelemetryConverter(ApplicationInsightsSinkExceptionOptions options)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of user-configurable options to influence the behavior of how exceptions are tracked");
+            _options = options;
+        }
+        
         /// <summary>
         ///     Creates a telemetry entry for a given log event
         /// </summary>
@@ -17,7 +33,21 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override ExceptionTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an exception telemetry entry");
+            Guard.For(() => logEvent.Exception is null, new ArgumentException(
+                "Requires a log event that tracks an exception to create an exception telemetry entry", nameof(logEvent)));
+            
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception);
+
+            Type exceptionType = logEvent.Exception.GetType();
+            PropertyInfo[] exceptionProperties = exceptionType.GetProperties(BindingFlags.Public);
+            foreach (PropertyInfo exceptionProperty in exceptionProperties)
+            {
+                string key = String.Format(_options.PropertyFormat, exceptionProperty.Name);
+                var value = exceptionProperty.GetValue(logEvent.Exception)?.ToString();
+                exceptionTelemetry.Properties[key] = value;
+            }
+            
             return exceptionTelemetry;
         }
     }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
@@ -39,13 +39,16 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception);
 
-            Type exceptionType = logEvent.Exception.GetType();
-            PropertyInfo[] exceptionProperties = exceptionType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            foreach (PropertyInfo exceptionProperty in exceptionProperties)
+            if (_options.IncludeProperties)
             {
-                string key = String.Format(_options.PropertyFormat, exceptionProperty.Name);
-                var value = exceptionProperty.GetValue(logEvent.Exception)?.ToString();
-                exceptionTelemetry.Properties[key] = value;
+                Type exceptionType = logEvent.Exception.GetType();
+                PropertyInfo[] exceptionProperties = exceptionType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                foreach (PropertyInfo exceptionProperty in exceptionProperties)
+                {
+                    string key = String.Format(_options.PropertyFormat, exceptionProperty.Name);
+                    var value = exceptionProperty.GetValue(logEvent.Exception)?.ToString();
+                    exceptionTelemetry.Properties[key] = value;
+                }
             }
             
             return exceptionTelemetry;

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,47 +1,106 @@
-﻿using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
 using GuardNet;
 using Serilog.Events;
 
 // ReSharper disable once CheckNamespace
 namespace Serilog.Configuration
 {
+    /// <summary>
+    /// Extensions on the <see cref="LoggerSinkConfiguration"/> class to add the Azure Application Insights as a Serilog sink.
+    /// </summary>
     public static class LoggerSinkConfigurationExtensions
     {
         /// <summary>
-        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application
-        ///     Insights.
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
         /// </summary>
         /// <remarks>
-        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on
-        ///     <see cref="ILogger" />
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
         /// </remarks>
         /// <param name="loggerSinkConfiguration">The logger configuration.</param>
-        /// <param name="instrumentationKey">Required Application Insights key.</param>
-        /// <returns></returns>
-        public static LoggerConfiguration AzureApplicationInsights(this LoggerSinkConfiguration loggerSinkConfiguration,
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsights(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
             string instrumentationKey)
         {
-            return AzureApplicationInsights(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose);
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsights(loggerSinkConfiguration, instrumentationKey, configureOptions: null);
         }
 
         /// <summary>
-        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application
-        ///     Insights.
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
         /// </summary>
         /// <remarks>
-        ///     Supported telemetry types are Traces, Dependencies, Events, Requests & Metrics for which we provide extensions on
-        ///     <see cref="ILogger" />
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
         /// </remarks>
         /// <param name="loggerSinkConfiguration">The logger configuration.</param>
-        /// <param name="instrumentationKey">Required Application Insights key.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        public static LoggerConfiguration AzureApplicationInsights(this LoggerSinkConfiguration loggerSinkConfiguration,
-            string instrumentationKey, LogEventLevel restrictedToMinimumLevel)
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsights(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string instrumentationKey,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration));
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey));
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
 
-            return loggerSinkConfiguration.ApplicationInsights(instrumentationKey, ApplicationInsightsTelemetryConverter.Create(), restrictedToMinimumLevel);
+            return AzureApplicationInsights(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose, configureOptions);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsights(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string instrumentationKey, 
+            LogEventLevel restrictedToMinimumLevel)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsights(loggerSinkConfiguration, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsights(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string instrumentationKey,
+            LogEventLevel restrictedToMinimumLevel,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            var options = new ApplicationInsightsSinkOptions();
+            configureOptions?.Invoke(options);
+            
+            return loggerSinkConfiguration.ApplicationInsights(instrumentationKey, ApplicationInsightsTelemetryConverter.Create(options), restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Integration/Fixture/TestException.cs
+++ b/src/Arcus.Observability.Tests.Integration/Fixture/TestException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Arcus.Observability.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents a custom <see cref="Exception"/> to determine if the exception is tracked as expected.
+    /// </summary>
+    public class TestException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestException" /> class.
+        /// </summary>
+        public TestException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestException" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the exception.</param>
+        public TestException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestException" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public TestException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+        
+        /// <summary>
+        /// Gets the custom test property of this exception to determine if the property is considered while tracking the exception.
+        /// </summary>
+        public string SpyProperty { get; set; }
+    }
+}

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Bogus;
 using Microsoft.Azure.ApplicationInsights;
 using Microsoft.Azure.ApplicationInsights.Query;
@@ -41,11 +42,18 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         /// </summary>
         protected string ApplicationId { get; }
 
-        protected ILoggerFactory CreateLoggerFactory(Action<LoggerConfiguration> configureLogging = null)
+        /// <summary>
+        /// Creates an <see cref="ILoggerFactory"/> instance that will create <see cref="Microsoft.Extensions.Logging.ILogger"/> instances that writes to Azure Application Insights.
+        /// </summary>
+        /// <param name="configureLogging">The optional function to configure additional logging features.</param>
+        /// <param name="configureOptions">The optional function to configure additional properties while writing to Azure Application Insights.</param>
+        protected ILoggerFactory CreateLoggerFactory(
+            Action<LoggerConfiguration> configureLogging = null,
+            Action<ApplicationInsightsSinkOptions> configureOptions = null)
         {
             var configuration = new LoggerConfiguration()
                 .WriteTo.Sink(new XunitLogEventSink(_outputWriter))
-                .WriteTo.AzureApplicationInsights(_instrumentationKey);
+                .WriteTo.AzureApplicationInsights(_instrumentationKey, configureOptions);
             
             configureLogging?.Invoke(configuration);
             return LoggerFactory.Create(builder => builder.AddSerilog(configuration.CreateLogger(), dispose: true));

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ExceptionTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ExceptionTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Arcus.Observability.Tests.Integration.Fixture;
 using Microsoft.Azure.ApplicationInsights.Query;
 using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
@@ -21,7 +23,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         {
             // Arrange
             string message = BogusGenerator.Lorem.Sentence();
-            var exception = new PlatformNotSupportedException(message);
+            string expectedProperty = BogusGenerator.Lorem.Word();
+            var exception = new TestException(message) { SpyProperty = expectedProperty };
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -36,7 +39,45 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     EventsResults<EventsExceptionResult> results = await client.Events.GetExceptionEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
-                    Assert.Contains(results.Value, result => result.Exception.OuterMessage == exception.Message);
+                    Assert.Contains(results.Value, result =>
+                    {
+                        return result.Exception.OuterMessage == exception.Message
+                               && result.CustomDimensions.TryGetValue($"Exception-{nameof(TestException.SpyProperty)}", out string actualProperty)
+                               && expectedProperty == actualProperty;
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public async Task LogExceptionWithCustomPropertyFormat_SinksToApplicationInsights_ResultsInExceptionTelemetry()
+        {
+            // Arrange
+            string message = BogusGenerator.Lorem.Sentence();
+            string expectedProperty = BogusGenerator.Lorem.Word();
+            var exception = new TestException(message) { SpyProperty = expectedProperty };
+            string propertyFormat = "Exception.{0}";
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory(configureOptions: options => options.Exception.PropertyFormat = propertyFormat))
+            {
+                ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
+
+                // Act
+                logger.LogCritical(exception, exception.Message);
+            }
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsExceptionResult> results = await client.Events.GetExceptionEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    Assert.Contains(results.Value, result =>
+                    {
+                        string propertyName = String.Format(propertyFormat, nameof(TestException.SpyProperty));
+                        return result.Exception.OuterMessage == exception.Message
+                               && result.CustomDimensions.TryGetValue(propertyName, out string actualProperty)
+                               && expectedProperty == actualProperty;
+                    });
                 });
             }
         }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkExceptionOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkExceptionOptionsTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
+{
+    public class ApplicationInsightsSinkExceptionOptionsTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void SetPropertyFormat_WithBlankValue_Fails(string propertyFormat)
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkExceptionOptions();
+            
+            // Act / Assert
+            Assert.Throws<ArgumentException>(() => options.PropertyFormat = propertyFormat);
+        }
+
+        [Theory]
+        [InlineData("Exception-{0}-{1}")]
+        [InlineData("Exception.{0}.Inner.{0}")]
+        [InlineData("Exception-")]
+        public void SetPropertyFormat_WithInvalidStringFormat_Fails(string propertyFormat)
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkExceptionOptions();
+            
+            // Act / Assert
+            Assert.Throws<FormatException>(() => options.PropertyFormat = propertyFormat);
+        }
+
+        [Theory]
+        [InlineData("Exception.{0}")]
+        [InlineData("{0} of exception")]
+        [InlineData("Property '{0}' of exception")]
+        public void SetPropertyFormat_WithCorrectStringFormat_Succeeds(string propertyFormat)
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkExceptionOptions();
+            
+            // Act / Assert
+            options.PropertyFormat = propertyFormat;
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Events;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
+{
+    public class LoggerConfigurationExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsights_WithoutInstrumentationKey_Fails(string instrumentationKey)
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsights(instrumentationKey));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsWithConfigOptions_WithoutInstrumentationKey_Fails(string instrumentationKey)
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsights(instrumentationKey, options => { }));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsWithMinLogLevel_WithoutInstrumentationKey_Fails(string instrumentationKey)
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsights(instrumentationKey, LogEventLevel.Debug));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsWithMinLogLevelWithConfigOptions_WithoutInstrumentationKey_Fails(string instrumentationKey)
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.Throws<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsights(instrumentationKey, LogEventLevel.Debug, options => { }));
+        }
+    }
+}


### PR DESCRIPTION
Include public properties when tracking exceptions to Azure Application Insights. This means that any custom and existing (base) properties will be included as `customDimensions` in the exception tracking entries in Application Insights.

Closes #184 