### PR TITLE
feat: add operation parent ID to correlation info

### DIFF
--- a/docs/preview/features/correlation.md
+++ b/docs/preview/features/correlation.md
@@ -9,6 +9,7 @@ layout: default
 
 - Transaction Id - ID that relates different requests together into a functional transaction.
 - Operation Id - Unique ID information for a single request.
+- Operation parent Id - ID of the original service that initiated the request.
 
 ## Installation
 

--- a/src/Arcus.Observability.Correlation/CorrelationInfo.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfo.cs
@@ -15,7 +15,7 @@ namespace Arcus.Observability.Correlation
         /// <param name="transactionId">The unique ID information that related different requests together in a single transaction.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
         public CorrelationInfo(string operationId, string transactionId)
-            : this(operationId, transactionId, parentOperationId: null)
+            : this(operationId, transactionId, operationParentId: null)
         {
         }
 
@@ -24,15 +24,15 @@ namespace Arcus.Observability.Correlation
         /// </summary>
         /// <param name="operationId">The unique ID information to identify the request.</param>
         /// <param name="transactionId">The ID information that related different requests together in a single transaction.</param>
-        /// <param name="parentOperationId">The ID information of the original service that initiated this request.</param>
+        /// <param name="operationParentId">The ID information of the original service that initiated this request.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
-        public CorrelationInfo(string operationId, string transactionId, string parentOperationId)
+        public CorrelationInfo(string operationId, string transactionId, string operationParentId)
         {
             Guard.NotNullOrEmpty(operationId, nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
 
             OperationId = operationId;
             TransactionId = transactionId;
-            ParentOperationId = parentOperationId;
+            OperationParentId = operationParentId;
         }
 
         /// <summary>
@@ -48,6 +48,6 @@ namespace Arcus.Observability.Correlation
         /// <summary>
         /// Gets the ID of the original service that initiated this request.
         /// </summary>
-        public string ParentOperationId { get; }
+        public string OperationParentId { get; }
     }
 }

--- a/src/Arcus.Observability.Correlation/CorrelationInfo.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfo.cs
@@ -1,32 +1,53 @@
-﻿using GuardNet;
+﻿using System;
+using GuardNet;
 
 namespace Arcus.Observability.Correlation
 {
     /// <summary>
-    ///     Represents the correlation ID information on the incoming requests and outgoing responses.
+    /// Represents the correlation ID information on the incoming requests and outgoing responses.
     /// </summary>
     public class CorrelationInfo
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CorrelationInfo" /> class.
+        /// Initializes a new instance of the <see cref="CorrelationInfo" /> class.
         /// </summary>
+        /// <param name="operationId">The unique ID information to identify the request.</param>
+        /// <param name="transactionId">The unique ID information that related different requests together in a single transaction.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
         public CorrelationInfo(string operationId, string transactionId)
+            : this(operationId, transactionId, parentOperationId: null)
         {
-            Guard.NotNullOrEmpty(operationId, nameof(operationId),
-                "Cannot create a correlation instance with a blank operation ID");
-
-            OperationId = operationId;
-            TransactionId = transactionId;
         }
 
         /// <summary>
-        ///     Gets the ID that relates different requests together.
+        /// Initializes a new instance of the <see cref="CorrelationInfo" /> class.
+        /// </summary>
+        /// <param name="operationId">The unique ID information to identify the request.</param>
+        /// <param name="transactionId">The ID information that related different requests together in a single transaction.</param>
+        /// <param name="parentOperationId">The ID information of the original service that initiated this request.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
+        public CorrelationInfo(string operationId, string transactionId, string parentOperationId)
+        {
+            Guard.NotNullOrEmpty(operationId, nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
+
+            OperationId = operationId;
+            TransactionId = transactionId;
+            ParentOperationId = parentOperationId;
+        }
+
+        /// <summary>
+        /// Gets the ID that relates different requests together in a single transaction.
         /// </summary>
         public string TransactionId { get; }
 
         /// <summary>
-        ///     Gets the unique ID information of the request.
+        /// Gets the unique ID information of the request.
         /// </summary>
         public string OperationId { get; }
+        
+        /// <summary>
+        /// Gets the ID of the original service that initiated this request.
+        /// </summary>
+        public string ParentOperationId { get; }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -11,6 +11,7 @@ namespace Arcus.Observability.Telemetry.Core
         {
             public const string OperationId = "OperationId";
             public const string TransactionId = "TransactionId";
+            public const string OperationParentId = "OperationParentId";
         }
 
         public static class DependencyTracking

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
+{
+    /// <summary>
+    /// Represents the consumer-configurable options model to change the behavior of the Serilog <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/>.
+    /// </summary>
+    public class CorrelationInfoEnricherOptions
+    {
+        private string _operationIdPropertyName = ContextProperties.Correlation.OperationId,
+                       _transactionIdPropertyName = ContextProperties.Correlation.TransactionId,
+                       _operationParentIdPropertyName = ContextProperties.Correlation.OperationParentId;
+
+        /// <summary>
+        /// Gets or sets the property name to enrich the log event with the correlation information operation ID.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string OperationIdPropertyName
+        {
+            get => _operationIdPropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information operation ID");
+                _operationIdPropertyName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the property name to enrich the log event with the correlation information transaction ID.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string TransactionIdPropertyName
+        {
+            get => _transactionIdPropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information transaction ID");
+                _transactionIdPropertyName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the property name to enrich the log event with the correlation information parent operation ID.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string OperationParentIdPropertyName
+        {
+            get => _operationParentIdPropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information parent operation ID");
+                _operationParentIdPropertyName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
@@ -106,7 +106,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             
             EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationIdPropertyName, correlationInfo.OperationId);
             EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.TransactionIdPropertyName, correlationInfo.TransactionId);
-            EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationParentIdPropertyName, correlationInfo.ParentOperationId);
+            EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationParentIdPropertyName, correlationInfo.OperationParentId);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
 using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
@@ -12,8 +13,6 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
     /// </summary>
     public class CorrelationInfoEnricher<TCorrelationInfo> : ILogEventEnricher where TCorrelationInfo : CorrelationInfo
     {
-        private readonly string _operationIdPropertyName, _transactionIdPropertyName;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> class.
         /// </summary>
@@ -36,16 +35,34 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor, 
             string operationIdPropertyName,
             string transactionIdPropertyName)
+            : this(correlationInfoAccessor, new CorrelationInfoEnricherOptions
+            {
+                OperationIdPropertyName = operationIdPropertyName,
+                TransactionIdPropertyName = transactionIdPropertyName
+            })
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> class.
+        /// </summary>
+        /// <param name="correlationInfoAccessor">The accessor implementation for the custom <see cref="CorrelationInfo"/> model.</param>
+        /// <param name="options">The user-configurable options to change the behavior of the enricher.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        public CorrelationInfoEnricher(
+            ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor, 
+            CorrelationInfoEnricherOptions options)
         {
             Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to enrich the log events with correlation information");
-            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
 
-            _operationIdPropertyName = operationIdPropertyName;
-            _transactionIdPropertyName = transactionIdPropertyName;
-
+            Options = options ?? new CorrelationInfoEnricherOptions();
             CorrelationInfoAccessor = correlationInfoAccessor;
         }
+
+        /// <summary>
+        /// Gets the user-configurable options to change the behavior of the enricher.
+        /// </summary>
+        protected CorrelationInfoEnricherOptions Options { get; }
 
         /// <summary>
         /// Gets the <see cref="ICorrelationInfoAccessor{TCorrelationInfo}"/> that provides the correlation model.
@@ -57,10 +74,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// </summary>
         /// <param name="logEvent">The log event to enrich.</param>
         /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logEvent"/> or the <paramref name="propertyFactory"/> is <c>null</c>.</exception>
+        public virtual void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            Guard.NotNull(logEvent, nameof(logEvent));
-            Guard.NotNull(propertyFactory, nameof(propertyFactory));
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
+            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
 
             TCorrelationInfo correlationInfo = CorrelationInfoAccessor.GetCorrelationInfo();
             if (correlationInfo is null)
@@ -77,17 +95,38 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <param name="logEvent">The log event to enrich with correlation information.</param>
         /// <param name="propertyFactory">The log property factory to create log properties with correlation information.</param>
         /// <param name="correlationInfo">The correlation model that contains the current correlation information.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logEvent"/>, the <paramref name="propertyFactory"/>, or the <paramref name="correlationInfo"/> is <c>null</c>.
+        /// </exception>
         protected virtual void EnrichCorrelationInfo(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, TCorrelationInfo correlationInfo)
         {
-            if (!String.IsNullOrEmpty(correlationInfo.OperationId))
-            {
-                LogEventProperty property = propertyFactory.CreateProperty(_operationIdPropertyName, correlationInfo.OperationId);
-                logEvent.AddPropertyIfAbsent(property);
-            }
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
+            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires the correlation information to enrich the log event");
+            
+            EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationIdPropertyName, correlationInfo.OperationId);
+            EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.TransactionIdPropertyName, correlationInfo.TransactionId);
+            EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationParentIdPropertyName, correlationInfo.ParentOperationId);
+        }
 
-            if (!String.IsNullOrEmpty(correlationInfo.TransactionId))
+        /// <summary>
+        /// Adds new log property to the <paramref name="logEvent"/> when the <paramref name="propertyValue"/> is present.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich with property.</param>
+        /// <param name="propertyFactory">The log property factory to create log properties.</param>
+        /// <param name="propertyName">The name of the log property.</param>
+        /// <param name="propertyValue">The value of the log property.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logEvent"/> or the <paramref name="propertyFactory"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
+        protected void EnrichLogPropertyIfPresent(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, string propertyName, string propertyValue)
+        {
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
+            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank name for the correlation log property");
+            
+            if (!String.IsNullOrEmpty(propertyValue))
             {
-                LogEventProperty property = propertyFactory.CreateProperty(_transactionIdPropertyName, correlationInfo.TransactionId);
+                LogEventProperty property = propertyFactory.CreateProperty(propertyName, propertyValue);
                 logEvent.AddPropertyIfAbsent(property);
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
 using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Configuration;
@@ -138,6 +139,9 @@ namespace Serilog
         /// <summary>
         /// Adds the previously registered <see cref="ICorrelationInfoAccessor"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
+        /// <remarks>
+        ///     Use the <see cref="WithCorrelationInfo(LoggerEnrichmentConfiguration,IServiceProvider,Action{CorrelationInfoEnricherOptions})"/> overload to configure the operation parent ID.
+        /// </remarks>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
         /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
@@ -157,6 +161,25 @@ namespace Serilog
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
+        }
+        
+        /// <summary>
+        /// Adds the previously registered <see cref="ICorrelationInfoAccessor"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
+        /// <param name="configureOptions">The function to configure the options to change the behavior of the enricher.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public static LoggerConfiguration WithCorrelationInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            IServiceProvider serviceProvider,
+            Action<CorrelationInfoEnricherOptions> configureOptions)
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+
+            var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
+            return WithCorrelationInfo(enrichmentConfiguration, accessor, configureOptions);
         }
 
         /// <summary>
@@ -184,6 +207,9 @@ namespace Serilog
         /// <summary>
         /// Adds the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
+        /// <remarks>
+        ///     Use the <see cref="WithCorrelationInfo{TCorrelationInfo}(LoggerEnrichmentConfiguration,IServiceProvider,Action{CorrelationInfoEnricherOptions})"/> overload to configure the operation parent ID.
+        /// </remarks>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
         /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
@@ -205,10 +231,33 @@ namespace Serilog
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
         }
+        
+        /// <summary>
+        /// Adds the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="serviceProvider">The instance to provide the <see cref="ICorrelationInfoAccessor"/> service while enriching the log events with the correlation information.</param>
+        /// <param name="configureOptions">The function to configure the options to change the behavior of the enricher.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration,
+            IServiceProvider serviceProvider,
+            Action<CorrelationInfoEnricherOptions> configureOptions)
+            where TCorrelationInfo : CorrelationInfo
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+
+            var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
+            return WithCorrelationInfo(enrichmentConfiguration, accessor, configureOptions);
+        }
 
         /// <summary>
         /// Adds the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
         /// </summary>
+        /// <remarks>
+        ///     Use the <see cref="WithCorrelationInfo(LoggerEnrichmentConfiguration,ICorrelationInfoAccessor,Action{CorrelationInfoEnricherOptions})"/> to configure the operation parent ID.
+        /// </remarks>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="correlationInfoAccessor">The accessor implementation for the <see cref="CorrelationInfo"/> model.</param>
         /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
@@ -228,11 +277,33 @@ namespace Serilog
 
             return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName);
         }
+        
+        /// <summary>
+        /// Adds the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> to the logger enrichment configuration which adds the <see cref="CorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="correlationInfoAccessor">The accessor implementation for the <see cref="CorrelationInfo"/> model.</param>
+        /// <param name="configureOptions">The function to configure the options to change the behavior of the enricher.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        public static LoggerConfiguration WithCorrelationInfo(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            ICorrelationInfoAccessor correlationInfoAccessor,
+            Action<CorrelationInfoEnricherOptions> configureOptions)
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+
+            return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, configureOptions);
+        }
 
         /// <summary>
         /// Adds the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> to the logger enrichment configuration which adds the custom <typeparamref name="TCorrelationInfo"/> information from the current context.
         /// </summary>
         /// <typeparam name="TCorrelationInfo">The type of the custom <see cref="CorrelationInfo"/> model.</typeparam>
+        /// <remarks>
+        ///     Use the <see cref="WithCorrelationInfo{TCorrelationInfo}(LoggerEnrichmentConfiguration,ICorrelationInfoAccessor{TCorrelationInfo},Action{CorrelationInfoEnricherOptions})"/>
+        ///     overload to configure the the operation parent ID.
+        /// </remarks>
         /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
         /// <param name="correlationInfoAccessor">The accessor implementation for the <typeparamref name="TCorrelationInfo"/> model.</param>
         /// <param name="operationIdPropertyName">The name of the property to enrich the log event with the correlation operation ID.</param>
@@ -254,6 +325,29 @@ namespace Serilog
             return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName));
         }
 
+        /// <summary>
+        /// Adds the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> to the logger enrichment configuration which adds the custom <typeparamref name="TCorrelationInfo"/> information from the current context.
+        /// </summary>
+        /// <typeparam name="TCorrelationInfo">The type of the custom <see cref="CorrelationInfo"/> model.</typeparam>
+        /// <param name="enrichmentConfiguration">The configuration to add the enricher.</param>
+        /// <param name="correlationInfoAccessor">The accessor implementation for the <typeparamref name="TCorrelationInfo"/> model.</param>
+        /// <param name="configureOptions">The function to configure the options to change the behavior of the enricher.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="enrichmentConfiguration"/> or <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        public static LoggerConfiguration WithCorrelationInfo<TCorrelationInfo>(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor,
+            Action<CorrelationInfoEnricherOptions> configureOptions) 
+            where TCorrelationInfo : CorrelationInfo
+        {
+            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+
+            var options = new CorrelationInfoEnricherOptions();
+            configureOptions?.Invoke(options);
+            
+            return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor, options));
+        }
+        
         /// <summary>
         /// Adds the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> to the logger enrichment configuration which adds the custom <typeparamref name="TCorrelationInfo"/> information from the current context.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -21,9 +21,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
                 return;
             }
 
-            if (telemetryEntry.Properties.TryGetValue(ContextProperties.Correlation.OperationId, out string correlationId))
+            if (telemetryEntry.Properties.TryGetValue(ContextProperties.Correlation.OperationId, out string operationId))
             {
-                telemetryEntry.Context.Operation.Id = correlationId;
+                telemetryEntry.Context.Operation.Id = operationId;
+            }
+
+            if (telemetryEntry.Properties.TryGetValue(ContextProperties.Correlation.OperationParentId, out string operationParentId))
+            {
+                telemetryEntry.Context.Operation.ParentId = operationParentId;
             }
         }
     }

--- a/src/Arcus.Observability.Tests.Integration/AssertX.cs
+++ b/src/Arcus.Observability.Tests.Integration/AssertX.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using GuardNet;
+using Xunit.Sdk;
+
+// ReSharper disable once CheckNamespace
+namespace Xunit
+{
+    /// <summary>
+    /// Extension class on the xUnit <see cref="Assert"/>.
+    /// </summary>
+    [DebuggerStepThrough]
+    public static class AssertX
+    {
+        /// <summary>
+        /// Verifies that a <paramref name="collection"/> has at least one element that matches the given <paramref name="assertion"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the <paramref name="collection"/>.</typeparam>
+        /// <param name="collection">The collection to set through.</param>
+        /// <param name="assertion">The element assertion to find at least a single element that matches.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or <paramref name="assertion"/> is <c>null</c>.</exception>
+        public static void Any<T>(IEnumerable<T> collection, Action<T> assertion)
+        {
+            Guard.NotNull(collection, nameof(collection), "Requires collection of elements to find a single element that matches the assertion");
+            Guard.NotNull(assertion, nameof(assertion), "Requires an element assertion to verify if an single element in the collection matches");
+            
+            T[] array = collection.ToArray();
+            var stack = new Stack<Tuple<int, object, Exception>>();
+
+            for (var index = 0; index < array.Length; index++)
+            {
+                T item = array[index];
+                try
+                {
+                    assertion(item);
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    stack.Push(new Tuple<int, object, Exception>(index, item, exception));
+                }
+            }
+
+            if (stack.Count > 0)
+            {
+                throw new ContainsException(array.Length, stack.ToArray());
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/ApplicationEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/ApplicationEnricherTests.cs
@@ -5,7 +5,7 @@ using Serilog;
 using Serilog.Events;
 using Xunit;
 
-namespace Arcus.Observability.Tests.Unit.Serilog
+namespace Arcus.Observability.Tests.Unit.Serilog.Enrichers
 {
     [Trait("Category", "Unit")]
     public class ApplicationEnricherTests

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/Configuration/CorrelationInfoEnricherOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/Configuration/CorrelationInfoEnricherOptionsTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog.Enrichers.Configuration
+{
+    [Trait("Category", "Unit")]
+    public class CorrelationInfoEnricherOptionsTests
+    {
+        [Fact]
+        public void SetOperationIdPropertyName_WithValue_GetsValue()
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            var expected = $"operation-{Guid.NewGuid()}";
+            
+            // Act
+            options.OperationIdPropertyName = expected;
+            
+            // Assert
+            Assert.Equal(expected, options.OperationIdPropertyName);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void SetOperationIdPropertyName_WithBlankValue_Fails(string operationIdPropertyName)
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.OperationIdPropertyName = operationIdPropertyName);
+        }
+
+        [Fact]
+        public void SetTransactionIdPropertyName_WithValue_GetsValue()
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            var expected = $"transaction-{Guid.NewGuid()}";
+            
+            // Act
+            options.TransactionIdPropertyName = expected;
+            
+            // Assert
+            Assert.Equal(expected, options.TransactionIdPropertyName);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void SetTransactionIdPropertyName_WithBlankValue_Fails(string transactionIdPropertyName)
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.TransactionIdPropertyName = transactionIdPropertyName);
+        }
+
+        [Fact]
+        public void SetOperationParentIdPropertyName_WithValue_GetsValue()
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            var expected = $"operation-parent-{Guid.NewGuid()}";
+            
+            // Act
+            options.OperationParentIdPropertyName = expected;
+            
+            // Assert
+            Assert.Equal(expected, options.OperationParentIdPropertyName);
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void SetOperationParentIdPropertyName_WithBlankValue_Fails(string operationParentIdPropertyName)
+        {
+            // Arrange
+            var options = new CorrelationInfoEnricherOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.OperationParentIdPropertyName = operationParentIdPropertyName);
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/KubernetesEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/KubernetesEnricherTests.cs
@@ -3,7 +3,7 @@ using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Serilog;
 using Xunit;
 
-namespace Arcus.Observability.Tests.Unit.Serilog
+namespace Arcus.Observability.Tests.Unit.Serilog.Enrichers
 {
     [Trait("Category", "Unit")]
     public class KubernetesEnricherTests

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/TestCorrelationInfoEnricher.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/TestCorrelationInfoEnricher.cs
@@ -4,7 +4,7 @@ using Arcus.Observability.Tests.Unit.Correlation;
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Arcus.Observability.Tests.Unit.Serilog 
+namespace Arcus.Observability.Tests.Unit.Serilog.Enrichers 
 {
     /// <summary>
     /// Test implementation for the <see cref="CorrelationInfoEnricher{TCorrelationInfo}"/> using the test <see cref="TestCorrelationInfo"/> model.

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/VersionEnricherTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Enrichers/VersionEnricherTests.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.Observability.Tests.Core;
-using Arcus.Observability.Tests.Unit.Serilog;
+using Arcus.Observability.Tests.Unit.Serilog.Enrichers;
 using Arcus.Observability.Tests.Unit.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -13,7 +13,7 @@ using Xunit;
 
 [assembly: AssemblyFileVersion(VersionEnricherTests.AssemblyVersion)]
 
-namespace Arcus.Observability.Tests.Unit.Serilog
+namespace Arcus.Observability.Tests.Unit.Serilog.Enrichers
 {
     [Trait(name: "Category", value: "Unit")]
     public class VersionEnricherTests


### PR DESCRIPTION
Adds the operation parent ID correlation information to our `CorrelatinoInfo` model so we can also include it in Serilog enrichment.

Relates to https://github.com/arcus-azure/arcus.webapi/issues/233