### PR TITLE
feat: improve guard checks on telemetry logging

### DIFF
--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Logging
     /// <summary>
     /// Telemetry extensions on the <see cref="ILogger"/> instance to write Application Insights compatible log messages.
     /// </summary>
+    // ReSharper disable once InconsistentNaming
     public static class ILoggerExtensions
     {
         /// <summary>
@@ -20,14 +21,24 @@ namespace Microsoft.Extensions.Logging
         /// <param name="response">Response that will be sent out</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or <paramref name="response"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s scheme contains whitespace, the <paramref name="request"/>'s host is missing or contains whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogRequest(this ILogger logger, HttpRequest request, HttpResponse response, TimeSpan duration, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-            Guard.NotNull(response, nameof(response));
-            Guard.For<ArgumentException>(() => request.Scheme != null && request.Scheme.Contains(" "), "HTTP request scheme cannot contain whitespace");
-            Guard.For<ArgumentException>(() => !request.Host.HasValue, "HTTP request host requires a value");
-            Guard.For<ArgumentException>(() => request.Host.ToString()?.Contains(" ") == true, "HTTP request host name cannot contain whitespace");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
+            Guard.For(() => !request.Path.HasValue, new ArgumentException("Requires a HTTP request with a path", nameof(request)));
+            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request with a HTTP method", nameof(request)));
+            Guard.For(() => request.Scheme?.Contains(" ") == true, new ArgumentException("Requires a HTTP request scheme without whitespace to track a HTTP request", nameof(request)));
+            Guard.For(() => !request.Host.HasValue, new ArgumentException("Requires a HTTP request with a host value to track a HTTP request", nameof(request)));
+            Guard.For(() => request.Host.ToString()?.Contains(" ") == true, new ArgumentException("Requires a HTTP request host name without whitespace to track a HTTP request", nameof(request)));
+            Guard.NotLessThan(response.StatusCode, 0, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan(response.StatusCode, 999, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
 
             LogRequest(logger, request, response.StatusCode, duration, context);
         }
@@ -40,14 +51,24 @@ namespace Microsoft.Extensions.Logging
         /// <param name="responseStatusCode">HTTP status code returned by the service</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="request"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s scheme contains whitespace, the <paramref name="request"/>'s host is missing or contains whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogRequest(this ILogger logger, HttpRequest request, int responseStatusCode, TimeSpan duration, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-            Guard.For<ArgumentException>(() => request.Scheme != null && request.Scheme.Contains(" "), "HTTP request scheme cannot contain whitespace");
-            Guard.For<ArgumentException>(() => !request.Host.HasValue, "HTTP request host requires a value");
-            Guard.For<ArgumentException>(() => request.Host.ToString()?.Contains(" ") == true, "HTTP request host name cannot contain whitespace");
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.For(() => !request.Path.HasValue, new ArgumentException("Requires a HTTP request with a path", nameof(request)));
+            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request with a HTTP method", nameof(request)));
+            Guard.For(() => request.Scheme?.Contains(" ") == true, new ArgumentException("Requires a HTTP request scheme without whitespace to track a HTTP request", nameof(request)));
+            Guard.For(() => !request.Host.HasValue, new ArgumentException("Requires a HTTP request with a host value to track a HTTP request", nameof(request)));
+            Guard.For(() => request.Host.ToString()?.Contains(" ") == true, new ArgumentException("Requires a HTTP request host name without whitespace to track a HTTP request", nameof(request)));
+            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
+            
             context = context ?? new Dictionary<string, object>();
 
             PathString resourcePath = request.Path;

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -25,38 +25,74 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an HTTP request
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="request">Request that was done</param>
         /// <param name="response">Response that will be sent out</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
-        public static void LogRequest(this ILogger logger, HttpRequestMessage request, HttpResponseMessage response, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s URI is blank,
+        ///     the <paramref name="request"/>'s scheme contains whitespace,
+        ///     the <paramref name="request"/>'s host contains whitespace,
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="response"/>'s status code is outside the 0-999 inclusively,
+        ///     the <paramref name="duration"/> is a negative time range.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestMessage request,
+            HttpResponseMessage response,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-            Guard.NotNull(response, nameof(response));
-            Guard.NotNull(request.RequestUri, nameof(request.RequestUri));
-            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "HTTP request scheme cannot contain whitespace");
-            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "HTTP request host name cannot contain whitespace");
-            
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
+            Guard.NotNull(request.RequestUri, nameof(request.RequestUri), "Requires a request URI to track a HTTP request");
+            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "Requires a HTTP request scheme without whitespace");
+            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotLessThan((int) response.StatusCode, 0, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan((int) response.StatusCode, 999, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+
             LogRequest(logger, request, response.StatusCode, duration, context);
         }
 
         /// <summary>
         ///     Logs an HTTP request
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="request">Request that was done</param>
         /// <param name="responseStatusCode">HTTP status code returned by the service</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
-        public static void LogRequest(this ILogger logger, HttpRequestMessage request, HttpStatusCode responseStatusCode, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s URI is blank,
+        ///     the <paramref name="request"/>'s scheme contains whitespace,
+        ///     the <paramref name="request"/>'s host contains whitespace,
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="responseStatusCode"/>'s status code is outside the 0-999 inclusively,
+        ///     the <paramref name="duration"/> is a negative time range.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestMessage request,
+            HttpStatusCode responseStatusCode,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-            Guard.NotNull(request.RequestUri, nameof(request.RequestUri));
-            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "HTTP request scheme cannot contain whitespace");
-            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "HTTP request host name cannot contain whitespace");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(request.RequestUri, nameof(request.RequestUri), "Requires a request URI to track a HTTP request");
+            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "Requires a HTTP request scheme without whitespace");
+            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotLessThan((int) responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan((int) responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
             
             context = context ?? new Dictionary<string, object>();
 
@@ -64,69 +100,106 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
+            logger.LogWarning(
+                RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
         }
 
         /// <summary>
         ///     Logs a dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogDependency(this ILogger logger, string dependencyType, object dependencyData, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        public static void LogDependency(
+            this ILogger logger,
+            string dependencyType,
+            object dependencyData,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType));
-            Guard.NotNull(dependencyData, nameof(dependencyData));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
         ///     Logs a dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogDependency(this ILogger logger, string dependencyType, object dependencyData, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogDependency(
+            this ILogger logger,
+            string dependencyType,
+            object dependencyData,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType));
-            Guard.NotNull(dependencyData, nameof(dependencyData));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+            
             LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
         }
 
         /// <summary>
         ///     Logs a dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="targetName">Name of the dependency target</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogDependency(this ILogger logger, string dependencyType, object dependencyData, string targetName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        public static void LogDependency(
+            this ILogger logger,
+            string dependencyType,
+            object dependencyData,
+            string targetName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType));
-            Guard.NotNull(dependencyData, nameof(dependencyData));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
         ///     Logs a dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="targetName">Name of dependency target</param>
@@ -134,15 +207,30 @@ namespace Microsoft.Extensions.Logging
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogDependency(this ILogger logger, string dependencyType, object dependencyData, string targetName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogDependency(
+            this ILogger logger,
+            string dependencyType,
+            object dependencyData,
+            string targetName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType));
-            Guard.NotNull(dependencyData, nameof(dependencyData));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
@@ -154,7 +242,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="secretName"/> is not in the correct format.</exception>
         /// <exception cref="UriFormatException">Thrown when the <paramref name="vaultUri"/> is not in the correct format.</exception>
@@ -169,6 +257,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
             Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
             Guard.For<FormatException>(
                 () => !SecretNameRegex.IsMatch(secretName), 
                 "Requires a Azure Key Vault secret name in the correct format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
@@ -192,6 +281,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="secretName"/> is not in the correct format.</exception>
         /// <exception cref="UriFormatException">Thrown when the <paramref name="vaultUri"/> is not in the correct format.</exception>
         public static void LogAzureKeyVaultDependency(
@@ -212,26 +302,38 @@ namespace Microsoft.Extensions.Logging
             Guard.For<UriFormatException>(
                 () => !KeyVaultUriRegex.IsMatch(vaultUri),
                 "Requires the Azure Key Vault host to be in the right format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
-
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
+            
             context = context ?? new Dictionary<string, object>();
             
-            logger.LogWarning(DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Search Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="searchServiceName">Name of the Azure Search service</param>
         /// <param name="operationName">Name of the operation to execute on the Azure Search service</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogAzureSearchDependency(this ILogger logger, string searchServiceName, string operationName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="searchServiceName"/> or <paramref name="operationName"/> is blank.</exception>
+        public static void LogAzureSearchDependency(
+            this ILogger logger,
+            string searchServiceName,
+            string operationName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName));
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Search dependency");
+            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+            
             context = context ?? new Dictionary<string, object>();
 
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
@@ -240,36 +342,53 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Search Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="searchServiceName">Name of the Azure Search service</param>
         /// <param name="operationName">Name of the operation to execute on the Azure Search service</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogAzureSearchDependency(this ILogger logger, string searchServiceName, string operationName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="searchServiceName"/> or <paramref name="operationName"/> is blank.</exception>
+        public static void LogAzureSearchDependency(
+            this ILogger logger,
+            string searchServiceName,
+            string operationName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName));
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="queueName">Name of the Service Bus queue</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusQueueDependency(this ILogger logger, string queueName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        public static void LogServiceBusQueueDependency(
+            this ILogger logger,
+            string queueName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus Queue when tracking the Azure Service Bus Queue dependency");
 
             LogServiceBusQueueDependency(logger, queueName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -277,15 +396,26 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="queueName">Name of the Service Bus queue</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusQueueDependency(this ILogger logger, string queueName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="queueName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogServiceBusQueueDependency(
+            this ILogger logger,
+            string queueName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank Azure Service Bus Queue name to track an Azure Service Bus Queue dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Queue operation");
             
             LogServiceBusDependency(logger, queueName, isSuccessful, startTime, duration, ServiceBusEntityType.Queue, context);
         }
@@ -293,15 +423,23 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="topicName">Name of the Service Bus topic</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusTopicDependency(this ILogger logger, string topicName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="topicName"/> is blank.</exception>
+        public static void LogServiceBusTopicDependency(
+            this ILogger logger,
+            string topicName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name to track an Azure Service Bus Topic dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus Topic when tracking the Azure Service Bus Topic dependency");
 
             LogServiceBusTopicDependency(logger, topicName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -309,15 +447,26 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="topicName">Name of the Service Bus topic</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusTopicDependency(this ILogger logger, string topicName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="topicName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogServiceBusTopicDependency(
+            this ILogger logger,
+            string topicName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name to track an Azure Service Bus Topic dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Topic operation");
             
             LogServiceBusDependency(logger, topicName, isSuccessful, startTime, duration, ServiceBusEntityType.Topic, context);
         }
@@ -325,16 +474,25 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="entityName">Name of the Service Bus entity</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
         /// <param name="entityType">Type of the Service Bus entity</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusDependency(this ILogger logger, string entityName, bool isSuccessful, DependencyMeasurement measurement, ServiceBusEntityType entityType = ServiceBusEntityType.Unknown, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> is blank.</exception>
+        public static void LogServiceBusDependency(
+            this ILogger logger,
+            string entityName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
 
             LogServiceBusDependency(logger, entityName, isSuccessful, measurement.StartTime, measurement.Elapsed, entityType, context);
         }
@@ -342,38 +500,58 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Service Bus Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="entityName">Name of the Service Bus entity</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="entityType">Type of the Service Bus entity</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogServiceBusDependency(this ILogger logger, string entityName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, ServiceBusEntityType entityType = ServiceBusEntityType.Unknown, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogServiceBusDependency(
+            this ILogger logger,
+            string entityName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Blob Storage Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Account of the storage resource</param>
         /// <param name="containerName">Name of the Blob Container resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogBlobStorageDependency(this ILogger logger, string accountName, string containerName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or <paramref name="containerName"/> is blank.</exception>
+        public static void LogBlobStorageDependency(
+            this ILogger logger,
+            string accountName,
+            string containerName,
+            bool isSuccessful,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
+            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Blob storage when tracking an Azure Blob storage dependency");
 
             LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -381,115 +559,176 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Blob Storage Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Account of the storage resource</param>
         /// <param name="containerName">Name of the Blob Container resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogBlobStorageDependency(this ILogger logger, string accountName, string containerName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>nul</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or <paramref name="containerName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogBlobStorageDependency(
+            this ILogger logger,
+            string accountName,
+            string containerName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
+            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Table Storage Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Account of the storage resource</param>
         /// <param name="tableName">Name of the Table Storage resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the Table Storage dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogTableStorageDependency(this ILogger logger, string accountName, string tableName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or <paramref name="tableName"/> is blank.</exception>
+        public static void LogTableStorageDependency(
+            this ILogger logger, 
+            string accountName, 
+            string tableName, 
+            bool isSuccessful, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
+            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Table storage when tracking an Azure Table storage dependency");
 
-            LogTableStorageDependency(logger, accountName: accountName, tableName: tableName, isSuccessful: isSuccessful, startTime: measurement.StartTime, duration: measurement.Elapsed, context: context);
+            LogTableStorageDependency(logger, accountName, tableName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
         ///     Logs an Azure Table Storage Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Account of the storage resource</param>
         /// <param name="tableName">Name of the Table Storage resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogTableStorageDependency(this ILogger logger, string accountName, string tableName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>nul</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or <paramref name="tableName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogTableStorageDependency(
+            this ILogger logger, 
+            string accountName, 
+            string tableName, 
+            bool isSuccessful, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
+            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Event Hub Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="namespaceName">Namespace of the resource</param>
         /// <param name="eventHubName">Name of the Event Hub resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogEventHubsDependency(this ILogger logger, string namespaceName, string eventHubName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="namespaceName"/> or <paramref name="eventHubName"/> is blank.</exception>
+        public static void LogEventHubsDependency(
+            this ILogger logger, 
+            string namespaceName, 
+            string eventHubName, 
+            bool isSuccessful, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName));
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
+            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Event Hub resource when tracking an Azure Event Hub dependency");
+            
             LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
         ///     Logs an Azure Event Hub Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="namespaceName">Namespace of the resource</param>
         /// <param name="eventHubName">Name of the Event Hub resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogEventHubsDependency(this ILogger logger, string namespaceName, string eventHubName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="namespaceName"/> or <paramref name="eventHubName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogEventHubsDependency(
+            this ILogger logger, 
+            string namespaceName, 
+            string eventHubName, 
+            bool isSuccessful, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName));
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
+            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an Azure Iot Hub Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="iotHubName">Name of the IoT Hub resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogIotHubDependency(this ILogger logger, string iotHubName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubName"/> is blank.</exception>
+        public static void LogIotHubDependency(
+            this ILogger logger, 
+            string iotHubName, 
+            bool isSuccessful, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the IoT Hub resource when tracking a IoT Hub dependency");
 
             LogIotHubDependency(logger, iotHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -497,63 +736,67 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an Azure Iot Hub Dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
-        /// <param name="iotHubName">Name of the Event Hub resource</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="iotHubName">Name of the IoT Hub resource</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogIotHubDependency(this ILogger logger, string iotHubName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogIotHubDependency(
+            this ILogger logger, 
+            string iotHubName, 
+            bool isSuccessful, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the IoT Hub operation");
+            
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
-        }
-
-        /// <summary>
-        ///     Logs an HTTP dependency
-        /// </summary>
-        /// <param name="logger">Logger to use</param>
-        /// <param name="request">Request that started the HTTP communication</param>
-        /// <param name="statusCode">Status code that was returned by the service for this HTTP communication</param>
-        /// <param name="measurement">Measuring the latency of the HTTP dependency</param>
-        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogHttpDependency(this ILogger logger, HttpRequestMessage request, HttpStatusCode statusCode, DependencyMeasurement measurement, Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-            Guard.NotNull(measurement, nameof(measurement));
-
-            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
+            logger.LogWarning(
+                DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs a Cosmos SQL dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Name of the storage resource</param>
         /// <param name="database">Name of the database</param>
         /// <param name="container">Name of the container</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency of the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogCosmosSqlDependency(this ILogger logger, string accountName, string database, string container, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/>, <paramref name="database"/>, or <paramref name="container"/> is blank.</exception>
+        public static void LogCosmosSqlDependency(
+            this ILogger logger, 
+            string accountName, 
+            string database, 
+            string container, 
+            bool isSuccessful, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-            Guard.NotNullOrWhitespace(database, nameof(database));
-            Guard.NotNullOrWhitespace(container, nameof(container));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Cosmos SQL storage when tracking an Cosmos SQL dependency");
+            
             LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
         ///     Logs a Cosmos SQL dependency.
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="accountName">Name of the storage resource</param>
         /// <param name="database">Name of the database</param>
         /// <param name="container">Name of the container</param>
@@ -561,33 +804,90 @@ namespace Microsoft.Extensions.Logging
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogCosmosSqlDependency(this ILogger logger, string accountName, string database, string container, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/>, <paramref name="database"/>, or <paramref name="container"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogCosmosSqlDependency(
+            this ILogger logger, 
+            string accountName, 
+            string database, 
+            string container, 
+            bool isSuccessful, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName));
-            Guard.NotNullOrWhitespace(database, nameof(database));
-            Guard.NotNullOrWhitespace(container, nameof(container));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
+            
             context = context ?? new Dictionary<string, object>();
             string data = $"{database}/{container}";
 
-            logger.LogWarning(DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs an HTTP dependency
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">Request that started the HTTP communication</param>
+        /// <param name="statusCode">Status code that was returned by the service for this HTTP communication</param>
+        /// <param name="measurement">Measuring the latency of the HTTP dependency</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/> doesn't have a request URI or HTTP method, the <paramref name="statusCode"/> is outside the bounds of the enumeration.
+        /// </exception>
+        public static void LogHttpDependency(
+            this ILogger logger, 
+            HttpRequestMessage request, 
+            HttpStatusCode statusCode, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            Guard.For(() => !Enum.IsDefined(typeof(HttpStatusCode), statusCode), 
+                new ArgumentException("Requires a response HTTP status code that's within the bound of the enumeration to track a HTTP dependency"));
+            
+            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        ///     Logs an HTTP dependency
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="request">Request that started the HTTP communication</param>
         /// <param name="statusCode">Status code that was returned by the service for this HTTP communication</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogHttpDependency(this ILogger logger, HttpRequestMessage request, HttpStatusCode statusCode, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/> doesn't have a request URI or HTTP method, the <paramref name="statusCode"/> is outside the bounds of the enumeration.
+        /// </exception>
+        public static void LogHttpDependency(
+            this ILogger logger, 
+            HttpRequestMessage request, 
+            HttpStatusCode statusCode, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(request, nameof(request));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
+            Guard.For(() => request.RequestUri is null, new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request)));
+            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request)));
+            Guard.For(() => !Enum.IsDefined(typeof(HttpStatusCode), statusCode), 
+                new ArgumentException("Requires a response HTTP status code that's within the bound of the enumeration to track a HTTP dependency"));
+            
             context = context ?? new Dictionary<string, object>();
 
             Uri requestUri = request.RequestUri;
@@ -596,26 +896,36 @@ namespace Microsoft.Extensions.Logging
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
             bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
 
-            logger.LogWarning(HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs a SQL dependency
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="serverName">Name of server hosting the database</param>
         /// <param name="databaseName">Name of database</param>
         /// <param name="tableName">Name of table</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="measurement">Measuring the latency to call the SQL dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogSqlDependency(this ILogger logger, string serverName, string databaseName, string tableName, bool isSuccessful, DependencyMeasurement measurement, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, or <paramref name="tableName"/> is blank.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger, 
+            string serverName, 
+            string databaseName, 
+            string tableName, 
+            bool isSuccessful, 
+            DependencyMeasurement measurement, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(serverName, nameof(serverName));
-            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName));
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName));
-            Guard.NotNull(measurement, nameof(measurement));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank SQL table name to track a SQL dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
 
             LogSqlDependency(logger, serverName, databaseName, tableName, measurement.DependencyData, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -623,7 +933,7 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs a SQL dependency
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="serverName">Name of server hosting the database</param>
         /// <param name="databaseName">Name of database</param>
         /// <param name="tableName">Name of table</param>
@@ -632,31 +942,49 @@ namespace Microsoft.Extensions.Logging
         /// <param name="duration">Duration of the operation</param>
         /// <param name="operationName">Name of the operation that was performed</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        public static void LogSqlDependency(this ILogger logger, string serverName, string databaseName, string tableName, string operationName, bool isSuccessful, DateTimeOffset startTime, TimeSpan duration, Dictionary<string, object> context = null)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, <paramref name="tableName"/>, or <paramref name="operationName"/> is blank.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger, 
+            string serverName, 
+            string databaseName, 
+            string tableName, 
+            string operationName, 
+            bool isSuccessful, 
+            DateTimeOffset startTime, 
+            TimeSpan duration, 
+            Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(serverName, nameof(serverName));
-            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName));
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName));
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName));
-
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank SQL table name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name of the SQL operation to track a SQL dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the SQL dependency operation");
+            
             context = context ?? new Dictionary<string, object>();
 
             string dependencyName = $"{databaseName}/{tableName}";
 
-            logger.LogWarning(SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(
+                SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
         }
 
         /// <summary>
         ///     Logs a custom event
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="name">Name of the event</param>
         /// <param name="context">Context that provides more insights on the event that occurred</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogEvent(this ILogger logger, string name, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(name, nameof(name));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
 
             context = context ?? new Dictionary<string, object>();
 
@@ -666,14 +994,16 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs a custom metric
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the metric.</param>
         /// <param name="name">Name of the metric</param>
         /// <param name="value">Value of the metric</param>
         /// <param name="context">Context that provides more insights on the event that occurred</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogMetric(this ILogger logger, string name, double value, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(name, nameof(name));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
 
             context = context ?? new Dictionary<string, object>();
 
@@ -683,15 +1013,17 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs a custom metric
         /// </summary>
-        /// <param name="logger">Logger to use</param>
+        /// <param name="logger">The logger to track the metric.</param>
         /// <param name="name">Name of the metric</param>
         /// <param name="value">Value of the metric</param>
         /// <param name="timestamp">Timestamp of the metric</param>
         /// <param name="context">Context that provides more insights on the event that occurred</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogMetric(this ILogger logger, string name, double value, DateTimeOffset timestamp, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(name, nameof(name));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
 
             context = context ?? new Dictionary<string, object>();
 
@@ -701,13 +1033,15 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         ///     Logs an event related to an security activity (i.e. input validation, authentication, authorization...).
         /// </summary>
-        /// <param name="logger">The logger to use.</param>
-        /// <param name="name">The user message written.</param>
+        /// <param name="logger">The logger to track the security event.</param>
+        /// <param name="name">The name of the security event written.</param>
         /// <param name="context">The context that provides more insights on the event that occurred.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogSecurityEvent(this ILogger logger, string name, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger));
-            Guard.NotNullOrWhitespace(name, nameof(name));
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name of the event to track an security event");
 
             context = context ?? new Dictionary<string, object>();
             context["EventType"] = "Security";

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -18,9 +18,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
     [Trait("Category", "Unit")]
     public class ILoggerExtensionsTests
     {
+        private const string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
+        
         private readonly Faker _bogusGenerator = new Faker();
-
-        private string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
 
         [Fact]
         public void LogMetric_ValidArguments_Succeeds()
@@ -124,6 +124,51 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogDependency_WithoutDependencyType_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = null;
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, startTime, duration));
+        }
+        
+        [Fact]
+        public void LogDependency_WithoutDependencyData_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            object dependencyData = null;
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, startTime, duration));
+        }
+        
+        [Fact]
+        public void LogDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
         public void LogDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
         {
             // Arrange
@@ -147,6 +192,49 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+        }
+        
+        [Fact]
+        public void LogDependencyWithDependencyMeasurement_WithoutDependencyMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Lorem.Word();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, measurement: null));
+        }
+        
+        [Fact]
+        public void LogDependencyWithDependencyMeasurement_WithoutDependencyType_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = null;
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DependencyMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, measurement));
+        }
+        
+        [Fact]
+        public void LogDependencyWithDependencyMeasurement_WithoutDependencyData_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            object dependencyData = null;
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DependencyMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, isSuccessful, measurement));
         }
 
         [Fact]
@@ -172,6 +260,70 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+        }
+        
+        [Fact]
+        public void LogDependencyTarget_WithoutDependencyType_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = null;
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogDependencyTarget_WithoutDependencyData_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            object dependencyData = null;
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogDependencyTarget_WithoutTarget_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = null;
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogDependencyTarget_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -200,6 +352,52 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
+        
+        [Fact]
+        public void LogDependencyTargetWithDependencyMeasurement_WithoutDependencyType_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = null;
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DependencyMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, measurement));
+        }
+
+        [Fact]
+        public void LogDependencyTargetWithDependencyMeasurement_WithoutDependencyData_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            object dependencyData = null;
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DependencyMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, measurement));
+        }
+
+        [Fact]
+        public void LogDependencyTargetWithDependencyMeasurement_WithoutDependencyMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Lorem.Word();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, measurement: null));
+        }
 
         [Theory]
         [ClassData(typeof(ValidAzureKeyVaultSecretNames))]
@@ -214,31 +412,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             // Act
             logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, startTime, duration);
-
-            // Assert
-            string logMessage = logger.WrittenMessage;
-            Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
-            Assert.Contains(vaultUri, logMessage);
-            Assert.Contains(secretName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
-            Assert.Contains(duration.ToString(), logMessage);
-        }
-
-        [Theory]
-        [ClassData(typeof(ValidAzureKeyVaultSecretNames))]
-        public void LogAzureKeyVaultDependency_WithValidSecretNameDependencyMeasurement_Succeeds(string secretName)
-        {
-            // Arrange
-            var logger = new TestLogger();
-            var vaultUri = "https://myvault.vault.azure.net";
-            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
-            DependencyMeasurement measurement = DependencyMeasurement.Start();
-            DateTimeOffset startTime = measurement.StartTime;
-            measurement.Dispose();
-            TimeSpan duration = measurement.Elapsed;
-
-            // Act
-            logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, measurement);
 
             // Assert
             string logMessage = logger.WrittenMessage;
@@ -272,7 +445,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogAzureKeyVaultDependency("https://my-vault.vault.azure.net", secretName, isSuccessful: true, startTime: DateTimeOffset.UtcNow, duration: TimeSpan.FromSeconds(value: 5)));
         }
-        
+
         [Theory]
         [ClassData(typeof(InvalidAzureKeyVaultSecretNames))]
         public void LogAzureKeyVaultDependency_WithInvalidSecretName_Fails(string secretName)
@@ -294,6 +467,43 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Act / Assert
             Assert.Throws<UriFormatException>(
                 () => logger.LogAzureKeyVaultDependency("https://vault-without-vault.azure.net-suffix", "MySecret", isSuccessful: true, startTime: DateTimeOffset.UtcNow, duration: TimeSpan.FromSeconds(5)));
+        }
+        
+        [Fact]
+        public void LogAzureKeyVaultDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            
+            // Act / Assert
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => logger.LogAzureKeyVaultDependency("https://my-vault.vault.azure.net", "MySecret", isSuccessful: true, startTime: DateTimeOffset.UtcNow, duration: duration));
+        }
+
+        [Theory]
+        [ClassData(typeof(ValidAzureKeyVaultSecretNames))]
+        public void LogAzureKeyVaultDependency_WithValidSecretNameDependencyMeasurement_Succeeds(string secretName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var vaultUri = "https://myvault.vault.azure.net";
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DependencyMeasurement measurement = DependencyMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, measurement);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(vaultUri, logMessage);
+            Assert.Contains(secretName, logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
         }
 
         [Theory]
@@ -368,6 +578,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogAzureSearchDependencyWithDependencyMeasurement_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string searchServiceName = _bogusGenerator.Commerce.Product();
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogAzureSearchDependency(searchServiceName, operationName, isSuccessful, startTime, duration));
+        }
+        
+        [Fact]
         public void LogAzureSearchDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
         {
             // Arrange
@@ -415,6 +640,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogServiceBusDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            const ServiceBusEntityType entityType = ServiceBusEntityType.Queue;
+            string entityName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            var startTime = DateTimeOffset.UtcNow;
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusDependency(entityName, isSuccessful, startTime, duration, entityType));
         }
 
         [Fact]
@@ -467,6 +707,20 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogServiceBusQueueDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            var startTime = DateTimeOffset.UtcNow;
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
         public void LogServiceBusQueueDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
         {
             // Arrange
@@ -512,6 +766,20 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+        }
+        
+        [Fact]
+        public void LogServiceBusTopicDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string topicName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            var startTime = DateTimeOffset.UtcNow;
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusTopicDependency(topicName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -568,6 +836,23 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogSqlDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = _bogusGenerator.Name.FullName();
+            string databaseName = _bogusGenerator.Name.FullName();
+            string tableName = _bogusGenerator.Name.FullName();
+            string operationName = _bogusGenerator.Name.FullName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, tableName, operationName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
         public void LogBlobStorageDependency_ValidArguments_Succeeds()
         {
             // Arrange
@@ -589,6 +874,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+        }
+        
+        [Fact]
+        public void LogBlobStorageDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string containerName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -643,6 +943,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogTableStorageDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
         public void LogTableStorageDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
         {
             // Arrange
@@ -691,6 +1006,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogEventHubsDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string eventHubName = _bogusGenerator.Commerce.ProductName();
+            string namespaceName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogEventHubsDependency(namespaceName, eventHubName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -744,6 +1074,20 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogIoTHubDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string iotHubName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogIotHubDependency(iotHubName: iotHubName, isSuccessful: isSuccessful, startTime: startTime, duration: duration));
+        }
+
+        [Fact]
         public void LogIotHubDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
         {
             // Arrange
@@ -793,6 +1137,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+        }
+        
+        [Fact]
+        public void LogIoTHubConnectionStringDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string iotHubName = _bogusGenerator.Commerce.ProductName().Replace(" ", String.Empty);
+            string deviceId = _bogusGenerator.Internet.Ip();
+            string sharedAccessKey = _bogusGenerator.Random.Hash();
+            var iotHubConnectionString = $"HostName={iotHubName}.;DeviceId={deviceId};SharedAccessKey={sharedAccessKey}";
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogIotHubDependency(iotHubConnectionString: iotHubConnectionString, isSuccessful: isSuccessful, startTime: startTime, duration: duration));
         }
 
         [Fact]
@@ -848,6 +1210,22 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogCosmosSqlDependency_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string container = _bogusGenerator.Commerce.ProductName();
+            string database = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogCosmosSqlDependency(accountName, database, container, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -924,7 +1302,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             bool isSuccessful = _bogusGenerator.Random.Bool();
             DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
             var duration = _bogusGenerator.Date.Timespan();
-            
 
             // Act
             logger.LogSqlDependency(connectionString, tableName, operationName, startTime, duration, isSuccessful);
@@ -942,7 +1319,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void LogSqlDependencyWithDependencyMeasurementConnectionString_ValidArguments_Succeeds()
+        public void LogSqlDependencyConnectionString_WithNegativeDuration_Fails()
         {
             // Arrange
             var logger = new TestLogger();
@@ -952,25 +1329,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             string tableName = _bogusGenerator.Name.FullName();
             string operationName = _bogusGenerator.Name.FullName();
             bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
 
-            var measurement = DependencyMeasurement.Start(operationName);
-            DateTimeOffset startTime = measurement.StartTime;
-            measurement.Dispose();
-            TimeSpan duration = measurement.Elapsed;
-
-            // Act
-            logger.LogSqlDependency(connectionString, tableName, operationName, measurement, isSuccessful);
-
-            // Assert
-            var logMessage = logger.WrittenMessage;
-            Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
-            Assert.Contains(serverName, logMessage);
-            Assert.Contains(databaseName, logMessage);
-            Assert.Contains(tableName, logMessage);
-            Assert.Contains(operationName, logMessage);
-            Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
-            Assert.Contains(duration.ToString(), logMessage);
+                // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(connectionString, tableName, operationName, startTime, duration, isSuccessful));
         }
 
         [Theory]
@@ -1079,6 +1442,38 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogSqlDependencyWithDependencyMeasurementConnectionString_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = _bogusGenerator.Name.FullName();
+            string databaseName = _bogusGenerator.Name.FullName();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string tableName = _bogusGenerator.Name.FullName();
+            string operationName = _bogusGenerator.Name.FullName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+
+            var measurement = DependencyMeasurement.Start(operationName);
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogSqlDependency(connectionString, tableName, operationName, measurement, isSuccessful);
+
+            // Assert
+            var logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
+            Assert.Contains(serverName, logMessage);
+            Assert.Contains(databaseName, logMessage);
+            Assert.Contains(tableName, logMessage);
+            Assert.Contains(operationName, logMessage);
+            Assert.Contains(isSuccessful.ToString(), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+        }
+
+        [Fact]
         public void LogHttpDependency_ValidArguments_Succeeds()
         {
             // Arrange
@@ -1104,31 +1499,17 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void LogHttpDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
+        public void LogHttpDependency_WithNegativeDuration_Fails()
         {
             // Arrange
             var logger = new TestLogger();
             var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.Url());
             var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = GeneratePositiveDuration().Negate();
 
-            using (var measurement = DependencyMeasurement.Start())
-            {
-                DateTimeOffset startTime = measurement.StartTime;
-
-                // Act
-                logger.LogHttpDependency(request, statusCode, measurement);
-
-                // Assert
-                var logMessage = logger.WrittenMessage;
-                Assert.StartsWith(MessagePrefixes.DependencyViaHttp, logMessage);
-                Assert.Contains(request.RequestUri.Host, logMessage);
-                Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
-                Assert.Contains(request.Method.ToString(), logMessage);
-                Assert.Contains(((int)statusCode).ToString(), logMessage);
-                Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
-                var isSuccessful = (int)statusCode >= 200 && (int)statusCode < 300;
-                Assert.Contains($"Successful: {isSuccessful}", logMessage); 
-            }
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogHttpDependency(request, statusCode, startTime, duration));
         }
 
         [Fact]
@@ -1143,6 +1524,34 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             // Act & Arrange
             Assert.Throws<ArgumentNullException>(() => logger.LogHttpDependency(request, statusCode, startTime, duration));
+        }
+
+        [Fact]
+        public void LogHttpDependencyWithDependencyMeasurement_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.Url());
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var measurement = DependencyMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogHttpDependency(request, statusCode, measurement);
+
+            // Assert
+            var logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.DependencyViaHttp, logMessage);
+            Assert.Contains(request.RequestUri.Host, logMessage);
+            Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
+            Assert.Contains(request.Method.ToString(), logMessage);
+            Assert.Contains(((int) statusCode).ToString(), logMessage);
+            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+            var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
+            Assert.Contains($"Successful: {isSuccessful}", logMessage);
         }
 
         [Fact]
@@ -1202,52 +1611,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void LogRequestMessage_ValidArgumentsIncludingResponse_Succeeds()
+        public void LogRequest_WithNegativeDuration_Fails()
         {
             // Arrange
             var logger = new TestLogger();
-            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
-            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
-            var host = _bogusGenerator.Name.FirstName().ToLower();
+            var statusCode = (int)_bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Lorem.Word()}";
+            var host = _bogusGenerator.Lorem.Word();
             var method = HttpMethod.Head;
-            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
-            var response = new HttpResponseMessage(statusCode);
-            var duration = _bogusGenerator.Date.Timespan();
+            var mockRequest = new Mock<HttpRequest>();
+            mockRequest.Setup(request => request.Method).Returns(method.ToString());
+            mockRequest.Setup(request => request.Host).Returns(new HostString(host));
+            mockRequest.Setup(request => request.Path).Returns(path);
+            var mockResponse = new Mock<HttpResponse>();
+            mockResponse.Setup(response => response.StatusCode).Returns(statusCode);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
 
-            // Act;
-            logger.LogRequest(request, response, duration);
-
-            // Assert
-            var logMessage = logger.WrittenMessage;
-            Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
-            Assert.Contains(path, logMessage);
-            Assert.Contains(host, logMessage);
-            Assert.Contains(((int)statusCode).ToString(), logMessage);
-            Assert.Contains(method.ToString(), logMessage);
-        }
-
-        [Fact]
-        public void LogRequestMessage_ValidArgumentsIncludingResponseStatusCode_Succeeds()
-        {
-            // Arrange
-            var logger = new TestLogger();
-            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
-            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
-            var host = _bogusGenerator.Name.FirstName().ToLower();
-            var method = HttpMethod.Head;
-            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
-            var duration = _bogusGenerator.Date.Timespan();
-
-            // Act;
-            logger.LogRequest(request, statusCode, duration);
-
-            // Assert
-            var logMessage = logger.WrittenMessage;
-            Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
-            Assert.Contains(path, logMessage);
-            Assert.Contains(host, logMessage);
-            Assert.Contains(((int)statusCode).ToString(), logMessage);
-            Assert.Contains(method.ToString(), logMessage);
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(mockRequest.Object, mockResponse.Object, duration));
         }
 
         [Fact]
@@ -1305,6 +1686,23 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Arrange
             var logger = new TestLogger();
             var statusCode = (int)_bogusGenerator.PickRandom<HttpStatusCode>();
+            HttpRequest request = null;
+            var mockResponse = new Mock<HttpResponse>();
+            mockResponse.Setup(response => response.StatusCode).Returns(statusCode);
+            var duration = _bogusGenerator.Date.Timespan();
+
+            // Act & Arrange
+            Assert.Throws<ArgumentNullException>(() => logger.LogRequest(request, mockResponse.Object, duration));
+        }
+        
+        [Fact]
+        public void LogRequest_OutsideResponseStatusCodeRange_ThrowsException()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = _bogusGenerator.PickRandom(
+                _bogusGenerator.Random.Int(max: -1), 
+                _bogusGenerator.Random.Int(min: 1000));
             HttpRequest request = null;
             var mockResponse = new Mock<HttpResponse>();
             mockResponse.Setup(response => response.StatusCode).Returns(statusCode);
@@ -1371,6 +1769,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogRequest_OutsideResponseStatusCodeRangeWhenPassingResponseStatusCode_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var request = new Mock<HttpRequest>();
+            var statusCode = _bogusGenerator.PickRandom(
+                _bogusGenerator.Random.Int(max: -1), 
+                _bogusGenerator.Random.Int(min: 1000));
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => logger.LogRequest(request.Object, statusCode, duration));
+        }
+        
+        [Fact]
         public void LogRequest_NoResponseWasSpecified_ThrowsException()
         {
             // Arrange
@@ -1390,14 +1803,86 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
-        public void LogSecurityEvent_WithNoEventName_ThrowsException()
+        public void LogRequestMessage_ValidArgumentsIncludingResponse_Succeeds()
         {
             // Arrange
             var logger = new TestLogger();
-            string eventName = null;
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            var host = _bogusGenerator.Name.FirstName().ToLower();
+            var method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            var response = new HttpResponseMessage(statusCode);
+            var duration = _bogusGenerator.Date.Timespan();
+
+            // Act;
+            logger.LogRequest(request, response, duration);
+
+            // Assert
+            var logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(path, logMessage);
+            Assert.Contains(host, logMessage);
+            Assert.Contains(((int)statusCode).ToString(), logMessage);
+            Assert.Contains(method.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogRequestMessage_ValidArgumentsIncludingResponseStatusCode_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            var host = _bogusGenerator.Name.FirstName().ToLower();
+            var method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            var duration = _bogusGenerator.Date.Timespan();
+
+            // Act;
+            logger.LogRequest(request, statusCode, duration);
+
+            // Assert
+            var logMessage = logger.WrittenMessage;
+            Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(path, logMessage);
+            Assert.Contains(host, logMessage);
+            Assert.Contains(((int)statusCode).ToString(), logMessage);
+            Assert.Contains(method.ToString(), logMessage);
+        }
+
+        [Fact]
+        public void LogRequestMessage_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            var host = _bogusGenerator.Name.FirstName().ToLower();
+            var method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request, statusCode, duration));
+        }
+        
+        [Fact]
+        public void LogRequestMessage_OutsideResponseStatusCodeRange_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (HttpStatusCode) _bogusGenerator.PickRandom(
+                _bogusGenerator.Random.Int(max: -1), 
+                _bogusGenerator.Random.Int(min: 1000));
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            var host = _bogusGenerator.Name.FirstName().ToLower();
+            var method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => logger.LogSecurityEvent(eventName));
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request, statusCode, duration));
         }
 
         [Fact]
@@ -1437,6 +1922,28 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(message, logMessage);
             Assert.Contains("[EventType, Security]", logMessage);
             Assert.Contains("[Property, something was wrong with this Property]", logMessage);
+        }
+
+        [Fact]
+        public void LogSecurityEvent_WithNoEventName_ThrowsException()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string eventName = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => logger.LogSecurityEvent(eventName));
+        }
+
+        private TimeSpan GeneratePositiveDuration()
+        {
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            if (duration < TimeSpan.Zero)
+            {
+                return duration.Negate();
+            }
+
+            return duration;
         }
     }
 }


### PR DESCRIPTION
Adds some additional guard checks to guard against negative time durations, response status codes outsides bounds of the enumeration, and missing blank checks for textual information.

Closes #201 