### PR TITLE
feat: log telemetry as structured value models for Serilog formatting

### DIFF
--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -64,7 +64,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogBlobStorageDependency(accountName: "multimedia", containerName: "images", isSuccessful: true, startTime, durationMeasurement.Elapsed);
-// Output: "Dependency DependencyLogTarget {DependencyType: Azure blob multimedia named images in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure blob",  "DependencyName": "images", "TargetName": "multimedia", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring Azure Cosmos DB dependencies
@@ -85,7 +85,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogCosmosSqlDependency(accountName: "administration", database: "docs", container: "purchases", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure DocumentDB docs/purchases named administration in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure DocumentDB", "DependencyData": "docs/purchases", "TargetName": "administration", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful" true, "Context": {}}
 ```
 
 ### Measuring Azure Event Hubs dependencies
@@ -104,7 +104,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogEventHubsDependency(namespaceName: "be.sensors.contoso", eventHubName: "temperature", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure Event Hubs be.sensors.contoso named temerature in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: "Dependency {"DependencyType": "Azure Event Hubs", "DependencyData": "be.sensors.contoso", "TargetName": "temerature", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring Azure IoT Hub dependencies
@@ -125,7 +125,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogIotHubDependency(iotHubName: "sensors", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure IoT Hub named sensors in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure IoT Hub", "TargetName": "sensors", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 Or, alternatively you can pass allong the IoT connection string itself so the host name will be selected for you.
@@ -152,7 +152,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogIotHubDependency(iotHubConnectionString: "Hostname=sensors;", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure IoT Hub named sensors in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure IoT Hub", "TargetName": "sensors", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring Azure Key Vault dependencies
@@ -173,7 +173,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.AzureKeyVaultDependency(vaultUri: "https://my-secret-store.vault.azure.net", secretName: "ServiceBus-ConnectionString", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure key vault get secret named https://my-secret-store.vault.azure.net in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure key vault", "DependencyData": "ServiceBus-ConnectionString", "TargetName": "https://my-secret-store.vault.azure.net", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring Azure Search dependencies
@@ -192,7 +192,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogAzureSearchDependency(searchServiceName: "orders-search", operationName: "get-orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure Search get-orders named orders-search in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure Search", "DependencyData": "get-orders", "TargetName": "orders-search", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 
 ### Measuring Azure Service Bus dependencies
 
@@ -207,10 +207,10 @@ var durationMeasurement = new Stopwatch();
 
 // Start measuring
 durationMeasurement.Start();
-var startTime = DateTimeOffset.UtcNow;
+var startTime = DateTimeOffset.UtcNow
 
 logger.LogServiceBusQueueDependency(queueName: "ordersqueue", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure Service Bus Queue named ordersqueue in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure Service Bus", "TargetName": "ordersqueue", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {"EntityType": "Queue"}}
 ```
 
 Note that we have an `LogServiceBusTopicDependency` to log dependency logs for an Azure Service Bus Topic and an `LogServiceBusDependency` to log Azure Service Bus logs where the entity type is not known.
@@ -231,7 +231,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogTableStorageDependency(accountName: "orderAccount", tableName: "orders", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency Azure table orders named orderAccount in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "Azure table", "DependencyData": "orders", "TargetName": "orderAccount", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring HTTP dependencies
@@ -256,7 +256,7 @@ var startTime = DateTimeOffset.UtcNow;
 var response = await httpClient.SendAsync(request);
 
 logger.LogHttpDependency(request, statusCode: response.StatusCode, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "HTTP Dependency requestbin.net for POST /r/ujxglouj completed with 200 in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: HTTP Dependency {"DependencyType" "Http", "DependencyName": "POST /r/ujxglouj", "TargetName": "requestbin.net", "ResultCode": 200, "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring SQL dependencies
@@ -276,7 +276,7 @@ durationMeasurement.Start();
 var products = await _repository.GetProducts();
 
 logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
+// Output: SQL Dependency {"DependencyType": "Sql", "DependencyName": "sample-database/my-table", "DependencyData": "get-products", "TargetName": "sample-server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
@@ -305,7 +305,7 @@ durationMeasurement.Start();
 var products = await _repository.GetProducts();
 
 logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessful: true, measurement: measurement);
-// Output: "SQL Dependency sample-server for sample-database/my-table for operation get-products in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
+// Output: SQL Dependency {"DependencyType": "Sql", "DependencyName": "sample-database/my-table", "DependencyData": "get-products", "TargetName": "sample-server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring custom dependencies
@@ -325,7 +325,7 @@ string dependencyName = "SendGrid";
 object dependencyData = "http://my.sendgrid.uri/"
 
 logger.LogDependency("SendGrid", dependencyData, isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: "Dependency SendGrid http://my.sendgrid.uri/ in 00:00:01.2396312 at 03/23/2020 09:32:02 +00:00 (Successful: True - Context: )"
+// Output: Dependency {"DependencyType": "SendGrid", "DependencyData": "http://my.sendgrid.uri/", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Making it easier to measure dependencies
@@ -397,7 +397,7 @@ Here is how you can report an `Order Created` event:
 using Microsoft.Extensions.Logging;
 
 logger.LogEvent("Order Created");
-// Output: "Events Order Created (Context: )"
+// Output: Events {"Name": "Order Created", "Context": {}}
 ```
 
 ### Security Events
@@ -410,7 +410,7 @@ Here is how an invalid `Order` can be reported:
 using Microsoft.Extensions.Logging;
 
 loger.LogSecurityEvent("Invalid Order");
-// Output: "Events Invalid Order (Context: )"
+// Output: Events {"Name": "Invalid Order", "Context": {"EventType": "Security"}}
 ```
 
 ## Metrics
@@ -423,7 +423,7 @@ Here is how you can report an `Invoice Received` metric:
 using Microsoft.Extensions.Logging;
 
 logger.LogMetric("Invoice Received", 133.37, telemetryContext);
-// Output: "Metric Invoice Received: 133.37 (Context: )"
+// Output: Metric {"Name": "Invoice Received", "Value": 133.37, "Timestamp": "03/23/2020 09:32:02 +00:00", "Context: {}}
 ```
 
 ## Requests
@@ -458,7 +458,7 @@ var stopWatch = Stopwatch.StartNew();
 await _next(httpContext);
 
 logger.LogRequest(httpContext.Request, httpContext.Response, stopWatch.Elapsed);
-// Output: "HTTP Request GET http://localhost:5000//weatherforecast completed with 200 in 00:00:00.0191554 at 03/23/2020 10:12:55 +00:00 - (Context: )"
+// Output: HTTP Request {"RequestMethod": "GET", "RequestHost": "http://localhost:5000/", "RequestUri": "http://localhost:5000/weatherforecast", "ResponseStatusCode": 200, "RequestDuration": "00:00:00.0191554", "RequestTime": "03/23/2020 10:12:55 +00:00", "Context": {}}
 ```
 
 [&larr; back](/)

--- a/docs/preview/features/writing-different-telemetry-types.md
+++ b/docs/preview/features/writing-different-telemetry-types.md
@@ -64,7 +64,7 @@ durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
 logger.LogBlobStorageDependency(accountName: "multimedia", containerName: "images", isSuccessful: true, startTime, durationMeasurement.Elapsed);
-// Output: "Dependency Azure blob multimedia named images in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
+// Output: "Dependency DependencyLogTarget {DependencyType: Azure blob multimedia named images in 00:00:00.2521801 at 03/23/2020 09:56:31 +00:00 (Successful: True - Context: )"
 ```
 
 ### Measuring Azure Cosmos DB dependencies

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
 using GuardNet;
 using Microsoft.AspNetCore.Http;
 
@@ -74,7 +75,7 @@ namespace Microsoft.Extensions.Logging
             PathString resourcePath = request.Path;
             var host = $"{request.Scheme}://{request.Host}";
 
-            logger.LogWarning(MessageFormats.RequestFormat, request.Method, host, resourcePath, responseStatusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
+            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, responseStatusCode, duration, context));
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -15,6 +15,7 @@ namespace Arcus.Observability.Telemetry.Core
 
         public static class DependencyTracking
         {
+            public const string DependencyLogEntry = "Dependency";
             public const string DependencyType = "DependencyType";
             public const string TargetName = "DependencyTargetName";
             public const string DependencyName = "DependencyName";
@@ -32,6 +33,7 @@ namespace Arcus.Observability.Telemetry.Core
 
         public static class EventTracking
         {
+            public const string EventLogEntry = "Event";
             public const string EventName = "EventName";
             
             [Obsolete("Use " + nameof(ContextProperties) + "." + nameof(TelemetryContext) + " instead")]
@@ -54,6 +56,7 @@ namespace Arcus.Observability.Telemetry.Core
 
         public static class RequestTracking
         {
+            public const string RequestLogEntry = "Request";
             public const string RequestMethod = "RequestMethod";
             public const string RequestHost = "RequestHost";
             public const string RequestUri = "RequestUri";
@@ -64,6 +67,7 @@ namespace Arcus.Observability.Telemetry.Core
 
         public static class MetricTracking
         {
+            public const string MetricLogEntry = "Metric";
             public const string MetricName = "MetricName";
             public const string MetricValue = "MetricValue";
             public const string Timestamp = "Timestamp";

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
 using GuardNet;
 using static Arcus.Observability.Telemetry.Core.MessageFormats;
 
@@ -100,8 +101,7 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(
-                RequestFormat, request.Method, host, resourcePath, statusCode, duration, DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
+            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, statusCode, duration, context));
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
-        /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
+        /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
-        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">
@@ -173,7 +173,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="targetName">Name of the dependency target</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
-        /// <param name="measurement">Measuring the latency to call the Service Bus dependency</param>
+        /// <param name="measurement">Measuring the latency to call the dependency</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="targetName">Name of dependency target</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
-        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
         /// <exception cref="ArgumentNullException">
@@ -229,8 +229,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyFormat, dependencyType, dependencyData, targetName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType, 
+                dependencyName: null, 
+                dependencyData: dependencyData, 
+                targetName: targetName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null,
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -306,8 +314,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
             
-            logger.LogWarning(
-                DependencyFormat, "Azure key vault", secretName, vaultUri, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure key vault", 
+                dependencyName: null, 
+                dependencyData: secretName, 
+                targetName: vaultUri, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null,
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -367,8 +383,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyFormat, "Azure Search", operationName, searchServiceName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure Search", 
+                dependencyName: null, 
+                dependencyData: operationName, 
+                targetName: searchServiceName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null, 
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -524,9 +548,18 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
             
             context = context ?? new Dictionary<string, object>();
+            context[ContextProperties.DependencyTracking.ServiceBus.EntityType] = entityType;
 
-            logger.LogWarning(
-                ServiceBusDependencyFormat, "Azure Service Bus", entityType, entityName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure Service Bus", 
+                dependencyName: null, 
+                dependencyData: null, 
+                targetName: entityName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null,
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -585,8 +618,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyFormat, "Azure blob", containerName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure blob", 
+                dependencyName: null, 
+                dependencyData: containerName, 
+                targetName: accountName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null,
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -645,8 +686,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyFormat, "Azure table", tableName, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure table",
+                dependencyName: null,
+                dependencyData: tableName,
+                targetName: accountName,
+                duration: duration,
+                startTime: startTime,
+                resultCode: null,
+                isSuccessful: isSuccessful,
+                context: context));
         }
 
         /// <summary>
@@ -705,8 +754,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyFormat, "Azure Event Hubs", namespaceName, eventHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure Event Hubs",
+                dependencyName: null,
+                dependencyData: namespaceName,
+                targetName: eventHubName,
+                duration: duration,
+                startTime: startTime,
+                resultCode: null,
+                isSuccessful: isSuccessful,
+                context: context));
         }
 
         /// <summary>
@@ -759,8 +816,7 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(
-                DependencyWithoutDataFormat, "Azure IoT Hub", iotHubName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry("Azure IoT Hub", dependencyName: null, dependencyData: null, targetName: iotHubName, duration: duration, startTime: startTime, resultCode: null, isSuccessful: isSuccessful, context: context));
         }
 
         /// <summary>
@@ -826,8 +882,7 @@ namespace Microsoft.Extensions.Logging
             context = context ?? new Dictionary<string, object>();
             string data = $"{database}/{container}";
 
-            logger.LogWarning(
-                DependencyFormat, "Azure DocumentDB", data, accountName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry("Azure DocumentDB", dependencyName: null, dependencyData: data, targetName: accountName, duration: duration, startTime: startTime, resultCode: null, isSuccessful: isSuccessful, context: context));
         }
 
         /// <summary>
@@ -896,8 +951,16 @@ namespace Microsoft.Extensions.Logging
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
             bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
 
-            logger.LogWarning(
-                HttpDependencyFormat, targetName, dependencyName, (int) statusCode, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(HttpDependencyFormat, new DependencyLogEntry(
+                dependencyType: "Http",
+                dependencyName: dependencyName, 
+                dependencyData: null,
+                targetName: targetName,
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: (int) statusCode, 
+                isSuccessful: isSuccessful,
+                context: context));
         }
 
         /// <summary>
@@ -969,8 +1032,16 @@ namespace Microsoft.Extensions.Logging
 
             string dependencyName = $"{databaseName}/{tableName}";
 
-            logger.LogWarning(
-                SqlDependencyFormat, serverName, dependencyName, operationName, duration, startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), isSuccessful, context);
+            logger.LogWarning(SqlDependencyFormat, new DependencyLogEntry(
+                dependencyType: "Sql",
+                targetName: serverName,
+                dependencyName: dependencyName, 
+                dependencyData: operationName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null,
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -988,7 +1059,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(EventFormat, name, context);
+            logger.LogWarning(EventFormat, new EventLogEntry(name, context));
         }
 
         /// <summary>
@@ -1027,7 +1098,7 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(MetricFormat, name, value, timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat), context);
+            logger.LogWarning(MetricFormat, new MetricLogEntry(name, value, timestamp, context));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -816,7 +816,16 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
-            logger.LogWarning(DependencyFormat, new DependencyLogEntry("Azure IoT Hub", dependencyName: null, dependencyData: null, targetName: iotHubName, duration: duration, startTime: startTime, resultCode: null, isSuccessful: isSuccessful, context: context));
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure IoT Hub", 
+                dependencyName: null, 
+                dependencyData: null, 
+                targetName: iotHubName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null, 
+                isSuccessful: isSuccessful, 
+                context: context));
         }
 
         /// <summary>
@@ -882,7 +891,17 @@ namespace Microsoft.Extensions.Logging
             context = context ?? new Dictionary<string, object>();
             string data = $"{database}/{container}";
 
-            logger.LogWarning(DependencyFormat, new DependencyLogEntry("Azure DocumentDB", dependencyName: null, dependencyData: data, targetName: accountName, duration: duration, startTime: startTime, resultCode: null, isSuccessful: isSuccessful, context: context));
+            logger.LogWarning(DependencyFormat, new DependencyLogEntry(
+                dependencyType: "Azure DocumentDB", 
+                dependencyName: null, 
+                dependencyData: data, 
+                targetName: accountName, 
+                duration: duration, 
+                startTime: startTime, 
+                resultCode: null, 
+                isSuccessful: 
+                isSuccessful, 
+                context: context));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
@@ -3,6 +3,10 @@
 // ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
+    /// <summary>
+    /// Extensions on the <see cref="IReadOnlyDictionary{TKey,TValue}"/> to get more easily access to the the items' values.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
     public static class IReadOnlyDictionaryExtensions
     {
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/FormatSpecifiers.cs
+++ b/src/Arcus.Observability.Telemetry.Core/FormatSpecifiers.cs
@@ -1,5 +1,8 @@
 ﻿namespace Arcus.Observability.Telemetry.Core
 {
+    /// <summary>
+    /// Represents the all formatting used when logging telemetry instances.
+    /// </summary>
     public static class FormatSpecifiers
     {
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Logging
+{
+    /// <summary>
+    /// Represents a custom dependency as a logging entry.
+    /// </summary>
+    public class DependencyLogEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyLogEntry"/> class.
+        /// </summary>
+        /// <param name="dependencyType">The custom type of dependency.</param>
+        /// <param name="dependencyName">The name of the dependency.</param>
+        /// <param name="dependencyData">The custom data of dependency.</param>
+        /// <param name="targetName">The name of dependency target.</param>
+        /// <param name="resultCode">The code of the result of the interaction with the dependency.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="startTime">The point in time when the interaction with the HTTP dependency was started.</param>
+        /// <param name="duration">The duration of the operation.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="dependencyData"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public DependencyLogEntry(
+            string dependencyType,
+            string dependencyName,
+            object dependencyData,
+            string targetName, 
+            TimeSpan duration,
+            DateTimeOffset startTime,
+            int? resultCode,
+            bool isSuccessful,
+            IDictionary<string, object> context)
+        {
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+            
+            DependencyType = dependencyType;
+            DependencyName = dependencyName;
+            DependencyData = dependencyData;
+            TargetName = targetName;
+            ResultCode = resultCode;
+            IsSuccessful = isSuccessful;
+
+            StartTime = startTime.ToString(FormatSpecifiers.InvariantTimestampFormat);
+            Duration = duration;
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets the custom type of the dependency.
+        /// </summary>
+        public string DependencyType { get; }
+        
+        /// <summary>
+        /// Gets the name of the dependency.
+        /// </summary>
+        public string DependencyName { get; }
+        
+        /// <summary>
+        /// Gets the custom data of the dependency.
+        /// </summary>
+        public object DependencyData { get; }
+        
+        /// <summary>
+        /// Gets the name of the dependency target.
+        /// </summary>
+        public string TargetName { get; }
+        
+        /// <summary>
+        /// Gets the code of the result of the interaction with the dependency.
+        /// </summary>
+        public int? ResultCode { get; }
+        
+        /// <summary>
+        /// Gets the indication whether or not the operation was successful.
+        /// </summary>
+        public bool IsSuccessful { get; }
+        
+        /// <summary>
+        /// Gets the point in time when the interaction with the HTTP dependency was started.
+        /// </summary>
+        public string StartTime { get; }
+        
+        /// <summary>
+        /// Gets the duration of the operation.
+        /// </summary>
+        public TimeSpan Duration { get; }
+        
+        /// <summary>
+        /// Gets the context that provides more insights on the dependency that was measured.
+        /// </summary>
+        public IDictionary<string, object> Context { get; }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            string contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
+            return $"{DependencyType} {DependencyName} {DependencyData} named {TargetName} in {Duration} at {StartTime} " +
+                   $"(Successful: {IsSuccessful} - ResultCode: {ResultCode} - Context: {contextFormatted})";
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Logging
+{
+    /// <summary>
+    /// Represents an event as a log entry.
+    /// </summary>
+    public class EventLogEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventLogEntry" /> class.
+        /// </summary>
+        /// <param name="name">The name of the event.</param>
+        /// <param name="context">The context that provides more insights on the event that occurred.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        public EventLogEntry(string name, IDictionary<string, object> context)
+        {
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
+
+            EventName = name;
+            Context = context ?? new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Gets the name of the event.
+        /// </summary>
+        public string EventName { get; }
+        
+        /// <summary>
+        /// Gets the context that provides more insights on the event that occurred.
+        /// </summary>
+        public IDictionary<string, object> Context { get; }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            string contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
+            return $"{EventName} (Context: {contextFormatted})";
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Logging
+{
+    /// <summary>
+    /// Represents a metric as a log entry.
+    /// </summary>
+    public class MetricLogEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MetricLogEntry"/> class.
+        /// </summary>
+        /// <param name="name">The name of the metric.</param>
+        /// <param name="value">The value of the metric.</param>
+        /// <param name="timestamp">The timestamp of the metric.</param>
+        /// <param name="context">The context that provides more insights on the event that occurred.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        public MetricLogEntry(string name, double value, DateTimeOffset timestamp, IDictionary<string, object> context)
+        {
+            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
+            
+            MetricName = name;
+            MetricValue = value;
+            Timestamp = timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat);
+            Context = context ?? new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Gets the name of the metric.
+        /// </summary>
+        public string MetricName { get; }
+        
+        /// <summary>
+        /// Gets the value of the metric.
+        /// </summary>
+        public double MetricValue { get; }
+        
+        /// <summary>
+        /// Gets the timestamp of the metric.
+        /// </summary>
+        public string Timestamp { get; }
+        
+        /// <summary>
+        /// Gets the context that provides more insights on the event that occurred.
+        /// </summary>
+        public IDictionary<string, object> Context { get; }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            string contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
+            return $"{MetricName}: {MetricValue.ToString(CultureInfo.InvariantCulture)} at {Timestamp} (Context: {contextFormatted})";
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Logging
+{
+    /// <summary>
+    /// Represents a HTTP request as a log entry.
+    /// </summary>
+    public class RequestLogEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestLogEntry"/> class.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request.</param>
+        /// <param name="host">The host that was requested.</param>
+        /// <param name="uri">The URI of the request.</param>
+        /// <param name="statusCode">The HTTP status code returned by the service.</param>
+        /// <param name="duration">The duration of the processing of the request.</param>
+        /// <param name="context">The context that provides more insights on the HTTP request that was tracked.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="duration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="uri"/>'s URI is blank,
+        ///     the <paramref name="host"/> contains whitespace,
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="statusCode"/>'s status code is outside the 100-599 inclusively,
+        ///     the <paramref name="duration"/> is a negative time range.
+        /// </exception>
+        public RequestLogEntry(
+            string method, 
+            string host, 
+            string uri, 
+            int statusCode,
+            TimeSpan duration,
+            IDictionary<string, object> context)
+        {
+            Guard.For<ArgumentException>(() => host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
+            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            
+            RequestMethod = method;
+            RequestHost = host;
+            RequestUri = uri;
+            ResponseStatusCode = statusCode;
+            RequestDuration = duration;
+            RequestTime = DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat);
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets the HTTP method of the request.
+        /// </summary>
+        public string RequestMethod { get; }
+        
+        /// <summary>
+        /// Gets the host that was requested.
+        /// </summary>
+        public string RequestHost { get; }
+        
+        /// <summary>
+        /// Gets ths URI of the request.
+        /// </summary>
+        public string RequestUri { get; }
+        
+        /// <summary>
+        /// Gets the HTTP response status code that was returned by the service.
+        /// </summary>
+        public int ResponseStatusCode { get; }
+        
+        /// <summary>
+        /// Gets the duration of the processing of the request.
+        /// </summary>
+        public TimeSpan RequestDuration { get; }
+        
+        /// <summary>
+        /// Gets the date when the request occurred.
+        /// </summary>
+        public string RequestTime { get; }
+        
+        /// <summary>
+        /// Gets the context that provides more insights on the HTTP request that was tracked.
+        /// </summary>
+        public IDictionary<string, object> Context { get; }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            string contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
+            return $"{RequestMethod} {RequestHost}/{RequestUri} completed with {ResponseStatusCode} in {RequestDuration} at {RequestTime} - (Context: {contextFormatted})";
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/MessageFormats.cs
+++ b/src/Arcus.Observability.Telemetry.Core/MessageFormats.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Observability.Telemetry.Core.Logging;
 
 namespace Arcus.Observability.Telemetry.Core
 {
@@ -10,20 +11,13 @@ namespace Arcus.Observability.Telemetry.Core
         /// <summary>
         /// Gets the message format to log external dependencies; compatible with Application Insights 'Dependencies'.
         /// </summary>
-        public const string DependencyFormat =
-            MessagePrefixes.Dependency + " {"
-            + ContextProperties.DependencyTracking.DependencyType + "} {"
-            + ContextProperties.DependencyTracking.DependencyData + "} named {"
-            + ContextProperties.DependencyTracking.TargetName + "} in {"
-            + ContextProperties.DependencyTracking.Duration + "} at {"
-            + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
-            + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.TelemetryContext + "})";
+        public const string DependencyFormat = MessagePrefixes.Dependency + " {@" + ContextProperties.DependencyTracking.DependencyLogEntry + "}";
 
         /// <summary>
         /// Gets the message format to log external dependencies without any custom data value (<see cref="ContextProperties.DependencyTracking.DependencyData"/>);
         /// compatible with Application Insights 'Dependencies'.
         /// </summary>
+        [Obsolete("Dependencies without data will be logged as '" + nameof(DependencyLogEntry) + "' models instead of this sentence-like format")]
         public const string DependencyWithoutDataFormat =
             MessagePrefixes.Dependency + " {"
             + ContextProperties.DependencyTracking.DependencyType + "} named {"
@@ -36,8 +30,9 @@ namespace Arcus.Observability.Telemetry.Core
         /// <summary>
         /// Gets the message format to log Azure Service Bus dependencies; compatible with Application Insights 'Dependencies'.
         /// </summary>
+        [Obsolete("Dependencies without data will be logged as '" + nameof(DependencyLogEntry) + "' models instead of this sentence-like format")]
         public const string ServiceBusDependencyFormat =
-            MessagePrefixes.Dependency + " {"
+            MessagePrefixes.Dependency + " {" 
             + ContextProperties.DependencyTracking.DependencyType + "} {"
             + ContextProperties.DependencyTracking.ServiceBus.EntityType + "} named {"
             + ContextProperties.DependencyTracking.TargetName + "} in {"
@@ -49,58 +44,26 @@ namespace Arcus.Observability.Telemetry.Core
         /// <summary>
         /// Gets the message format to log HTTP dependencies; compatible with Application Insights 'Dependencies'.
         /// </summary>
-        public const string HttpDependencyFormat =
-            MessagePrefixes.DependencyViaHttp + " {"
-            + ContextProperties.DependencyTracking.TargetName + "} for {"
-            + ContextProperties.DependencyTracking.DependencyName + "} completed with {"
-            + ContextProperties.DependencyTracking.ResultCode + "} in {"
-            + ContextProperties.DependencyTracking.Duration + "} at {"
-            + ContextProperties.DependencyTracking.StartTime + "} (Successful: {"
-            + ContextProperties.DependencyTracking.IsSuccessful + "} - Context: {@"
-            + ContextProperties.TelemetryContext + "})";
+        public const string HttpDependencyFormat = MessagePrefixes.DependencyViaHttp + " {@" + ContextProperties.DependencyTracking.DependencyLogEntry + "}";
 
         /// <summary>
         /// Gets the message format to log SQL dependencies; compatible with Application Insights 'Dependencies'.
         /// </summary>
-        public const string SqlDependencyFormat =
-            MessagePrefixes.DependencyViaSql + " {" 
-            + ContextProperties.DependencyTracking.TargetName + "} for {"
-            + ContextProperties.DependencyTracking.DependencyName
-            + "} for operation {" + ContextProperties.DependencyTracking.DependencyData
-            + "} in {" + ContextProperties.DependencyTracking.Duration
-            + "} at {" + ContextProperties.DependencyTracking.StartTime
-            + "} (Successful: {" + ContextProperties.DependencyTracking.IsSuccessful
-            + "} - Context: {@" + ContextProperties.TelemetryContext + "})";
+        public const string SqlDependencyFormat = MessagePrefixes.DependencyViaSql + " {@" + ContextProperties.DependencyTracking.DependencyLogEntry + "}";
 
         /// <summary>
         /// Gets the message format to log events; compatible with Application Insights 'Events'.
         /// </summary>
-        public const string EventFormat = 
-            MessagePrefixes.Event + " {" 
-            + ContextProperties.EventTracking.EventName
-            + "} (Context: {@" + ContextProperties.TelemetryContext + "})";
-        
+        public const string EventFormat = MessagePrefixes.Event + " {@" + ContextProperties.EventTracking.EventLogEntry + "}";
+
         /// <summary>
         /// Gets the message format to log metrics; compatible with Application Insights 'Metrics'.
         /// </summary>
-        public const string MetricFormat =
-            MessagePrefixes.Metric + " {" 
-            + ContextProperties.MetricTracking.MetricName + "}: {" 
-            + ContextProperties.MetricTracking.MetricValue + "} at {"
-            + ContextProperties.MetricTracking.Timestamp
-            + "} (Context: {@" + ContextProperties.TelemetryContext + "})";
+        public const string MetricFormat = MessagePrefixes.Metric + " {@" + ContextProperties.MetricTracking.MetricLogEntry + "}";
         
         /// <summary>
         /// Gets the message format to log HTTP requests; compatible with Application Insights 'Requests'.
         /// </summary>
-        public const string RequestFormat =
-            MessagePrefixes.RequestViaHttp + " {"
-            + ContextProperties.RequestTracking.RequestMethod + "} {"
-            + ContextProperties.RequestTracking.RequestHost + "}/{" 
-            + ContextProperties.RequestTracking.RequestUri + "} completed with {"
-            + ContextProperties.RequestTracking.ResponseStatusCode + "} in {"
-            + ContextProperties.RequestTracking.RequestDuration + "} at {"
-            + ContextProperties.RequestTracking.RequestTime + "} - (Context: {@"
-            + ContextProperties.TelemetryContext + "})";
+        public const string RequestFormat = MessagePrefixes.RequestViaHttp + " {@" + ContextProperties.RequestTracking.RequestLogEntry + "}";
     }
 }

--- a/src/Arcus.Observability.Telemetry.Core/MessagePrefixes.cs
+++ b/src/Arcus.Observability.Telemetry.Core/MessagePrefixes.cs
@@ -1,12 +1,38 @@
 ﻿namespace Arcus.Observability.Telemetry.Core
 {
+    /// <summary>
+    /// Represents all the log message prefixes that are prepended when an telemetry instance gets logged.
+    /// </summary>
     public static class MessagePrefixes
     {
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights HTTP dependencies.
+        /// </summary>
         public const string DependencyViaHttp = "HTTP Dependency";
+        
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights SQL dependencies.
+        /// </summary>
         public const string DependencyViaSql = "SQL Dependency";
+        
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights custom dependencies.
+        /// </summary>
         public const string Dependency = "Dependency";
+        
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights Events.
+        /// </summary>
         public const string Event = "Events";
+        
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights Metrics.
+        /// </summary>
         public const string Metric = "Metric";
+        
+        /// <summary>
+        /// Gets the log message prefix when logging Azure Application Insights Requests.
+        /// </summary>
         public const string RequestViaHttp = "HTTP Request";
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using GuardNet;
 
 // ReSharper disable once CheckNamespace
@@ -11,6 +12,8 @@ namespace Serilog.Events
     /// </summary>
     public static class LogEventPropertyValueExtensions
     {
+        private static readonly StructureValue EmptyStructureValue = new StructureValue(new LogEventProperty[0]);
+        
         /// <summary>
         ///     Provide a string representation for a property key
         /// </summary>
@@ -149,6 +152,33 @@ namespace Serilog.Events
             var logEventPropertyValue = eventPropertyValues.GetAsRawString(propertyKey);
             var value = bool.Parse(logEventPropertyValue);
             return value;
+        }
+        
+        /// <summary>
+        /// Provide a <see cref="StructureValue"/> representation for a property value associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <param name="properties">The series of log properties, containing a <see cref="StructureValue"/> with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key that is associated with the property value that's an <see cref="StructureValue"/>.</param>
+        /// <returns>
+        ///     An <see cref="StructureValue"/> that contains its own name-value pair collection of the log event; an empty collection instead.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        public static StructureValue GetAsStructureValue(this IReadOnlyDictionary<string, LogEventPropertyValue> properties, string propertyKey)
+        {
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve the structure value from the log event");
+            
+            if (properties is null)
+            {
+                return EmptyStructureValue;
+            }
+            
+            if (properties.TryGetValue(propertyKey, out LogEventPropertyValue propertyValue)
+                && propertyValue is StructureValue value)
+            {
+                return value;
+            }
+
+            return EmptyStructureValue;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/CustomDependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/CustomDependencyTelemetryConverter.cs
@@ -1,4 +1,4 @@
-﻿using Arcus.Observability.Telemetry.Core;
+﻿using Arcus.Observability.Telemetry.Core.Logging;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -10,12 +10,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     public class CustomDependencyTelemetryConverter : DependencyTelemetryConverter
     {
         /// <summary>
-        ///     Gets the custom dependency type name from the given <paramref name="logEvent"/> to use in an <see cref="DependencyTelemetry"/> instance.
+        ///     Gets the custom dependency type name from the given <paramref name="logEntry"/> to use in an <see cref="DependencyTelemetry"/> instance.
         /// </summary>
-        /// <param name="logEvent">The logged event.</param>
-        protected override string GetDependencyType(LogEvent logEvent)
+        /// <param name="logEntry">The logged event.</param>
+        protected override string GetDependencyType(StructureValue logEntry)
         {
-            return logEvent.Properties.GetAsRawString(ContextProperties.DependencyTracking.DependencyType);
+            return logEntry.Properties.GetAsRawString(nameof(DependencyLogEntry.DependencyType));
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/HttpDependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/HttpDependencyTelemetryConverter.cs
@@ -9,10 +9,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     public class HttpDependencyTelemetryConverter : DependencyTelemetryConverter
     {
         /// <summary>
-        ///     Gets the custom dependency type name from the given <paramref name="logEvent"/> to use in an <see cref="DependencyTelemetry"/> instance.
+        ///     Gets the custom dependency type name from the given <paramref name="logEntry"/> to use in an <see cref="DependencyTelemetry"/> instance.
         /// </summary>
-        /// <param name="logEvent">The logged event.</param>
-        protected override string GetDependencyType(LogEvent logEvent)
+        /// <param name="logEntry">The logged event.</param>
+        protected override string GetDependencyType(StructureValue logEntry)
         {
             return DependencyType.Http.ToString();
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/SqlDependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/Dependencies/SqlDependencyTelemetryConverter.cs
@@ -9,10 +9,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     public class SqlDependencyTelemetryConverter : DependencyTelemetryConverter
     {
         /// <summary>
-        ///     Gets the custom dependency type name from the given <paramref name="logEvent"/> to use in an <see cref="DependencyTelemetry"/> instance.
+        ///     Gets the custom dependency type name from the given <paramref name="logEntry"/> to use in an <see cref="DependencyTelemetry"/> instance.
         /// </summary>
-        /// <param name="logEvent">The logged event.</param>
-        protected override string GetDependencyType(LogEvent logEvent)
+        /// <param name="logEntry">The logged event.</param>
+        protected override string GetDependencyType(StructureValue logEntry)
         {
             return DependencyType.Sql.ToString();
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -19,24 +21,31 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override RequestTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            var requestMethod = logEvent.Properties.GetAsRawString(ContextProperties.RequestTracking.RequestMethod);
-            var requestHost = logEvent.Properties.GetAsRawString(ContextProperties.RequestTracking.RequestHost);
-            var requestUri = logEvent.Properties.GetAsRawString(ContextProperties.RequestTracking.RequestUri);
-            var responseStatusCode = logEvent.Properties.GetAsRawString(ContextProperties.RequestTracking.ResponseStatusCode);
-            var requestDuration = logEvent.Properties.GetAsTimeSpan(ContextProperties.RequestTracking.RequestDuration);
-            var requestTime = logEvent.Properties.GetAsDateTimeOffset(ContextProperties.RequestTracking.RequestTime);
-            var operationId = logEvent.Properties.GetAsRawString(ContextProperties.Correlation.OperationId);
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Request telemetry instance");
+            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Request telemetry instance");
+            
+            StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.RequestTracking.RequestLogEntry);
+            string requestMethod = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestMethod));
+            string requestHost = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestHost));
+            string requestUri = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestUri));
+            string responseStatusCode = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.ResponseStatusCode));
+            TimeSpan requestDuration = logEntry.Properties.GetAsTimeSpan(nameof(RequestLogEntry.RequestDuration));
+            DateTimeOffset requestTime = logEntry.Properties.GetAsDateTimeOffset(nameof(RequestLogEntry.RequestTime));
+            IDictionary<string, string> context = logEntry.Properties.GetAsDictionary(nameof(RequestLogEntry.Context));
+
+            string operationId = logEvent.Properties.GetAsRawString(ContextProperties.Correlation.OperationId);
 
             var requestName = $"{requestMethod} {requestUri}";
-            var isSuccessfulRequest = DetermineRequestOutcome(responseStatusCode);
+            bool isSuccessfulRequest = DetermineRequestOutcome(responseStatusCode);
             var url = new Uri($"{requestHost}{requestUri}");
 
             var requestTelemetry = new RequestTelemetry(requestName, requestTime, requestDuration, responseStatusCode, isSuccessfulRequest)
             {
                 Id = operationId,
-                Url = url
+                Url = url,
             };
 
+            requestTelemetry.Properties.AddRange(context);
             return requestTelemetry;
         }
 
@@ -46,12 +55,8 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="logEvent">Event that was logged and written to this sink</param>
         protected override void RemoveIntermediaryProperties(LogEvent logEvent)
         {
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestMethod);
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestHost);
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestUri);
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.ResponseStatusCode);
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestDuration);
-            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestTime);
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to remove the intermediary Azure Application Insights Request telemetry properties");
+            logEvent.RemovePropertyIfPresent(ContextProperties.RequestTracking.RequestLogEntry);
         }
 
         private static bool DetermineRequestOutcome(string rawResponseStatusCode)

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
@@ -22,6 +23,9 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="formatProvider">The instance to control formatting.</param>
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights trace telemetry instance");
+            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights trace telemetry instance");
+
             foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
             {
                 _cloudContextConverter.EnrichWithAppInfo(logEvent, telemetry);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
@@ -1,0 +1,29 @@
+﻿using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Represents a set of extension on the <see cref="IDictionary{TKey,TValue}"/> to more easily interact with multiple dictionaries.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    internal static class IDictionaryExtensions
+    {
+        /// <summary>
+        /// Adds the items from the <paramref name="additionalItems"/> to this current <paramref name="items"/>.
+        /// </summary>
+        /// <param name="items">The current set of items.</param>
+        /// <param name="additionalItems">The additional set of items.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="items"/> or <paramref name="additionalItems"/> is <c>null</c>.</exception>
+        internal static void AddRange(this IDictionary<string, string> items, IDictionary<string, string> additionalItems)
+        {
+            Guard.NotNull(items, nameof(items), "Requires a base dictionary to add the additional items to");
+            Guard.NotNull(additionalItems, nameof(additionalItems), "Requires an additional set of items to add to the base dictionary");
+            
+            foreach (KeyValuePair<string, string> property in additionalItems)
+            {
+                items.Add(property);
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Serilog.Events
+{
+    /// <summary>
+    /// Extensions on the Serilog <see cref="StructureValue.Properties"/> to have more easily access to typed property values.
+    /// </summary>
+    internal static class LogEventPropertyExtensions
+    {
+        private static readonly IDictionary<string, string> EmptyContext = new Dictionary<string, string>();
+        
+        /// <summary>
+        /// Gets a raw string representation for a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <remarks>The built-in <c>ToString</c> wraps the string with quotes</remarks>
+        /// <param name="properties">The properties containing an property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property value is associated with.</param>
+        /// <returns>
+        ///     An raw string representation of the property value when the property was found; <c>null</c> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        internal static string GetAsRawString(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a raw string representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a raw string representation");
+            
+            LogEventProperty propertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
+            if (propertyValue?.Value is null 
+                || (propertyValue.Value is ScalarValue scalarValue 
+                    && scalarValue.Value is null))
+            {
+                return null;
+            }
+            
+            return propertyValue.Value.ToDecentString();
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="TimeSpan"/> representation for a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <param name="properties">The properties containing a property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property value is associated with.</param>
+        /// <returns>
+        ///     An <see cref="TimeSpan"/> representation of the property value when the property was found; <see cref="TimeSpan.Zero"/> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the property value cannot be parsed as a <see cref="TimeSpan"/> due of its format.</exception>
+        /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="TimeSpan"/> duration.</exception>
+        internal static TimeSpan GetAsTimeSpan(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a TimeSpan representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a TimeSpan representation");
+            
+            string propertyValue = properties.GetAsRawString(propertyKey);
+            if (propertyValue is null)
+            {
+                return TimeSpan.Zero;
+            }
+            
+            TimeSpan value = TimeSpan.Parse(propertyValue);
+            return value;
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="DateTimeOffset"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <param name="properties">The properties containing a property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property value is associated with.</param>
+        /// <returns>
+        ///     An <see cref="DateTimeOffset"/> representation with <see cref="CultureInfo.InvariantCulture"/> of the property value when the property was found;
+        ///     <c>default(<see cref="DateTimeOffset"/>)</c> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        /// <exception cref="FormatException">Throw when the property value cannot be parsed as a <see cref="DateTimeOffset"/> due to its format.</exception>
+        internal static DateTimeOffset GetAsDateTimeOffset(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a DateTimeOffset representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a DateTimeOffset representation");
+            
+            string propertyValue = properties.GetAsRawString(propertyKey);
+            if (propertyValue is null)
+            {
+                return default(DateTimeOffset);
+            }
+            
+            DateTimeOffset value = DateTimeOffset.Parse(propertyValue, CultureInfo.InvariantCulture);
+            return value;
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="IDictionary{TKey,TValue}"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <remarks>The built-in <c>ToString</c> wraps the string with quotes</remarks>
+        /// <param name="properties">The properties containing the property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property is associated with.</param>
+        /// <returns>
+        ///     An <see cref="IDictionary{TKey,TValue}"/> representation with raw string representations of name-value pairs when the property was found;
+        ///     an empty dictionary otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        internal static IDictionary<string, string> GetAsDictionary(
+            this IReadOnlyList<LogEventProperty> properties, 
+            string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a IDictionary<string, string> representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a IDictionary<string, string> represenation");
+            
+            LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
+            if (property?.Value is DictionaryValue dictionary)
+            {
+                return dictionary.Elements.ToDictionary(
+                    item => item.Key.ToDecentString(),
+                    item => item.Value.ToDecentString());
+            }
+
+            return EmptyContext;
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="Double"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <remarks>The built-in <c>ToString</c> wraps the <c>string</c> with quotes.</remarks>
+        /// <param name="properties">The properties containing the property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property is associated with.</param>
+        /// <returns>
+        ///     An <see cref="Double"/> representation with <see cref="CultureInfo.InvariantCulture"/> when the property was found; <see cref="Double.NaN"/> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the property value cannot be parsed as a <see cref="Double"/> due to its format.</exception>
+        /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="Double"/> range.</exception>
+        internal static double GetAsDouble(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Double representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property as a Double representation");
+            
+            LogEventProperty logEventPropertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
+            string rawDouble = logEventPropertyValue?.Value?.ToDecentString();
+
+            if (rawDouble is null)
+            {
+                return double.NaN;
+            }
+
+            return double.Parse(rawDouble, CultureInfo.InvariantCulture);
+
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="Boolean"/> representation of a property in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <param name="properties">The properties containing the property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property is associated with.</param>
+        /// <returns>
+        ///     An <see cref="Boolean"/> representation when the property was found; <c>false</c> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the property value cannot be parsed as a <see cref="Boolean"/> due to its format.</exception>
+        internal static bool GetAsBool(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Boolean representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a Boolean representation");
+            
+            string propertyValue = properties.GetAsRawString(propertyKey);
+            if (propertyValue is null)
+            {
+                return false;
+            }
+            
+            bool value = bool.Parse(propertyValue);
+            return value;
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -152,7 +152,6 @@ namespace Serilog.Events
             }
 
             return double.Parse(rawDouble, CultureInfo.InvariantCulture);
-
         }
         
         /// <summary>

--- a/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
+++ b/src/Arcus.Observability.Tests.Unit/Arcus.Observability.Tests.Unit.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -58,13 +58,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestMethod);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestHost);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestDuration);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -109,13 +103,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestMethod);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestHost);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestDuration);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -161,13 +149,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestMethod);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestHost);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestDuration);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -212,13 +194,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestMethod);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestHost);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestDuration);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestTime);
-            AssertDoesNotContainLogProperty(logEvent, RequestTracking.ResponseStatusCode);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
@@ -260,15 +236,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -307,15 +275,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -354,15 +314,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -401,15 +353,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -449,15 +393,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -497,15 +433,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -545,15 +473,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -592,15 +512,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -640,15 +552,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyType);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -689,14 +593,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -737,14 +634,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.TargetName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyName);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.IsSuccessful);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyData);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.ResultCode);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.StartTime);
-            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.Duration);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, DependencyTracking.DependencyLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var dependencyTelemetry = Assert.IsType<DependencyTelemetry>(telemetry);
@@ -787,8 +677,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventName);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, EventTracking.EventLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var eventTelemetry = Assert.IsType<EventTelemetry>(telemetry);
@@ -854,10 +743,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
 
             // Assert
-            AssertDoesNotContainLogProperty(logEvent, MetricTracking.MetricName);
-            AssertDoesNotContainLogProperty(logEvent, MetricTracking.MetricValue);
-            AssertDoesNotContainLogProperty(logEvent, MetricTracking.Timestamp);
-            AssertDoesNotContainLogProperty(logEvent, ContextProperties.TelemetryContext);
+            AssertDoesNotContainLogProperty(logEvent, MetricTracking.MetricLogEntry);
             Assert.Collection(telemetries, telemetry =>
             {
                 var metricTelemetry = Assert.IsType<MetricTelemetry>(telemetry);

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Serilog.Events;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog.Extensions
+{
+    public class LogEventPropertyValueExtensionsTests
+    {
+        [Fact]
+        public void GetAsStructureValue_WithoutPropertyKey_Fails()
+        {
+            // Arrange
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>());
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => properties.GetAsStructureValue(propertyKey: null));
+        }
+
+        [Fact]
+        public void GetAsStructureValue_WithFoundPropertyWithoutAssociatedStructureValue_Succeeds()
+        {
+            string propertyKey = $"prop-{Guid.NewGuid()}";
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>
+                {
+                    [propertyKey] = new ScalarValue("some value")
+                });
+            
+            // Act
+            StructureValue result = properties.GetAsStructureValue(propertyKey);
+            
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result.Properties);
+        }
+
+        [Fact]
+        public void GetAsStructureValue_WithFoundPropertyKeyAssociatedWithStructureValue_Succeeds()
+        {
+            // Arrange
+            string propertyKey = $"prop-{Guid.NewGuid()}";
+            var expected = new StructureValue(new LogEventProperty[0]);
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>
+                {
+                    [propertyKey] = expected
+                });
+            
+            // Act
+            StructureValue actual = properties.GetAsStructureValue(propertyKey);
+            
+            // Assert
+            Assert.Same(expected, actual);
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1531,7 +1531,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         {
             // Arrange
             var logger = new TestLogger();
-            var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.Url());
+            var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.UrlWithPath());
             var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
             var measurement = DependencyMeasurement.Start();
             DateTimeOffset startTime = measurement.StartTime;


### PR DESCRIPTION
Change the way we log telemetry output by creating separate models that gets logged in one go without the 'sentence-like' formatting; which is not serializable.

Closes #205 