### PR TITLE
feat: Provide dependency names for dependencies & requests

### DIFF
--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Logging
             PathString resourcePath = request.Path;
             var host = $"{request.Scheme}://{request.Host}";
 
-            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, null, responseStatusCode, duration, context));
+            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, responseStatusCode, duration, context));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerExtensions.cs
@@ -49,6 +49,37 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">Logger to use</param>
         /// <param name="request">Request that was done</param>
+        /// <param name="response">Response that will be sent out</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or <paramref name="response"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s scheme contains whitespace, the <paramref name="request"/>'s host is missing or contains whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogRequest(this ILogger logger, HttpRequest request, HttpResponse response, string operationName, TimeSpan duration, Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
+            Guard.For(() => !request.Path.HasValue, new ArgumentException("Requires a HTTP request with a path", nameof(request)));
+            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request with a HTTP method", nameof(request)));
+            Guard.For(() => request.Scheme?.Contains(" ") == true, new ArgumentException("Requires a HTTP request scheme without whitespace to track a HTTP request", nameof(request)));
+            Guard.For(() => !request.Host.HasValue, new ArgumentException("Requires a HTTP request with a host value to track a HTTP request", nameof(request)));
+            Guard.For(() => request.Host.ToString()?.Contains(" ") == true, new ArgumentException("Requires a HTTP request host name without whitespace to track a HTTP request", nameof(request)));
+            Guard.NotLessThan(response.StatusCode, 0, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan(response.StatusCode, 999, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
+
+            LogRequest(logger, request, response.StatusCode, operationName, duration, context);
+        }
+
+        /// <summary>
+        ///     Logs an HTTP request
+        /// </summary>
+        /// <param name="logger">Logger to use</param>
+        /// <param name="request">Request that was done</param>
         /// <param name="responseStatusCode">HTTP status code returned by the service</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
@@ -75,7 +106,42 @@ namespace Microsoft.Extensions.Logging
             PathString resourcePath = request.Path;
             var host = $"{request.Scheme}://{request.Host}";
 
-            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, responseStatusCode, duration, context));
+            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, null, responseStatusCode, duration, context));
+        }
+
+        /// <summary>
+        ///     Logs an HTTP request
+        /// </summary>
+        /// <param name="logger">Logger to use</param>
+        /// <param name="request">Request that was done</param>
+        /// <param name="responseStatusCode">HTTP status code returned by the service</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="request"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s scheme contains whitespace, the <paramref name="request"/>'s host is missing or contains whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogRequest(this ILogger logger, HttpRequest request, int responseStatusCode, string operationName, TimeSpan duration, Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.For(() => !request.Path.HasValue, new ArgumentException("Requires a HTTP request with a path", nameof(request)));
+            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request with a HTTP method", nameof(request)));
+            Guard.For(() => request.Scheme?.Contains(" ") == true, new ArgumentException("Requires a HTTP request scheme without whitespace to track a HTTP request", nameof(request)));
+            Guard.For(() => !request.Host.HasValue, new ArgumentException("Requires a HTTP request with a host value to track a HTTP request", nameof(request)));
+            Guard.For(() => request.Host.ToString()?.Contains(" ") == true, new ArgumentException("Requires a HTTP request host name without whitespace to track a HTTP request", nameof(request)));
+            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
+
+            context = context ?? new Dictionary<string, object>();
+
+            PathString resourcePath = request.Path;
+            var host = $"{request.Scheme}://{request.Host}";
+
+            logger.LogWarning(MessageFormats.RequestFormat, new RequestLogEntry(request.Method, host, resourcePath, operationName, responseStatusCode, duration, context));
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, null, statusCode, duration, context));
+            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, statusCode, duration, context));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -225,6 +225,37 @@ namespace Microsoft.Extensions.Logging
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="dependencyName">The name of the dependency</param>
+        /// <param name="measurement">Measuring the latency to call the dependency</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        public static void LogDependency(
+            this ILogger logger,            
+            string dependencyType,
+            object dependencyData,
+            bool isSuccessful,
+            string dependencyName,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+
+            LogDependency(logger, dependencyType, dependencyData, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        ///     Logs a dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="dependencyType">Custom type of dependency</param>
+        /// <param name="dependencyData">Custom data of dependency</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
@@ -248,6 +279,40 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
             
             LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
+        }
+
+        /// <summary>
+        ///     Logs a dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="dependencyType">Custom type of dependency</param>
+        /// <param name="dependencyData">Custom data of dependency</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="dependencyName">The name of the dependency</param>
+        /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogDependency(
+            this ILogger logger,            
+            string dependencyType,
+            object dependencyData,
+            bool isSuccessful,
+            string dependencyName,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+
+            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, dependencyName, startTime: startTime, duration: duration, context: context);
         }
 
         /// <summary>
@@ -287,6 +352,39 @@ namespace Microsoft.Extensions.Logging
         /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="dependencyType">Custom type of dependency</param>
         /// <param name="dependencyData">Custom data of dependency</param>
+        /// <param name="targetName">Name of the dependency target</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="dependencyName">The name of the dependency</param>
+        /// <param name="measurement">Measuring the latency to call the dependency</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/>, <paramref name="measurement"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        public static void LogDependency(
+            this ILogger logger,
+            string dependencyType,
+            object dependencyData,
+            string targetName,
+            bool isSuccessful,
+            string dependencyName,
+            DependencyMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+
+            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        ///     Logs a dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="dependencyType">Custom type of dependency</param>
+        /// <param name="dependencyData">Custom data of dependency</param>
         /// <param name="targetName">Name of dependency target</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
@@ -311,18 +409,54 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
             Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-            
+
+            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName: targetName, startTime, duration, context);
+        }
+
+        /// <summary>
+        ///     Logs a dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="dependencyType">Custom type of dependency</param>
+        /// <param name="dependencyData">Custom data of dependency</param>
+        /// <param name="targetName">Name of dependency target</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="dependencyName">The name of the dependency</param>
+        /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogDependency(
+            this ILogger logger,            
+            string dependencyType,
+            object dependencyData,
+            string targetName,
+            bool isSuccessful,
+            string dependencyName,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+
             context = context ?? new Dictionary<string, object>();
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
-                dependencyType, 
-                dependencyName: targetName, 
-                dependencyData: dependencyData, 
-                targetName: targetName, 
-                duration: duration, 
-                startTime: startTime, 
+                dependencyType,
+                dependencyName: dependencyName,
+                dependencyData: dependencyData,
+                targetName: targetName,
+                duration: duration,
+                startTime: startTime,
                 resultCode: null,
-                isSuccessful: isSuccessful, 
+                isSuccessful: isSuccessful,
                 context: context));
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType, 
-                dependencyName: null, 
+                dependencyName: targetName, 
                 dependencyData: dependencyData, 
                 targetName: targetName, 
                 duration: duration, 
@@ -398,10 +398,10 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
             
             context = context ?? new Dictionary<string, object>();
-            
+
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure key vault", 
-                dependencyName: null, 
+                dependencyName: vaultUri, 
                 dependencyData: secretName, 
                 targetName: vaultUri, 
                 duration: duration, 
@@ -470,7 +470,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Search", 
-                dependencyName: null, 
+                dependencyName: searchServiceName, 
                 dependencyData: operationName, 
                 targetName: searchServiceName, 
                 duration: duration, 
@@ -637,7 +637,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Service Bus", 
-                dependencyName: null, 
+                dependencyName: entityName, 
                 dependencyData: null, 
                 targetName: entityName, 
                 duration: duration, 
@@ -703,9 +703,11 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
+            string dependencyName = $"{accountName}/{containerName}";
+
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure blob", 
-                dependencyName: null, 
+                dependencyName: dependencyName, 
                 dependencyData: containerName, 
                 targetName: accountName, 
                 duration: duration, 
@@ -771,9 +773,11 @@ namespace Microsoft.Extensions.Logging
             
             context = context ?? new Dictionary<string, object>();
 
+            string dependencyName = $"{accountName}/{tableName}";
+
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure table",
-                dependencyName: null,
+                dependencyName: dependencyName,
                 dependencyData: tableName,
                 targetName: accountName,
                 duration: duration,
@@ -841,7 +845,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Event Hubs",
-                dependencyName: null,
+                dependencyName: eventHubName,
                 dependencyData: namespaceName,
                 targetName: eventHubName,
                 duration: duration,
@@ -903,7 +907,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure IoT Hub", 
-                dependencyName: null, 
+                dependencyName: iotHubName, 
                 dependencyData: null, 
                 targetName: iotHubName, 
                 duration: duration, 
@@ -978,7 +982,7 @@ namespace Microsoft.Extensions.Logging
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure DocumentDB", 
-                dependencyName: null, 
+                dependencyName: data, 
                 dependencyData: data, 
                 targetName: accountName, 
                 duration: duration, 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -66,6 +66,46 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="request">Request that was done</param>
+        /// <param name="response">Response that will be sent out</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s URI is blank,
+        ///     the <paramref name="request"/>'s scheme contains whitespace,
+        ///     the <paramref name="request"/>'s host contains whitespace,
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="response"/>'s status code is outside the 0-999 inclusively,
+        ///     the <paramref name="duration"/> is a negative time range.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestMessage request,
+            HttpResponseMessage response,
+            string operationName,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
+            Guard.NotNull(request.RequestUri, nameof(request.RequestUri), "Requires a request URI to track a HTTP request");
+            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "Requires a HTTP request scheme without whitespace");
+            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotLessThan((int)response.StatusCode, 0, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan((int)response.StatusCode, 999, nameof(response), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+
+            LogRequest(logger, request, response.StatusCode, operationName, duration, context);
+        }
+
+        /// <summary>
+        ///     Logs an HTTP request
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">Request that was done</param>
         /// <param name="responseStatusCode">HTTP status code returned by the service</param>
         /// <param name="duration">Duration of the operation</param>
         /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
@@ -101,7 +141,52 @@ namespace Microsoft.Extensions.Logging
             string resourcePath = request.RequestUri.AbsolutePath;
             string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
 
-            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, statusCode, duration, context));
+            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, null, statusCode, duration, context));
+        }
+
+        /// <summary>
+        ///     Logs an HTTP request
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">Request that was done</param>
+        /// <param name="responseStatusCode">HTTP status code returned by the service</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="context">Context that provides more insights on the HTTP request that was tracked</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="request"/>'s URI is blank,
+        ///     the <paramref name="request"/>'s scheme contains whitespace,
+        ///     the <paramref name="request"/>'s host contains whitespace,
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="responseStatusCode"/>'s status code is outside the 0-999 inclusively,
+        ///     the <paramref name="duration"/> is a negative time range.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestMessage request,
+            HttpStatusCode responseStatusCode,
+            string operationName,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(request.RequestUri, nameof(request.RequestUri), "Requires a request URI to track a HTTP request");
+            Guard.For<ArgumentException>(() => request.RequestUri.Scheme?.Contains(" ") == true, "Requires a HTTP request scheme without whitespace");
+            Guard.For<ArgumentException>(() => request.RequestUri.Host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotLessThan((int)responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotGreaterThan((int)responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+
+            context = context ?? new Dictionary<string, object>();
+
+            var statusCode = (int)responseStatusCode;
+            string resourcePath = request.RequestUri.AbsolutePath;
+            string host = $"{request.RequestUri.Scheme}://{request.RequestUri.Host}";
+
+            logger.LogWarning(RequestFormat, new RequestLogEntry(request.Method.ToString(), host, resourcePath, operationName, statusCode, duration, context));
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -16,6 +16,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <param name="method">The HTTP method of the request.</param>
         /// <param name="host">The host that was requested.</param>
         /// <param name="uri">The URI of the request.</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
         /// <param name="statusCode">The HTTP status code returned by the service.</param>
         /// <param name="duration">The duration of the processing of the request.</param>
         /// <param name="context">The context that provides more insights on the HTTP request that was tracked.</param>
@@ -32,6 +33,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             string method, 
             string host, 
             string uri, 
+            string operationName,
             int statusCode,
             TimeSpan duration,
             IDictionary<string, object> context)
@@ -46,6 +48,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             RequestUri = uri;
             ResponseStatusCode = statusCode;
             RequestDuration = duration;
+            OperationName = operationName;
             RequestTime = DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat);
             Context = context;
             Context[ContextProperties.General.TelemetryType] = TelemetryType.Request;
@@ -80,7 +83,12 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the date when the request occurred.
         /// </summary>
         public string RequestTime { get; }
-        
+
+        /// <summary>
+        /// Gets the name of the operation.
+        /// </summary>
+        public string OperationName { get; }
+
         /// <summary>
         /// Gets the context that provides more insights on the HTTP request that was tracked.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -66,6 +66,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             IDictionary<string, object> context)
         {
             Guard.For<ArgumentException>(() => host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires an operation name that is not null or whitespace");
             Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
             Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -35,12 +35,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             int statusCode,
             TimeSpan duration,
             IDictionary<string, object> context) : this (method, host, uri, $"{method} {uri}", statusCode, duration, context)
-        {
-            Guard.For<ArgumentException>(() => host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-        }
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestLogEntry"/> class.

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -34,21 +34,12 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             string uri,
             int statusCode,
             TimeSpan duration,
-            IDictionary<string, object> context)
+            IDictionary<string, object> context) : this (method, host, uri, $"{method} {uri}", statusCode, duration, context)
         {
             Guard.For<ArgumentException>(() => host?.Contains(" ") == true, "Requires a HTTP request host name without whitespace");
             Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
             Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            RequestMethod = method;
-            RequestHost = host;
-            RequestUri = uri;
-            ResponseStatusCode = statusCode;
-            RequestDuration = duration;
-            RequestTime = DateTimeOffset.UtcNow.ToString(FormatSpecifiers.InvariantTimestampFormat);
-            Context = context;
-            Context[ContextProperties.General.TelemetryType] = TelemetryType.Request;
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CloudContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CloudContextConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Serilog.Events;
 
@@ -29,6 +30,16 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
             telemetry.Context.Cloud.RoleName = componentName;
             telemetry.Context.Cloud.RoleInstance = string.IsNullOrWhiteSpace(podName) ? machineName : podName;
+
+            //if (telemetry is RequestTelemetry f)
+            //{
+            //    f.Context.Operation.Name = f.Name;
+            //}
+
+            //if (telemetry is DependencyTelemetry d)
+            //{
+            //    d.Context.Operation.Name = d.Name;
+            //}
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CloudContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CloudContextConverter.cs
@@ -30,16 +30,6 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
             telemetry.Context.Cloud.RoleName = componentName;
             telemetry.Context.Cloud.RoleInstance = string.IsNullOrWhiteSpace(podName) ? machineName : podName;
-
-            //if (telemetry is RequestTelemetry f)
-            //{
-            //    f.Context.Operation.Name = f.Name;
-            //}
-
-            //if (telemetry is DependencyTelemetry d)
-            //{
-            //    d.Context.Operation.Name = d.Name;
-            //}
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -45,6 +45,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
             ForwardPropertiesToTelemetryProperties(logEvent, telemetryEntry, formatProvider);
             _operationContextConverter.EnrichWithCorrelationInfo(telemetryEntry);
+            _operationContextConverter.EnrichWithOperationName(telemetryEntry);
 
             return new List<ITelemetry> { telemetryEntry };
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -2,6 +2,7 @@
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using System;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
 {
@@ -29,6 +30,42 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             if (telemetryEntry.Properties.TryGetValue(ContextProperties.Correlation.OperationParentId, out string operationParentId))
             {
                 telemetryEntry.Context.Operation.ParentId = operationParentId;
+            }
+        }
+
+        /// <summary>
+        /// Enrich the given <paramref name="telemetryEntry"/> with the operation name.
+        /// </summary>
+        /// <param name="telemetryEntry">The telemetry instance to enrich.</param>
+        public void EnrichWithOperationName<TEntry>(TEntry telemetryEntry) where TEntry : ITelemetry, ISupportProperties
+        {
+            if (telemetryEntry is RequestTelemetry r)
+            {
+                // Check if operation has already been set with a custom value in the RequestTelemetryConverter, if not use the request name
+                if (String.IsNullOrEmpty(r.Context.Operation.Name))
+                {
+                    r.Context.Operation.Name = r.Name;
+                }
+            }
+
+            if (telemetryEntry is DependencyTelemetry d)
+            {
+                d.Context.Operation.Name = d.Name;
+            }
+
+            if (telemetryEntry is EventTelemetry e)
+            {
+                e.Context.Operation.Name = e.Name;
+            }
+
+            if (telemetryEntry is AvailabilityTelemetry a)
+            {
+                a.Context.Operation.Name = a.Name;
+            }
+
+            if (telemetryEntry is MetricTelemetry m)
+            {
+                m.Context.Operation.Name = m.Name;
             }
         }
     }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -39,33 +39,33 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="telemetryEntry">The telemetry instance to enrich.</param>
         public void EnrichWithOperationName<TEntry>(TEntry telemetryEntry) where TEntry : ITelemetry, ISupportProperties
         {
-            if (telemetryEntry is RequestTelemetry r)
+            if (telemetryEntry is RequestTelemetry requestTelemetry)
             {
                 // Check if operation has already been set with a custom value in the RequestTelemetryConverter, if not use the request name
-                if (String.IsNullOrEmpty(r.Context.Operation.Name))
+                if (String.IsNullOrEmpty(requestTelemetry.Context.Operation.Name))
                 {
-                    r.Context.Operation.Name = r.Name;
+                    requestTelemetry.Context.Operation.Name = requestTelemetry.Name;
                 }
             }
 
-            if (telemetryEntry is DependencyTelemetry d)
+            if (telemetryEntry is DependencyTelemetry dependencyTelemetry)
             {
-                d.Context.Operation.Name = d.Name;
+                dependencyTelemetry.Context.Operation.Name = dependencyTelemetry.Name;
             }
 
-            if (telemetryEntry is EventTelemetry e)
+            if (telemetryEntry is EventTelemetry eventTelemetry)
             {
-                e.Context.Operation.Name = e.Name;
+                eventTelemetry.Context.Operation.Name = eventTelemetry.Name;
             }
 
-            if (telemetryEntry is AvailabilityTelemetry a)
+            if (telemetryEntry is AvailabilityTelemetry availabilityTelemetry)
             {
-                a.Context.Operation.Name = a.Name;
+                availabilityTelemetry.Context.Operation.Name = availabilityTelemetry.Name;
             }
 
-            if (telemetryEntry is MetricTelemetry m)
+            if (telemetryEntry is MetricTelemetry metricTelemetry)
             {
-                m.Context.Operation.Name = m.Name;
+                metricTelemetry.Context.Operation.Name = metricTelemetry.Name;
             }
         }
     }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -43,16 +43,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             var requestTelemetry = new RequestTelemetry(requestName, requestTime, requestDuration, responseStatusCode, isSuccessfulRequest)
             {
                 Id = operationId,
-                Url = url,
+                Url = url
             };
 
             if (!String.IsNullOrEmpty(operationName))
             {
                 requestTelemetry.Context.Operation.Name = $"{requestMethod} {operationName}";
-            }
-            else
-            {
-                requestTelemetry.Context.Operation.Name = requestName;
             }
 
             requestTelemetry.Properties.AddRange(context);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -46,9 +46,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
                 Url = url
             };
 
-            if (!String.IsNullOrEmpty(operationName))
+            // Add requestMethod to the operationName if it is missing
+            if (!operationName.StartsWith(requestMethod))
             {
                 requestTelemetry.Context.Operation.Name = $"{requestMethod} {operationName}";
+            }
+            else
+            {
+                requestTelemetry.Context.Operation.Name = operationName;
             }
 
             requestTelemetry.Properties.AddRange(context);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -29,6 +29,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             string requestHost = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestHost));
             string requestUri = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestUri));
             string responseStatusCode = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.ResponseStatusCode));
+            string operationName = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.OperationName));
             TimeSpan requestDuration = logEntry.Properties.GetAsTimeSpan(nameof(RequestLogEntry.RequestDuration));
             DateTimeOffset requestTime = logEntry.Properties.GetAsDateTimeOffset(nameof(RequestLogEntry.RequestTime));
             IDictionary<string, string> context = logEntry.Properties.GetAsDictionary(nameof(RequestLogEntry.Context));
@@ -44,6 +45,15 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
                 Id = operationId,
                 Url = url,
             };
+
+            if (!String.IsNullOrEmpty(operationName))
+            {
+                requestTelemetry.Context.Operation.Name = $"{requestMethod} {operationName}";
+            }
+            else
+            {
+                requestTelemetry.Context.Operation.Name = requestName;
+            }
 
             requestTelemetry.Properties.AddRange(context);
             return requestTelemetry;

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureKeyVaultDependencyTests.cs
@@ -28,6 +28,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string dependencyType = "Azure key vault";
             string vaultUri = "https://myvault.vault.azure.net";
             string secretName = "MySecret";
+            string dependencyName = vaultUri;
 
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
@@ -54,7 +55,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     {
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == vaultUri
-                               && result.Dependency.Data == secretName;
+                               && result.Dependency.Data == secretName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -71,6 +73,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(vaultUri, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/AzureSearchDependencyTests.cs
@@ -28,6 +28,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string dependencyType = "Azure Search";
             string searchServiceName = BogusGenerator.Commerce.Product();
             string operationName = BogusGenerator.Commerce.ProductName();
+            string dependencyName = searchServiceName;
 
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
@@ -54,7 +55,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     {
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == searchServiceName
-                               && result.Dependency.Data == operationName;
+                               && result.Dependency.Data == operationName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -71,6 +73,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(searchServiceName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/BlobStorageDependencyTests.cs
@@ -28,6 +28,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string componentName = BogusGenerator.Commerce.ProductName();
             string containerName = BogusGenerator.Commerce.ProductName();
             string accountName = BogusGenerator.Finance.AccountName();
+            string dependencyName = $"{accountName}/{containerName}";
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithComponentName(componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -54,7 +55,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == accountName
                                && result.Dependency.Data == containerName
-                               && result.Cloud.RoleName == componentName;
+                               && result.Cloud.RoleName == componentName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -71,6 +73,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(accountName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CosmosSqlDependencyTests.cs
@@ -29,6 +29,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string container = BogusGenerator.Commerce.ProductName();
             string database = BogusGenerator.Commerce.ProductName();
             string accountName = BogusGenerator.Finance.AccountName();
+            string dependencyData = $"{database}/{container}";
+            string dependencyName = $"{database}/{container}";
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithComponentName(componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -55,8 +58,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     {
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == accountName
-                               && result.Dependency.Data == $"{database}/{container}"
-                               && result.Cloud.RoleName == componentName;
+                               && result.Dependency.Data == dependencyData
+                               && result.Cloud.RoleName == componentName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -69,10 +73,13 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 Assert.Equal(dependencyType, actualDependencyType.Value.ToDecentString());
 
                 var actualDependencyData = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyData));
-                Assert.Equal($"{database}/{container}", actualDependencyData.Value.ToDecentString());
+                Assert.Equal(dependencyData, actualDependencyData.Value.ToDecentString());
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(accountName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -27,7 +27,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
-                
+
                 bool isSuccessful = BogusGenerator.PickRandom(true, false);
                 DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
@@ -47,8 +47,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Data == dependencyData);
                 });
             }
-            
-            AssertX.Any(GetLogEventsFromMemory(), logEvent => {
+
+            AssertX.Any(GetLogEventsFromMemory(), logEvent =>
+            {
                 StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
                 Assert.NotNull(logEntry);
 
@@ -73,7 +74,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
-                bool isSuccessful = BogusGenerator.PickRandom(true, false);                
+                bool isSuccessful = BogusGenerator.PickRandom(true, false);
                 DateTimeOffset startTime = DateTimeOffset.Now;
                 TimeSpan duration = BogusGenerator.Date.Timespan();
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
@@ -93,8 +94,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 });
             }
 
-AssertX.Any(GetLogEventsFromMemory(), logEvent => 
-{
+            AssertX.Any(GetLogEventsFromMemory(), logEvent =>
+            {
                 StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
                 Assert.NotNull(logEntry);
 

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -61,5 +61,53 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });
         }
+
+        [Fact]
+        public async Task LogDependency_SinksToApplicationInsights_ResultsInDependencyTelemetryWithDependencyName()
+        {
+            // Arrange
+            string dependencyType = "Arcus";
+            string dependencyData = BogusGenerator.Finance.Account();
+            string dependencyName = BogusGenerator.Random.Word();
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory())
+            {
+                ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
+
+                bool isSuccessful = BogusGenerator.PickRandom(true, false);                
+                DateTimeOffset startTime = DateTimeOffset.Now;
+                TimeSpan duration = BogusGenerator.Date.Timespan();
+                Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+                // Act
+                logger.LogDependency(dependencyType, dependencyData, isSuccessful, dependencyName, startTime, duration, telemetryContext);
+            }
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
+                    Assert.NotEmpty(results.Value);
+                    Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Data == dependencyData && result.Dependency.Name == dependencyName);
+                });
+            }
+
+            AssertX.Any(GetLogEventsFromMemory(), logEvent => {
+                StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
+                Assert.NotNull(logEntry);
+
+                var actualDependencyType = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyType));
+                Assert.Equal(dependencyType, actualDependencyType.Value.ToDecentString());
+
+                var actualDependencyData = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyData));
+                Assert.Equal(dependencyData, actualDependencyData.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
+
+                Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
+            });
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomDependencyTests.cs
@@ -93,7 +93,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 });
             }
 
-            AssertX.Any(GetLogEventsFromMemory(), logEvent => {
+AssertX.Any(GetLogEventsFromMemory(), logEvent => 
+{
                 StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
                 Assert.NotNull(logEntry);
 

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/EventHubsTests.cs
@@ -29,6 +29,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string componentName = BogusGenerator.Commerce.ProductName();
             string eventHubName = BogusGenerator.Commerce.ProductName();
             string namespaceName = BogusGenerator.Finance.AccountName();
+            string dependencyName = eventHubName;
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithComponentName(componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -54,7 +56,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == eventHubName
                                && result.Dependency.Data == namespaceName
-                               && result.Cloud.RoleName == componentName;
+                               && result.Cloud.RoleName == componentName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -71,6 +74,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(eventHubName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/IoTHubTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/IoTHubTests.cs
@@ -28,6 +28,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string dependencyType = "Azure IoT Hub";
             string componentName = BogusGenerator.Commerce.ProductName();
             string iotHubName = BogusGenerator.Commerce.ProductName();
+            string dependencyName = iotHubName;
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithComponentName(componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -52,7 +54,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     {
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == iotHubName
-                               && result.Cloud.RoleName == componentName;
+                               && result.Cloud.RoleName == componentName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -66,6 +69,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(iotHubName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
@@ -25,6 +25,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             // Arrange
             string dependencyType = "Azure Service Bus";
             string entityName = BogusGenerator.Commerce.Product();
+            string dependencyName = entityName;
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -45,7 +47,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 {
                     EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
-                    Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Target == entityName);
+                    Assert.Contains(results.Value, result => result.Dependency.Type == dependencyType && result.Dependency.Target == entityName && result.Dependency.Name == dependencyName);
                 });
             }
 
@@ -58,6 +60,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(entityName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
@@ -27,6 +27,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string serverName = BogusGenerator.Database.Engine();
             string databaseName = BogusGenerator.Database.Collation();
             string tableName = BogusGenerator.Database.Column();
+            string dependencyName = $"{databaseName}/{tableName}";
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory())
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -51,9 +53,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                     Assert.NotEmpty(results.Value);
                     Assert.Contains(results.Value, result =>
                     {
-                        return result.Dependency.Type == "SQL"
+                        return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == serverName
-                               && result.Dependency.Name == $"SQL: {databaseName}/{tableName}";
+                               && result.Dependency.Name == $"{dependencyType}: {dependencyName}";
                     });
                 });
             }
@@ -65,11 +67,11 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 var actualDependencyType = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyType));
                 Assert.Equal(dependencyType, actualDependencyType.Value.ToDecentString(), true);
 
-                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
-                Assert.Equal($"{databaseName}/{tableName}", actualDependencyName.Value.ToDecentString());
-
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(serverName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
@@ -28,6 +28,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string componentName = BogusGenerator.Commerce.ProductName();
             string tableName = BogusGenerator.Commerce.ProductName();
             string accountName = BogusGenerator.Finance.AccountName();
+            string dependencyName = $"{accountName}/{tableName}";
+
             using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => LoggerEnrichmentConfigurationExtensions.WithComponentName(config.Enrich, componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
@@ -54,7 +56,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                         return result.Dependency.Type == dependencyType
                                && result.Dependency.Target == accountName
                                && result.Dependency.Data == tableName
-                               && result.Cloud.RoleName == componentName;
+                               && result.Cloud.RoleName == componentName
+                               && result.Dependency.Name == dependencyName;
                     });
                 });
             }
@@ -71,6 +74,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                 var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(accountName, actualTargetName.Value.ToDecentString());
+
+                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+                Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
 
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });

--- a/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/TelemetryTypeFilterTests.cs
@@ -856,6 +856,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog
             var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
             string targetName = _bogusGenerator.Lorem.Word();
             bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyName = _bogusGenerator.Random.Word();
             DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
             TimeSpan duration = _bogusGenerator.Date.Timespan();
             string propertyName = _bogusGenerator.Random.Word();
@@ -873,7 +874,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog
                 ILogger logger = factory.CreateLogger<TelemetryTypeFilterTests>();
 
                 // Act
-                logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, startTime, duration, properties);
+                logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, properties);
 
                 // Assert
                 LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
@@ -885,6 +886,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog
                 Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
                 Assert.Contains(duration.ToString(), logMessage);
                 Assert.Contains(isSuccessful.ToString(), logMessage);
+                Assert.Contains(dependencyName, logMessage);
                 Assert.Contains(propertyName, logMessage);
                 Assert.Contains(propertyValue, logMessage);
             }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/OperationContextConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/OperationContextConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
+using Bogus;
 using Microsoft.ApplicationInsights.DataContracts;
 using Xunit;
 
@@ -9,6 +10,8 @@ namespace Arcus.Observability.Tests.Unit.Serilog
     [Trait("Category", "Unit")]
     public class OperationContextConverterTests
     {
+        private readonly Faker _bogusGenerator = new Faker();
+
         [Fact]
         public void EnrichWithCorrelationInfo_TraceWithOperationId_OperationIdSetOnContext()
         {
@@ -223,6 +226,122 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             Assert.NotNull(traceTelemetry.Context);
             Assert.NotNull(traceTelemetry.Context.Operation);
             Assert.Null(traceTelemetry.Context.Operation.Id);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_RequestWithRequestNameAndOperationName_OperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var operationName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new RequestTelemetry();
+            traceTelemetry.Name = telemetryName;
+            traceTelemetry.Context.Operation.Name = operationName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(operationName, traceTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_RequestWithRequestNameWithoutOperationName_NoOperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new RequestTelemetry();
+            traceTelemetry.Name = telemetryName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(telemetryName, traceTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_DependencyWithRequestName_NoOperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new DependencyTelemetry();
+            traceTelemetry.Name = telemetryName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(telemetryName, traceTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_EventWithRequestName_NoOperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new EventTelemetry();
+            traceTelemetry.Name = telemetryName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(telemetryName, traceTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_AvailabilityWithRequestName_NoOperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new AvailabilityTelemetry();
+            traceTelemetry.Name = telemetryName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(telemetryName, traceTelemetry.Context.Operation.Name);
+        }
+
+        [Fact]
+        public void EnrichWithOperationName_MetricWithRequestName_NoOperationNameSetOnContext()
+        {
+            // Arrange
+            var telemetryName = _bogusGenerator.Random.Word();
+            var traceTelemetry = new MetricTelemetry();
+            traceTelemetry.Name = telemetryName;
+            var converter = new OperationContextConverter();
+
+            // Act
+            converter.EnrichWithOperationName(traceTelemetry);
+
+            // Assert
+            Assert.NotNull(traceTelemetry);
+            Assert.NotNull(traceTelemetry.Context);
+            Assert.NotNull(traceTelemetry.Context.Operation);
+            Assert.Equal(telemetryName, traceTelemetry.Context.Operation.Name);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -528,6 +528,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(secretName, logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure key vault " + vaultUri, logMessage);
         }
 
         [Theory]
@@ -612,6 +614,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(secretName, logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure key vault " + vaultUri, logMessage);
         }
 
         [Theory]
@@ -683,6 +687,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Search " + searchServiceName, logMessage);
         }
 
         [Fact]
@@ -724,6 +730,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Search " + searchServiceName, logMessage);
         }
 
         [Fact]
@@ -748,6 +756,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + entityName, logMessage);
         }
 
         [Fact]
@@ -789,6 +799,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + entityName, logMessage);
         }
 
         [Fact]
@@ -812,6 +824,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + queueName, logMessage);
         }
 
         [Fact]
@@ -851,6 +865,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + queueName, logMessage);
         }
 
         [Fact]
@@ -874,6 +890,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + topicName, logMessage);
         }
         
         [Fact]
@@ -913,6 +931,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Service Bus " + topicName, logMessage);
         }
 
         [Fact]
@@ -941,6 +961,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{databaseName}/{tableName}";
+            Assert.Contains("Sql " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -982,6 +1005,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{accountName}/{containerName}";
+            Assert.Contains("Azure blob " + dependencyName, logMessage);
         }
         
         [Fact]
@@ -1014,7 +1040,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             TimeSpan duration = measurement.Elapsed;
 
             // Act
-            logger.LogBlobStorageDependency(containerName, accountName, isSuccessful, measurement);
+            logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement);
 
             // Assert
             var logMessage = logger.WrittenMessage;
@@ -1024,6 +1050,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{accountName}/{containerName}";
+            Assert.Contains("Azure blob " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1048,6 +1077,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{accountName}/{tableName}";
+            Assert.Contains("Azure table " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1090,6 +1122,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{accountName}/{tableName}";
+            Assert.Contains("Azure table " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1114,6 +1149,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Event Hubs " + eventHubName, logMessage);
         }
 
         [Fact]
@@ -1156,6 +1193,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure Event Hubs " + eventHubName, logMessage);
         }
 
         [Fact]
@@ -1179,6 +1218,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
         }
 
         [Fact]
@@ -1219,6 +1260,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
         }
 
         [Fact]
@@ -1245,6 +1288,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
         }
         
         [Fact]
@@ -1292,6 +1337,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
         }
 
         [Fact]
@@ -1318,6 +1365,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{database}/{container}";
+            Assert.Contains("Azure DocumentDB " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1363,6 +1413,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{database}/{container}";
+            Assert.Contains("Azure DocumentDB " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1395,6 +1448,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{databaseName}/{tableName}";
+            Assert.Contains("Sql " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1424,6 +1480,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{databaseName}/{tableName}";
+            Assert.Contains("Sql " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1579,6 +1638,9 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
+            // Check specifically on dependencyName
+            string dependencyName = $"{databaseName}/{tableName}";
+            Assert.Contains("Sql " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1604,6 +1666,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
+            // Check specifically on dependencyName
+            Uri requestUri = request.RequestUri;
+            HttpMethod requestMethod = request.Method;
+            string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
+            Assert.Contains("Http " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1660,6 +1727,11 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
+            // Check specifically on dependencyName
+            Uri requestUri = request.RequestUri;
+            HttpMethod requestMethod = request.Method;
+            string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
+            Assert.Contains("Http " + dependencyName, logMessage);
         }
 
         [Fact]

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -528,8 +528,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(secretName, logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure key vault " + vaultUri, logMessage);
+            string dependencyName = vaultUri;
+            Assert.Contains("Azure key vault " + dependencyName, logMessage);
         }
 
         [Theory]
@@ -614,8 +614,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(secretName, logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure key vault " + vaultUri, logMessage);
+            string dependencyName = vaultUri;
+            Assert.Contains("Azure key vault " + dependencyName, logMessage);
         }
 
         [Theory]
@@ -687,8 +687,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Search " + searchServiceName, logMessage);
+            string dependencyName = searchServiceName;
+            Assert.Contains("Azure Search " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -730,8 +730,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Search " + searchServiceName, logMessage);
+            string dependencyName = searchServiceName;
+            Assert.Contains("Azure Search " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -756,8 +756,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + entityName, logMessage);
+            string dependencyName = entityName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -799,8 +799,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + entityName, logMessage);
+            string dependencyName = entityName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -824,8 +824,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + queueName, logMessage);
+            string dependencyName = queueName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -865,8 +865,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + queueName, logMessage);
+            string dependencyName = queueName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -890,8 +890,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + topicName, logMessage);
+            string dependencyName = topicName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
         
         [Fact]
@@ -961,7 +961,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{databaseName}/{tableName}";
             Assert.Contains("Sql " + dependencyName, logMessage);
         }
@@ -1005,7 +1004,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{accountName}/{containerName}";
             Assert.Contains("Azure blob " + dependencyName, logMessage);
         }
@@ -1076,7 +1074,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{accountName}/{tableName}";
             Assert.Contains("Azure table " + dependencyName, logMessage);
         }
@@ -1121,7 +1118,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{accountName}/{tableName}";
             Assert.Contains("Azure table " + dependencyName, logMessage);
         }
@@ -1148,8 +1144,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Event Hubs " + eventHubName, logMessage);
+            string dependencyName = eventHubName;
+            Assert.Contains("Azure Event Hubs " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1192,8 +1188,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Event Hubs " + eventHubName, logMessage);
+            string dependencyName = eventHubName;
+            Assert.Contains("Azure Event Hubs " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1217,8 +1213,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
+            string dependencyName = iotHubName;
+            Assert.Contains("Azure IoT Hub " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1259,8 +1255,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
+            string dependencyName = iotHubName;
+            Assert.Contains("Azure IoT Hub " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1287,8 +1283,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
+            string dependencyName = iotHubName;
+            Assert.Contains("Azure IoT Hub " + dependencyName, logMessage);
         }
         
         [Fact]
@@ -1336,8 +1332,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure IoT Hub " + iotHubName, logMessage);
+            string dependencyName = iotHubName;
+            Assert.Contains("Azure IoT Hub " + dependencyName, logMessage);
         }
 
         [Fact]
@@ -1364,7 +1360,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{database}/{container}";
             Assert.Contains("Azure DocumentDB " + dependencyName, logMessage);
         }
@@ -1412,7 +1407,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{database}/{container}";
             Assert.Contains("Azure DocumentDB " + dependencyName, logMessage);
         }
@@ -1447,7 +1441,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{databaseName}/{tableName}";
             Assert.Contains("Sql " + dependencyName, logMessage);
         }
@@ -1479,7 +1472,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{databaseName}/{tableName}";
             Assert.Contains("Sql " + dependencyName, logMessage);
         }
@@ -1637,7 +1629,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{databaseName}/{tableName}";
             Assert.Contains("Sql " + dependencyName, logMessage);
         }
@@ -1665,7 +1656,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
-            // Check specifically on dependencyName
             Uri requestUri = request.RequestUri;
             HttpMethod requestMethod = request.Method;
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";
@@ -1726,7 +1716,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             var isSuccessful = (int) statusCode >= 200 && (int) statusCode < 300;
             Assert.Contains($"Successful: {isSuccessful}", logMessage);
-            // Check specifically on dependencyName
             Uri requestUri = request.RequestUri;
             HttpMethod requestMethod = request.Method;
             string dependencyName = $"{requestMethod} {requestUri.AbsolutePath}";

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -122,6 +122,32 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogDependency_ValidArgumentsWithDependencyName_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyName = _bogusGenerator.Random.Word();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act
+            logger.LogDependency(dependencyType, dependencyData, isSuccessful, dependencyName, startTime, duration);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+            Assert.Contains(dependencyType, logMessage);
+            Assert.Contains(dependencyData, logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+            Assert.Contains(isSuccessful.ToString(), logMessage);
+            Assert.Contains(dependencyName, logMessage);
+        }
+
+        [Fact]
         public void LogDependency_WithoutDependencyType_Fails()
         {
             // Arrange
@@ -191,7 +217,35 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
-        
+
+        [Fact]
+        public void LogDependencyWithDependencyMeasurement_ValidArgumentsWithDependencyName_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Lorem.Word();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyName = _bogusGenerator.Random.Word();
+            var measurement = DependencyMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogDependency(dependencyType, dependencyData, isSuccessful, dependencyName, measurement);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+            Assert.Contains(dependencyType, logMessage);
+            Assert.Contains(dependencyData, logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+            Assert.Contains(isSuccessful.ToString(), logMessage);
+            Assert.Contains(dependencyName, logMessage);
+        }
+
         [Fact]
         public void LogDependencyWithDependencyMeasurement_WithoutDependencyMeasurement_Fails()
         {
@@ -259,7 +313,34 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
-        
+
+        [Fact]
+        public void LogDependencyTarget_ValidArgumentsWithDependencyName_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Name.FullName();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyName = _bogusGenerator.Random.Word();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+
+            // Act
+            logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+            Assert.Contains(dependencyType, logMessage);
+            Assert.Contains(dependencyData, logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+            Assert.Contains(isSuccessful.ToString(), logMessage);
+            Assert.Contains(dependencyName, logMessage);
+        }
+
         [Fact]
         public void LogDependencyTarget_WithoutDependencyType_Fails()
         {
@@ -350,7 +431,36 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
         }
-        
+
+        [Fact]
+        public void LogDependencyWithDependencyMeasurementTarget_ValidArgumentsWithDependencyName_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Lorem.Word();
+            var dependencyData = _bogusGenerator.Finance.Amount().ToString("F");
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyName = _bogusGenerator.Random.Word();
+            var measurement = DependencyMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            // Act
+            logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, dependencyName, measurement);
+
+            // Assert
+            string logMessage = logger.WrittenMessage;
+            Assert.Contains(TelemetryType.Dependency.ToString(), logMessage);
+            Assert.Contains(dependencyType, logMessage);
+            Assert.Contains(dependencyData, logMessage);
+            Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
+            Assert.Contains(duration.ToString(), logMessage);
+            Assert.Contains(isSuccessful.ToString(), logMessage);
+            Assert.Contains(dependencyName, logMessage);
+        }
+
         [Fact]
         public void LogDependencyTargetWithDependencyMeasurement_WithoutDependencyType_Fails()
         {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1050,7 +1050,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(isSuccessful.ToString(), logMessage);
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
-            // Check specifically on dependencyName
             string dependencyName = $"{accountName}/{containerName}";
             Assert.Contains("Azure blob " + dependencyName, logMessage);
         }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -931,8 +931,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Contains(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), logMessage);
             Assert.Contains(duration.ToString(), logMessage);
             Assert.Contains(isSuccessful.ToString(), logMessage);
-            // Check specifically on dependencyName
-            Assert.Contains("Azure Service Bus " + topicName, logMessage);
+            var dependencyName = topicName;
+            Assert.Contains("Azure Service Bus " + dependencyName, logMessage);
         }
 
         [Fact]


### PR DESCRIPTION
- Requests are now logged with an operation name so they don't show in Application Insights as '<Empty>'. For example: 
![image](https://user-images.githubusercontent.com/32359437/131838050-911829f8-03a6-41df-b745-e8a669de0a45.png)
After discussion with @stijnmoreels we decided to add 2 overloads to be able to specify a custom operataion name as well. 
- Names have been added to all dependancies so that they don't show up in Application Insights 'n/a'. For example:
![image](https://user-images.githubusercontent.com/32359437/131838108-758c63f7-b34a-4c00-9341-810b9eda4117.png)
