### PR TITLE
fix: use ubuntu-latest for build pipelines

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -37,7 +37,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: 'nuget/determine-pr-version.yml@templates'
             parameters:
@@ -65,7 +65,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -85,7 +85,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -108,7 +108,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -28,7 +28,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: build/build-solution.yml@templates
             parameters:
@@ -53,7 +53,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -73,7 +73,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -93,7 +93,7 @@ stages:
       - job: PushToNuGet
         displayName: 'Push to NuGet.org'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,3 +1,4 @@
 variables:
   DotNet.Sdk.Version: '3.1.201'
   Project: 'Arcus.Observability'
+  Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
Use `ubuntu-latest` for the VM image of the build pipelines.

Relates to https://github.com/arcus-azure/arcus/issues/144