### PR TITLE
fix: small typo in use-with-dotnet-and-functions.md

### DIFF
--- a/docs/v2.1/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v2.1/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 


### PR DESCRIPTION
small typo