### PR TITLE
docs: fix 'note' typo in Azure Functions guidance feature docs

### DIFF
--- a/docs/guidance/use-with-dotnet-and-functions.md
+++ b/docs/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 

--- a/docs/preview/guidance/use-with-dotnet-and-functions.md
+++ b/docs/preview/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 

--- a/docs/v0.3/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v0.3/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 

--- a/docs/v0.4/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v0.4/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 

--- a/docs/v1.0/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v1.0/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 

--- a/docs/v2.0/guidance/use-with-dotnet-and-functions.md
+++ b/docs/v2.0/guidance/use-with-dotnet-and-functions.md
@@ -62,7 +62,7 @@ namespace Arcus.Samples.AzureFunction
 }
 ```
 
-> :bulb: Not that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
+> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 


### PR DESCRIPTION
The guidance feature docs were having a small type, first discovered by @MassimoC in #197 .