### PR TITLE
feat: revisit telemetry type filter usage outside Azure Application Insights Serilog sink

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan((int) responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotGreaterThan((int) responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-            
+
             context = context ?? new Dictionary<string, object>();
-            
+
             var statusCode = (int)responseStatusCode;
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
             Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
-            
+
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -382,7 +382,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
             
             context = context ?? new Dictionary<string, object>();
-            
+
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Search", 
                 dependencyName: null, 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
             
             context = context ?? new Dictionary<string, object>();
-
+            
             var statusCode = (int)responseStatusCode;
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
@@ -382,7 +382,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
             
             context = context ?? new Dictionary<string, object>();
-
+            
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Search", 
                 dependencyName: null, 

--- a/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
@@ -49,6 +49,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             StartTime = startTime.ToString(FormatSpecifiers.InvariantTimestampFormat);
             Duration = duration;
             Context = context;
+            Context[ContextProperties.General.TelemetryType] = TelemetryType.Dependency;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
@@ -22,6 +22,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
 
             EventName = name;
             Context = context ?? new Dictionary<string, object>();
+            Context[ContextProperties.General.TelemetryType] = TelemetryType.Events;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
@@ -27,6 +27,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             MetricValue = value;
             Timestamp = timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat);
             Context = context ?? new Dictionary<string, object>();
+            Context[ContextProperties.General.TelemetryType] = TelemetryType.Metrics;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -48,6 +48,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             RequestDuration = duration;
             RequestTime = DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat);
             Context = context;
+            Context[ContextProperties.General.TelemetryType] = TelemetryType.Request;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
+++ b/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
@@ -29,7 +29,7 @@ namespace Arcus.Observability.Telemetry.Core
         Events = 4,
         
         /// <summary>
-        /// Specifies the type of logged telemetry as value metrics.
+        /// Specifies the type of logged telemetry as metrics.
         /// </summary>
         Metrics = 8
     }

--- a/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
+++ b/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
@@ -1,14 +1,36 @@
-﻿namespace Arcus.Observability.Telemetry.Core
+﻿using Microsoft.Extensions.Logging;
+
+namespace Arcus.Observability.Telemetry.Core
 {
     /// <summary>
-    ///     Different types of telemetry
+    /// Represents the supported types of telemetry available to track during extensions on the <see cref="ILogger"/>.
+    /// Compatible with Azure Application Insights.
     /// </summary>
     public enum TelemetryType
     {
-        Trace,
-        Dependency,
-        Request,
-        Events,
-        Metrics
+        /// <summary>
+        /// Specifies the type of logged telemetry as traces.
+        /// </summary>
+        Trace = 0,
+        
+        /// <summary>
+        /// Specifies the type of logged telemetry as tracked dependencies.
+        /// </summary>
+        Dependency = 1,
+        
+        /// <summary>
+        /// Specifies the type of logged telemetry as HTTP requests.
+        /// </summary>
+        Request = 2,
+        
+        /// <summary>
+        /// Specifies the type of logged telemetry as custom events.
+        /// </summary>
+        Events = 4,
+        
+        /// <summary>
+        /// Specifies the type of logged telemetry as value metrics.
+        /// </summary>
+        Metrics = 8
     }
 }

--- a/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
+++ b/src/Arcus.Observability.Telemetry.Core/TelemetryType.cs
@@ -3,8 +3,8 @@
 namespace Arcus.Observability.Telemetry.Core
 {
     /// <summary>
-    /// Represents the supported types of telemetry available to track during extensions on the <see cref="ILogger"/>.
-    /// Compatible with Azure Application Insights.
+    /// <para>Represents the supported types of telemetry available to track during extensions on the <see cref="ILogger"/>.</para>
+    /// <para>Also compatible (but not limited to) with Azure Application Insights (see: <see href="https://observability.arcus-azure.net/features/sinks/azure-application-insights" /> for more information).</para>
     /// </summary>
     public enum TelemetryType
     {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -99,7 +99,7 @@ namespace Serilog.Events
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventPropertyValues"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         /// <exception cref="FormatException">
-        ///     Thrown when the Serilog property value cannot be parsed correctly to the provided <typeparamref name="TEnum"/> enumeration type.
+        ///     Thrown when the Serilog property value cannot be parsed correctly because the <typeparamref name="TEnum"/> does not present an enumeration type.
         /// </exception>
         /// <returns>
         ///     The parsed representation of the Serilog property value as the provided <typeparamref name="TEnum"/> enumeration type; <c>null</c> otherwise.

--- a/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
+++ b/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Observability.Telemetry.AspNetCore\Arcus.Observability.Telemetry.AspNetCore.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Core\Arcus.Observability.Telemetry.Core.csproj" />
+    <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Filters\Arcus.Observability.Telemetry.Serilog.Filters.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights\Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Tests.Core\Arcus.Observability.Tests.Core.csproj" />
   </ItemGroup>

--- a/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
@@ -1,0 +1,1266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Arcus.Observability.Tests.Core;
+using Bogus;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+using Xunit;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Arcus.Observability.Tests.Integration.Serilog
+{
+    [Trait("Category", "Integration")]
+    public class TelemetryTypeFilterTests
+    {
+        private readonly Faker _bogusGenerator = new Faker();
+
+        public static IEnumerable<object[]> TelemetryTypesWithoutEvent => GetTelemetryTypesWithout(TelemetryType.Events);
+        public static IEnumerable<object[]> TelemetryTypesWithoutMetric => GetTelemetryTypesWithout(TelemetryType.Metrics);
+        public static IEnumerable<object[]> TelemetryTypesWithoutDependency => GetTelemetryTypesWithout(TelemetryType.Dependency);
+        public static IEnumerable<object[]> TelemetryTypesWithoutRequest => GetTelemetryTypesWithout(TelemetryType.Request);
+        
+        [Fact]
+        public void LogEvent_WithTelemetryTypeFilter_FiltersInLogEvent()
+        {
+            // Arrange
+            string eventName = _bogusGenerator.Random.Word();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogEvent(eventName, properties);
+                
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+                Assert.Contains(TelemetryType.Events.ToString(), writtenMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutEvent))]
+        public void LogEvent_WithTelemetryTypeFilterOnOtherType_FiltersOutEvent(TelemetryType telemetryType)
+        {
+            // Arrange
+            string eventName = _bogusGenerator.Random.Word();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType, isTrackingEnabled: false))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogEvent(eventName, properties);
+                
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogSecurityEvent_WithTelemetryTypeFilter_FiltersInLogEvent()
+        {
+            // Arrange
+            string eventName = _bogusGenerator.Random.Word();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Events))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogSecurityEvent(eventName, properties);
+                
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+                Assert.Contains(TelemetryType.Events.ToString(), writtenMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutEvent))]
+        public void LogSecurityEvent_WithTelemetryTypeFilterOnOtherType_FiltersOutEvent(TelemetryType telemetryType)
+        {
+            // Arrange
+            string eventName = _bogusGenerator.Random.Word();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType, isTrackingEnabled: false))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogSecurityEvent(eventName, properties);
+                
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+
+        [Fact]
+        public void LogMetric_WithTelemetryTypeFilter_FiltersInMetric()
+        {
+            // Arrange
+            string metricName = _bogusGenerator.Random.Word();
+            double metricValue = _bogusGenerator.Random.Double();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Metrics))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogMetric(metricName, metricValue, properties);
+                
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(metricName, writtenMessage);
+                Assert.Contains(metricValue.ToString(CultureInfo.InvariantCulture), writtenMessage);
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+                Assert.Contains(TelemetryType.Metrics.ToString(), writtenMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutMetric))]
+        public void LogMetric_WithTelemetryTypeFilterOnDifferentTyp_FiltersOutMetric(TelemetryType telemetryType)
+        {
+            // Arrange
+            string metricName = _bogusGenerator.Random.Word();
+            double metricValue = _bogusGenerator.Random.Double();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogMetric(metricName, metricValue, properties);
+                
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+
+        [Fact]
+        public void LogRequest_WithTelemetryTypeFilter_FilersInRequest()
+        {
+            // Arrange
+            var statusCode = (int)_bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Lorem.Word()}";
+            string host = _bogusGenerator.Lorem.Word();
+            HttpMethod method = HttpMethod.Head;
+            var stubbedRequest = new Mock<HttpRequest>();
+            stubbedRequest.Setup(request => request.Method).Returns(method.ToString());
+            stubbedRequest.Setup(request => request.Host).Returns(new HostString(host));
+            stubbedRequest.Setup(request => request.Path).Returns(path);
+            var stubbedResponse = new Mock<HttpResponse>();
+            stubbedResponse.Setup(response => response.StatusCode).Returns(statusCode);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Request))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogRequest(stubbedRequest.Object, stubbedResponse.Object, duration, properties);
+                
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(path, writtenMessage);
+                Assert.Contains(host, writtenMessage);
+                Assert.Contains(statusCode.ToString(), writtenMessage);
+                Assert.Contains(method.ToString(), writtenMessage);
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+                Assert.Contains(TelemetryType.Request.ToString(), writtenMessage);
+            }
+        }
+        
+         [Theory]
+         [MemberData(nameof(TelemetryTypesWithoutRequest))]
+        public void LogRequest_WithTelemetryTypeFilterOnDifferentTelemetryType_FilersOutRequest(TelemetryType telemetryType)
+        {
+            // Arrange
+            var statusCode = (int)_bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Lorem.Word()}";
+            string host = _bogusGenerator.Lorem.Word();
+            HttpMethod method = HttpMethod.Head;
+            var stubbedRequest = new Mock<HttpRequest>();
+            stubbedRequest.Setup(request => request.Method).Returns(method.ToString());
+            stubbedRequest.Setup(request => request.Host).Returns(new HostString(host));
+            stubbedRequest.Setup(request => request.Path).Returns(path);
+            var stubbedResponse = new Mock<HttpResponse>();
+            stubbedResponse.Setup(response => response.StatusCode).Returns(statusCode);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogRequest(stubbedRequest.Object, stubbedResponse.Object, duration, properties);
+                
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogRequestMessage_WithTelemetryTypeFilter_FiltersInRequestMessage()
+        {
+            // Arrange
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            string host = _bogusGenerator.Name.FirstName().ToLower();
+            HttpMethod method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            var response = new HttpResponseMessage(statusCode);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+
+             var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Request))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogRequest(request, response, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Request.ToString(), writtenMessage);
+                Assert.Contains(path, writtenMessage);
+                Assert.Contains(host, writtenMessage);
+                Assert.Contains(((int)statusCode).ToString(), writtenMessage);
+                Assert.Contains(method.ToString(), writtenMessage);
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+                Assert.Contains(TelemetryType.Request.ToString(), writtenMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutRequest))]
+        public void LogRequestMessage_WithTelemetryTypeFilter_FiltersOutRequestMessage(TelemetryType telemetryType)
+        {
+            // Arrange
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{_bogusGenerator.Name.FirstName().ToLower()}";
+            string host = _bogusGenerator.Name.FirstName().ToLower();
+            HttpMethod method = HttpMethod.Head;
+            var request = new HttpRequestMessage(method, new Uri("https://" + host + path));
+            var response = new HttpResponseMessage(statusCode);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+
+             var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogRequest(request, response, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogHttpDependency_WithTelemetryTypeFilter_FiltersInHttpDependency()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.UrlWithPath());
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogHttpDependency(request, statusCode, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string writtenMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), writtenMessage);
+                Assert.Contains(request.RequestUri.Host, writtenMessage);
+                Assert.Contains(request.RequestUri.PathAndQuery, writtenMessage);
+                Assert.Contains(request.Method.ToString(), writtenMessage);
+                Assert.Contains(((int) statusCode).ToString(), writtenMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), writtenMessage);
+                bool isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
+                Assert.Contains($"Successful: {isSuccessful}", writtenMessage);
+                Assert.Contains(propertyName, writtenMessage);
+                Assert.Contains(propertyValue, writtenMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogHttpDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutHttpDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, _bogusGenerator.Internet.UrlWithPath());
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogHttpDependency(request, statusCode, startTime, duration);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogSqlDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string serverName = _bogusGenerator.Name.FullName();
+            string databaseName = _bogusGenerator.Name.FullName();
+            string tableName = _bogusGenerator.Name.FullName();
+            string operationName = _bogusGenerator.Name.FullName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogSqlDependency(serverName, databaseName, tableName, operationName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(serverName, logMessage);
+                Assert.Contains(databaseName, logMessage);
+                Assert.Contains(tableName, logMessage);
+                Assert.Contains(operationName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogSqlDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string serverName = _bogusGenerator.Name.FullName();
+            string databaseName = _bogusGenerator.Name.FullName();
+            string tableName = _bogusGenerator.Name.FullName();
+            string operationName = _bogusGenerator.Name.FullName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogSqlDependency(serverName, databaseName, tableName, operationName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogServiceBusTopicDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string topicName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogServiceBusTopicDependency(topicName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(ServiceBusEntityType.Topic.ToString(), logMessage);
+                Assert.Contains(topicName, logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogServiceBusTopicDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string topicName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogServiceBusTopicDependency(topicName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogServiceBusQueueDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+             var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(ServiceBusEntityType.Queue.ToString(), logMessage);
+                Assert.Contains(queueName, logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogServiceBusQueueDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogAzureSearchDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string searchServiceName = _bogusGenerator.Commerce.Product();
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogAzureSearchDependency(searchServiceName, operationName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(searchServiceName, logMessage);
+                Assert.Contains(operationName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogAzureSearchDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string searchServiceName = _bogusGenerator.Commerce.Product();
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogAzureSearchDependency(searchServiceName, operationName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogAzureKeyVaultDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            var vaultUri = "https://myvault.vault.azure.net";
+            string secretName = "MySecret";
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(vaultUri, logMessage);
+                Assert.Contains(secretName, logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogAzureKeyVaultDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            var vaultUri = "https://myvault.vault.azure.net";
+            string secretName = "MySecret";
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogAzureKeyVaultDependency(vaultUri, secretName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogDependencyTarget_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(dependencyType, logMessage);
+                Assert.Contains(dependencyData, logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogDependencyTarget_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogCosmosSqlDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string container = _bogusGenerator.Commerce.ProductName();
+            string database = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogCosmosSqlDependency(accountName, database, container, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(container, logMessage);
+                Assert.Contains(database, logMessage);
+                Assert.Contains(accountName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogCosmosSqlDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string container = _bogusGenerator.Commerce.ProductName();
+            string database = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogCosmosSqlDependency(accountName, database, container, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogIotHubDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string iotHubName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogIotHubDependency(iotHubName: iotHubName, isSuccessful: isSuccessful, startTime: startTime, duration: duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(iotHubName, logMessage);
+                Assert.Contains(iotHubName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogIotHubDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string iotHubName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogIotHubDependency(iotHubName: iotHubName, isSuccessful: isSuccessful, startTime: startTime, duration: duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogEventHubsDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string eventHubName = _bogusGenerator.Commerce.ProductName();
+            string namespaceName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogEventHubsDependency(namespaceName, eventHubName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(namespaceName, logMessage);
+                Assert.Contains(eventHubName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogEventHubsDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string eventHubName = _bogusGenerator.Commerce.ProductName();
+            string namespaceName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+            
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+                
+                // Act
+                logger.LogEventHubsDependency(namespaceName, eventHubName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogTableStorageDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+
+                // Act
+                logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(tableName, logMessage);
+                Assert.Contains(accountName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogTableStorageDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+
+                // Act
+                logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+        
+        [Fact]
+        public void LogBlobStorageDependency_WithTelemetryTypeFilter_FiltersInDependency()
+        {
+            // Arrange
+            string containerName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+             string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(TelemetryType.Dependency))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+
+                // Act
+                logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+                Assert.NotNull(logEvent);
+                string logMessage = logEvent.RenderMessage();
+                Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+                Assert.Contains(containerName, logMessage);
+                Assert.Contains(accountName, logMessage);
+                Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+                Assert.Contains(duration.ToString(), logMessage);
+                Assert.Contains(propertyName, logMessage);
+                Assert.Contains(propertyValue, logMessage);
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(TelemetryTypesWithoutDependency))]
+        public void LogBlobStorageDependency_WithTelemetryTypeFilterOnDifferentTelemetryType_FiltersOutDependency(TelemetryType telemetryType)
+        {
+            // Arrange
+            string containerName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+             string propertyName = _bogusGenerator.Random.Word();
+            string propertyValue = _bogusGenerator.Random.Word();
+            var properties = new Dictionary<string, object> {[propertyName] = propertyValue};
+            
+            var spySink = new InMemoryLogSink();
+            Logger serilogLogger = new LoggerConfiguration()
+                .Filter.With(TelemetryTypeFilter.On(telemetryType))
+                .WriteTo.Sink(spySink)
+                .CreateLogger();
+
+            using (var factory = new SerilogLoggerFactory(serilogLogger))
+            {
+                ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
+
+                // Act
+                logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, startTime, duration, properties);
+
+                // Assert
+                Assert.Empty(spySink.CurrentLogEmits);
+            }
+        }
+
+        private static IEnumerable<object[]> GetTelemetryTypesWithout(TelemetryType telemetryType)
+        {
+            return Enum.GetValues(typeof(TelemetryType))
+                       .OfType<TelemetryType>()
+                       .Where(type => type != telemetryType)
+                       .Select(type => new object[] {type})
+                       .ToArray();
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
@@ -427,7 +427,6 @@ namespace Arcus.Observability.Tests.Integration.Serilog
             DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
             TimeSpan duration = _bogusGenerator.Date.Timespan();
 
-            
             var spySink = new InMemoryLogSink();
             Logger serilogLogger = new LoggerConfiguration()
                 .Filter.With(TelemetryTypeFilter.On(telemetryType))

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
@@ -92,18 +92,19 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Extensions
         }
 
         [Fact]
-        public void GetAsEnum_WithoutParsablePropertyValue_Fails()
+        public void GetAsEnum_WithoutEnumType_Fails()
         {
             // Arrange
             string propertyKey = _bogusGenerator.Random.Word();
+            TelemetryType telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
             var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
                 new Dictionary<string, LogEventPropertyValue>
                 {
-                    [propertyKey] = new ScalarValue(_bogusGenerator.Random.Word())
+                    [propertyKey] = new ScalarValue(telemetryType)
                 });
             
             // Act / Assert
-            Assert.ThrowsAny<FormatException>(() => properties.GetAsEnum<TelemetryType>(propertyKey));
+            Assert.ThrowsAny<FormatException>(() => properties.GetAsEnum<TimeSpan>(propertyKey));
         }
         
         [Fact]

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Extensions/LogEventPropertyValueExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Arcus.Observability.Telemetry.Core;
+using Bogus;
 using Serilog.Events;
 using Xunit;
 
@@ -8,21 +10,24 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Extensions
 {
     public class LogEventPropertyValueExtensionsTests
     {
-        [Fact]
-        public void GetAsStructureValue_WithoutPropertyKey_Fails()
+        private readonly Faker _bogusGenerator = new Faker();
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void GetAsStructureValue_WithoutPropertyKey_Fails(string propertyKey)
         {
             // Arrange
             var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
                 new Dictionary<string, LogEventPropertyValue>());
             
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => properties.GetAsStructureValue(propertyKey: null));
+            Assert.ThrowsAny<ArgumentException>(() => properties.GetAsStructureValue(propertyKey));
         }
 
         [Fact]
         public void GetAsStructureValue_WithFoundPropertyWithoutAssociatedStructureValue_Succeeds()
         {
-            string propertyKey = $"prop-{Guid.NewGuid()}";
+            string propertyKey = _bogusGenerator.Random.Word();
             var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
                 new Dictionary<string, LogEventPropertyValue>
                 {
@@ -41,7 +46,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Extensions
         public void GetAsStructureValue_WithFoundPropertyKeyAssociatedWithStructureValue_Succeeds()
         {
             // Arrange
-            string propertyKey = $"prop-{Guid.NewGuid()}";
+            string propertyKey = _bogusGenerator.Random.Word();
             var expected = new StructureValue(new LogEventProperty[0]);
             var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
                 new Dictionary<string, LogEventPropertyValue>
@@ -54,6 +59,70 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Extensions
             
             // Assert
             Assert.Same(expected, actual);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void GetAsEnum_WithoutPropertyKey_Fails(string propertyKey)
+        {
+            // Arrange
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>());
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => properties.GetAsEnum<TelemetryType>(propertyKey));
+        }
+
+        [Fact]
+        public void GetAsEnum_WithoutPropertyValue_ReturnsNull()
+        {
+            // Arrange
+            string propertyKey = _bogusGenerator.Random.Word();
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>
+                {
+                    [propertyKey] = null
+                });
+            
+            // Act
+            TelemetryType? result = properties.GetAsEnum<TelemetryType>(propertyKey);
+            
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetAsEnum_WithoutParsablePropertyValue_Fails()
+        {
+            // Arrange
+            string propertyKey = _bogusGenerator.Random.Word();
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>
+                {
+                    [propertyKey] = new ScalarValue(_bogusGenerator.Random.Word())
+                });
+            
+            // Act / Assert
+            Assert.ThrowsAny<FormatException>(() => properties.GetAsEnum<TelemetryType>(propertyKey));
+        }
+        
+        [Fact]
+        public void GetAsEnum_WithParsablePropertyValue_Succeeds()
+        {
+            // Arrange
+            string propertyKey = _bogusGenerator.Random.Word();
+            TelemetryType expected = _bogusGenerator.Random.Enum<TelemetryType>();
+            var properties = new ReadOnlyDictionary<string, LogEventPropertyValue>(
+                new Dictionary<string, LogEventPropertyValue>
+                {
+                    [propertyKey] = new ScalarValue(expected)
+                });
+            
+            // Act
+            TelemetryType? actual = properties.GetAsEnum<TelemetryType>(propertyKey);
+
+            // Assert
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -18,8 +18,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
     [Trait("Category", "Unit")]
     public class ILoggerExtensionsTests
     {
-        private const string ExpectedDateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffff zzz";
-        
         private readonly Faker _bogusGenerator = new Faker();
 
         [Fact]
@@ -36,6 +34,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Metric, logMessage);
+            Assert.Contains(TelemetryType.Metrics.ToString(), logMessage);
             Assert.Contains(metricName, logMessage);
             Assert.Contains(metricValue.ToString(CultureInfo.InvariantCulture), logMessage);
         }
@@ -55,9 +54,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Metric, logMessage);
+            Assert.Contains(TelemetryType.Metrics.ToString(), logMessage);
             Assert.Contains(metricName, logMessage);
             Assert.Contains(metricValue.ToString(CultureInfo.InvariantCulture), logMessage);
-            Assert.Contains(timestamp.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
         }
 
         [Fact]
@@ -85,6 +85,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Event, logMessage);
+            Assert.Contains(TelemetryType.Events.ToString(), logMessage);
             Assert.Contains(eventName, logMessage);
         }
 
@@ -116,9 +117,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -187,9 +189,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -255,9 +258,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -346,9 +350,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(dependencyType, logMessage);
             Assert.Contains(dependencyData, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -416,9 +421,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(vaultUri, logMessage);
             Assert.Contains(secretName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -500,9 +506,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(vaultUri, logMessage);
             Assert.Contains(secretName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -570,10 +577,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(searchServiceName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -611,10 +619,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(searchServiceName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -635,9 +644,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(entityType.ToString(), logMessage);
             Assert.Contains(entityName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -676,9 +686,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(entityType.ToString(), logMessage);
             Assert.Contains(entityName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -699,9 +710,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(ServiceBusEntityType.Queue.ToString(), logMessage);
             Assert.Contains(queueName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -738,9 +750,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(ServiceBusEntityType.Queue.ToString(), logMessage);
             Assert.Contains(queueName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -761,9 +774,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(ServiceBusEntityType.Topic.ToString(), logMessage);
             Assert.Contains(topicName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -800,9 +814,10 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency + " Azure Service Bus", logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(ServiceBusEntityType.Topic.ToString(), logMessage);
             Assert.Contains(topicName, logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
@@ -826,12 +841,14 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
+            Assert.Contains(TelemetryType.Dependency
+                .ToString(), logMessage);
             Assert.Contains(serverName, logMessage);
             Assert.Contains(databaseName, logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -869,10 +886,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(containerName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
         
@@ -911,10 +929,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(containerName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -935,10 +954,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -977,10 +997,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1001,10 +1022,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(namespaceName, logMessage);
             Assert.Contains(eventHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1043,10 +1065,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(namespaceName, logMessage);
             Assert.Contains(eventHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1066,10 +1089,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1106,10 +1130,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1132,10 +1157,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
         
@@ -1179,10 +1205,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(iotHubName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1204,11 +1231,12 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(container, logMessage);
             Assert.Contains(database, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1249,11 +1277,12 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Dependency, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(container, logMessage);
             Assert.Contains(database, logMessage);
             Assert.Contains(accountName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1280,12 +1309,13 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(serverName, logMessage);
             Assert.Contains(databaseName, logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1309,12 +1339,13 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(serverName, logMessage);
             Assert.Contains(databaseName, logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1464,12 +1495,13 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaSql, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(serverName, logMessage);
             Assert.Contains(databaseName, logMessage);
             Assert.Contains(tableName, logMessage);
             Assert.Contains(operationName, logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
         }
 
@@ -1489,11 +1521,12 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(request.RequestUri.Host, logMessage);
             Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
             Assert.Contains(request.Method.ToString(), logMessage);
             Assert.Contains(((int) statusCode).ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
         }
@@ -1544,11 +1577,12 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.DependencyViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
             Assert.Contains(request.RequestUri.Host, logMessage);
             Assert.Contains(request.RequestUri.PathAndQuery, logMessage);
             Assert.Contains(request.Method.ToString(), logMessage);
             Assert.Contains(((int) statusCode).ToString(), logMessage);
-            Assert.Contains(startTime.ToString(ExpectedDateTimeFormat), logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
@@ -1577,6 +1611,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Request.ToString(), logMessage);
             Assert.Contains(path, logMessage);
             Assert.Contains(host, logMessage);
             Assert.Contains(statusCode.ToString(), logMessage);
@@ -1604,6 +1639,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Request.ToString(), logMessage);
             Assert.Contains(path, logMessage);
             Assert.Contains(host, logMessage);
             Assert.Contains(statusCode.ToString(), logMessage);
@@ -1815,12 +1851,13 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             var response = new HttpResponseMessage(statusCode);
             var duration = _bogusGenerator.Date.Timespan();
 
-            // Act;
+            // Act
             logger.LogRequest(request, response, duration);
 
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Request.ToString(), logMessage);
             Assert.Contains(path, logMessage);
             Assert.Contains(host, logMessage);
             Assert.Contains(((int)statusCode).ToString(), logMessage);
@@ -1845,6 +1882,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             var logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.RequestViaHttp, logMessage);
+            Assert.Contains(TelemetryType.Request.ToString(), logMessage);
             Assert.Contains(path, logMessage);
             Assert.Contains(host, logMessage);
             Assert.Contains(((int)statusCode).ToString(), logMessage);
@@ -1898,6 +1936,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Event, logMessage);
+            Assert.Contains(TelemetryType.Events.ToString(), logMessage);
             Assert.Contains(message, logMessage);
             Assert.Contains("[EventType, Security]", logMessage);
         }
@@ -1919,6 +1958,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Assert
             string logMessage = logger.WrittenMessage;
             Assert.StartsWith(MessagePrefixes.Event, logMessage);
+            Assert.Contains(TelemetryType.Events.ToString(), logMessage);
             Assert.Contains(message, logMessage);
             Assert.Contains("[EventType, Security]", logMessage);
             Assert.Contains("[Property, something was wrong with this Property]", logMessage);

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
@@ -71,7 +71,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             bool isEnabled = filter.IsEnabled(logEvent);
             
             // Assert
-            Assert.True(isEnabled);
+            Assert.False(isEnabled);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             bool isEnabled = filter.IsEnabled(logEvent);
             
             // Assert
-            Assert.True(isEnabled);
+            Assert.False(isEnabled);
         }
 
         [Theory]

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Linq;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Filters;
+using Bogus;
+using Serilog.Events;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry
+{
+    [Trait("Category", "Unit")]
+    public class TelemetryTypeFilterTests
+    {
+        private readonly Faker _bogusGenerator = new Faker();
+        
+        [Fact]
+        public void LogEventAsTelemetry_FiltersInCorrectTelemetry_Succeeds()
+        {
+            // Arrange
+            DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
+            var level = _bogusGenerator.Random.Enum<LogEventLevel>();
+            var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
+            var properties = new[]
+            {
+                new LogEventProperty(ContextProperties.General.TelemetryType, new ScalarValue(telemetryType))
+            };
+
+            var logEvent = new LogEvent(timestamp, level, exception: null, MessageTemplate.Empty, properties);
+            var filter = TelemetryTypeFilter.On(telemetryType, isTrackingEnabled: true);
+            
+            // Act
+            bool isEnabled = filter.IsEnabled(logEvent);
+            
+            // Assert
+            Assert.True(isEnabled);
+        }
+
+        [Fact]
+        public void LogEventAsTelemetry_FiltersOutCorrectTelemetry_Succeeds()
+        {
+            // Arrange
+            DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
+            var level = _bogusGenerator.Random.Enum<LogEventLevel>();
+            var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
+            var properties = new[]
+            {
+                new LogEventProperty(ContextProperties.General.TelemetryType, new ScalarValue(telemetryType))
+            };
+
+            var logEvent = new LogEvent(timestamp, level, exception: null, MessageTemplate.Empty, properties);
+            var filter = TelemetryTypeFilter.On(telemetryType);
+            
+            // Act
+            bool isEnabled = filter.IsEnabled(logEvent);
+            
+            // Assert
+            Assert.False(isEnabled);
+        }
+
+        [Fact]
+        public void LogEventWithoutTelemetry_DoesntFilterAnything_Succeeds()
+        {
+            // Arrange
+            DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
+            var level = _bogusGenerator.Random.Enum<LogEventLevel>();
+            var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
+            var logEvent = new LogEvent(timestamp, level, exception: null, MessageTemplate.Empty, Enumerable.Empty<LogEventProperty>());
+            var filter = TelemetryTypeFilter.On(telemetryType);
+            
+            // Act
+            bool isEnabled = filter.IsEnabled(logEvent);
+            
+            // Assert
+            Assert.True(isEnabled);
+        }
+
+        [Fact]
+        public void LogEventWithoutValidTelemetry_DoesntFilterAnything_Succeeds()
+        {
+            // Assert
+            DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
+            var level = _bogusGenerator.Random.Enum<LogEventLevel>();
+            var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
+            var logEvent = new LogEvent(timestamp, level, exception: null, MessageTemplate.Empty, Enumerable.Empty<LogEventProperty>());
+            var filter = TelemetryTypeFilter.On(telemetryType);
+            
+            // Act
+            bool isEnabled = filter.IsEnabled(logEvent);
+            
+            // Assert
+            Assert.True(isEnabled);
+        }
+
+        [Theory]
+        [InlineData(TelemetryType.Request | TelemetryType.Dependency)]
+        [InlineData(TelemetryType.Metrics | TelemetryType.Request | TelemetryType.Events)]
+        public void CreateFilter_WithTelemetryTypeOutsideEnum_Fails(TelemetryType telemetryType)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => TelemetryTypeFilter.On(telemetryType));
+        }
+        
+        [Theory]
+        [InlineData(TelemetryType.Request | TelemetryType.Dependency)]
+        [InlineData(TelemetryType.Metrics | TelemetryType.Request | TelemetryType.Events)]
+        public void CreateFilterWithTracked_WithTelemetryTypeOutsideEnum_Fails(TelemetryType telemetryType)
+        {
+            // Arrange
+            bool isTrackingEnabled = _bogusGenerator.Random.Bool();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => TelemetryTypeFilter.On(telemetryType, isTrackingEnabled));
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/TelemetryTypeFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Filters;
@@ -61,23 +62,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         public void LogEventWithoutTelemetry_DoesntFilterAnything_Succeeds()
         {
             // Arrange
-            DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
-            var level = _bogusGenerator.Random.Enum<LogEventLevel>();
-            var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();
-            var logEvent = new LogEvent(timestamp, level, exception: null, MessageTemplate.Empty, Enumerable.Empty<LogEventProperty>());
-            var filter = TelemetryTypeFilter.On(telemetryType);
-            
-            // Act
-            bool isEnabled = filter.IsEnabled(logEvent);
-            
-            // Assert
-            Assert.False(isEnabled);
-        }
-
-        [Fact]
-        public void LogEventWithoutValidTelemetry_DoesntFilterAnything_Succeeds()
-        {
-            // Assert
             DateTimeOffset timestamp = _bogusGenerator.Date.RecentOffset();
             var level = _bogusGenerator.Random.Enum<LogEventLevel>();
             var telemetryType = _bogusGenerator.Random.Enum<TelemetryType>();


### PR DESCRIPTION
Updates the `TelemetryTypeFilter` so it can be used with the new telemetry log format + outside Azure Application Insights sinks.

Closes #206 