### PR TITLE
feat: generate request telemetry id

### DIFF
--- a/docs/preview/02-Features/sinks/azure-application-insights.md
+++ b/docs/preview/02-Features/sinks/azure-application-insights.md
@@ -45,6 +45,25 @@ ILogger logger = new LoggerConfiguration()
 
 The Azure Application Insights sink has some additional configuration which can be changed to influence the tracking.
 
+### Requests
+
+### Request ID
+
+When tracking requests, the ID for the request telemetry is by default a generated GUID. The generation of this ID can be configurable via the options.
+This is useful (for example) in a service-to-service correlation system where you want the ID of the incoming request based on the sending system, or you want to incorporate the operation ID in the request ID.
+
+```csharp
+using Serilog;
+using Serilog.Configuration;
+
+ILogger logger = new LoggerConfiguration()
+    .WriteTo.AzureApplicationInsights("<key>", options =>
+    {
+        // Configurable generation function for the telemetry request ID.
+        options.Request.GenerateId = () => $"my-custom-ID-{Guid.NewGuid()}";
+    })
+```
+
 ### Exceptions
 
 #### Properties

--- a/docs/preview/02-Features/sinks/azure-application-insights.md
+++ b/docs/preview/02-Features/sinks/azure-application-insights.md
@@ -50,7 +50,7 @@ The Azure Application Insights sink has some additional configuration which can 
 ### Request ID
 
 When tracking requests, the ID for the request telemetry is by default a generated GUID. The generation of this ID can be configured via the options.
-This is useful (for example) in a service-to-service correlation system where you want the ID of the incoming request based on the sending system, or you want to incorporate the operation ID in the request ID.
+This is useful (for example) in a service-to-service correlation system where you want the ID of the incoming request to be based on the sending system, or you want to incorporate the operation ID in the request ID.
 
 ```csharp
 using Serilog;

--- a/docs/preview/02-Features/sinks/azure-application-insights.md
+++ b/docs/preview/02-Features/sinks/azure-application-insights.md
@@ -49,7 +49,7 @@ The Azure Application Insights sink has some additional configuration which can 
 
 ### Request ID
 
-When tracking requests, the ID for the request telemetry is by default a generated GUID. The generation of this ID can be configurable via the options.
+When tracking requests, the ID for the request telemetry is by default a generated GUID. The generation of this ID can be configured via the options.
 This is useful (for example) in a service-to-service correlation system where you want the ID of the incoming request based on the sending system, or you want to incorporate the operation ID in the request ID.
 
 ```csharp

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkOptions.cs
@@ -6,6 +6,11 @@
     public class ApplicationInsightsSinkOptions
     {
         /// <summary>
+        /// Gets the Application Insights options related to tracking requests.
+        /// </summary>
+        public ApplicationInsightsSinkRequestOptions Request { get; } = new ApplicationInsightsSinkRequestOptions();
+        
+        /// <summary>
         /// Gets the Application Insights options related to tracking exceptions.
         /// </summary>
         public ApplicationInsightsSinkExceptionOptions Exception { get; } = new ApplicationInsightsSinkExceptionOptions();

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
+{
+    /// <summary>
+    /// User-defined configuration options to influence the behavior of the Azure Application Insights Serilog sink while tracking requests.
+    /// </summary>
+    public class ApplicationInsightsSinkRequestOptions
+    {
+        private Func<string> _generatedId = Guid.NewGuid().ToString;
+
+        /// <summary>
+        /// <para>Gets or sets the function to generate the request ID of the telemetry model while tracking requests.</para>
+        /// <para>Default: GUID generation.</para>
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="value"/> is <c>null</c>.</exception>
+        public Func<string> GenerateId
+        {
+            get => _generatedId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Requires a function to generate the request ID of the telemetry model while tracking requests");
+                _generatedId = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
@@ -15,16 +15,17 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
     /// </summary>
     public class ApplicationInsightsTelemetryConverter : TelemetryConverterBase
     {
+        private readonly RequestTelemetryConverter _requestTelemetryConverter;
         private readonly ExceptionTelemetryConverter _exceptionTelemetryConverter;
         private readonly TraceTelemetryConverter _traceTelemetryConverter = new TraceTelemetryConverter();
         private readonly EventTelemetryConverter _eventTelemetryConverter = new EventTelemetryConverter();
         private readonly MetricTelemetryConverter _metricTelemetryConverter = new MetricTelemetryConverter();
-        private readonly RequestTelemetryConverter _requestTelemetryConverter = new RequestTelemetryConverter();
         private readonly DependencyTelemetryConverter _dependencyTelemetryConverter = new DependencyTelemetryConverter();
 
         private ApplicationInsightsTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
             Guard.NotNull(options, nameof(options), "Requires a set of options to influence how to track to Application Insights");
+            _requestTelemetryConverter = new RequestTelemetryConverter(options.Request);
             _exceptionTelemetryConverter = new ExceptionTelemetryConverter(options.Exception);
         }
         

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -28,6 +28,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// Initializes a new instance of the <see cref="RequestTelemetryConverter" /> class.
         /// </summary>
         /// <param name="options">The user-defined configuration options to tracking requests.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options" /> is <c>null</c>.</exception>
         public RequestTelemetryConverter(ApplicationInsightsSinkRequestOptions options)
         {
             Guard.NotNull(options, nameof(options), "Requires a set of user-configurable options to influence the behavior of how requests are tracked");

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -85,7 +85,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             await Policy.TimeoutAsync(timeout)
                         .WrapAsync(Policy.Handle<Exception>(exception =>
                             {
-                                _outputWriter.WriteLine($"Failed to contact Azure Application Insights. Reason: {exception.Message}");
+                                _outputWriter.WriteLine($"Failed to find correct telemetry at Azure Application Insights. Reason: {exception.Message}");
                                 return true;
                             })
                                          .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(3)))

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -67,7 +67,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
-                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _);
+                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _));
                 Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
                 AssertOperationContext(requestTelemetry, operationId);
 

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
 using Arcus.Observability.Tests.Core;
 using Bogus;
@@ -66,7 +67,57 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
-                Assert.Equal(operationId, requestTelemetry.Id);
+                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _);
+                Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
+                AssertOperationContext(requestTelemetry, operationId);
+
+                AssertContainsTelemetryProperty(requestTelemetry, "Client", "https://localhost");
+                AssertContainsTelemetryProperty(requestTelemetry, "ContentType", "application/json");
+            });
+        }
+        
+        [Fact]
+        public void LogRequestMessage_WithRequestAndResponseWithCustomId_CreatesRequestTelemetry()
+        {
+            // Arrange
+            var spySink = new InMemoryLogSink();
+            string operationId = $"operation-id-{Guid.NewGuid()}";
+            ILogger logger = CreateLogger(
+                spySink, config => config.Enrich.WithProperty(ContextProperties.Correlation.OperationId, operationId));
+
+            var telemetryContext = new Dictionary<string, object>
+            {
+                ["Client"] = "https://localhost",
+                ["ContentType"] = "application/json",
+            };
+            var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, new Uri("https://" + "localhost" + "/api/v1/health"));
+            var statusCode = HttpStatusCode.OK;
+            var response = new HttpResponseMessage(statusCode);
+            TimeSpan duration = TimeSpan.FromSeconds(5);
+            logger.LogRequest(request, response, duration, telemetryContext);
+
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            var requestId = Guid.NewGuid().ToString();
+            var converter = ApplicationInsightsTelemetryConverter.Create(new ApplicationInsightsSinkOptions
+            {
+                Request = { GenerateId = () => requestId }
+            });
+
+            // Act
+            IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
+
+            // Assert
+            AssertDoesContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
+            Assert.Collection(telemetries, telemetry =>
+            {
+                var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
+                Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
+                Assert.Equal(duration, requestTelemetry.Duration);
+                Assert.Equal(((int) statusCode).ToString(), requestTelemetry.ResponseCode);
+                Assert.True(requestTelemetry.Success);
+                Assert.Equal(requestId, requestTelemetry.Id);
                 Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
                 AssertOperationContext(requestTelemetry, operationId);
 
@@ -109,9 +160,58 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
                 Assert.Equal(duration, requestTelemetry.Duration);
-                Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
+                Assert.Equal(((int) statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
-                Assert.Equal(operationId, requestTelemetry.Id);
+                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _));
+                Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
+                AssertOperationContext(requestTelemetry, operationId);
+
+                AssertContainsTelemetryProperty(requestTelemetry, "Client", "https://localhost");
+                AssertContainsTelemetryProperty(requestTelemetry, "ContentType", "application/json");
+            });
+        }
+        
+        [Fact]
+        public void LogRequestMessage_WithRequestAndResponseStatusCodeWithCustomId_CreatesRequestTelemetry()
+        {
+            // Arrange
+            var spySink = new InMemoryLogSink();
+            string operationId = $"operation-id-{Guid.NewGuid()}";
+            ILogger logger = CreateLogger(
+                spySink, config => config.Enrich.WithProperty(ContextProperties.Correlation.OperationId, operationId));
+
+            var telemetryContext = new Dictionary<string, object>
+            {
+                ["Client"] = "https://localhost",
+                ["ContentType"] = "application/json",
+            };
+            var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, new Uri("https://" + "localhost" + "/api/v1/health"));
+            var statusCode = HttpStatusCode.OK;
+            TimeSpan duration = TimeSpan.FromSeconds(5);
+            logger.LogRequest(request, statusCode, duration, telemetryContext);
+
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            var requestId = Guid.NewGuid().ToString();
+            var converter = ApplicationInsightsTelemetryConverter.Create(new ApplicationInsightsSinkOptions
+            {
+                Request = { GenerateId = () => requestId }
+            });
+
+            // Act
+            IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
+
+            // Assert
+            AssertDoesContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
+            Assert.Collection(telemetries, telemetry =>
+            {
+                var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
+                Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
+                Assert.Equal(duration, requestTelemetry.Duration);
+                Assert.Equal(((int) statusCode).ToString(), requestTelemetry.ResponseCode);
+                Assert.True(requestTelemetry.Success);
+                Assert.Equal(requestId, requestTelemetry.Id);
                 Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
                 AssertOperationContext(requestTelemetry, operationId);
 
@@ -155,9 +255,59 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
                 Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
                 Assert.Equal(duration, requestTelemetry.Duration);
-                Assert.Equal(((int)statusCode).ToString(), requestTelemetry.ResponseCode);
+                Assert.Equal(((int) statusCode).ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
-                Assert.Equal(operationId, requestTelemetry.Id);
+                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _));
+                Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
+                AssertOperationContext(requestTelemetry, operationId);
+
+                AssertContainsTelemetryProperty(requestTelemetry, "Client", "https://localhost");
+                AssertContainsTelemetryProperty(requestTelemetry, "ContentType", "application/json");
+            });
+        }
+        
+        [Fact]
+        public void LogRequest_WithRequestAndResponseWithCustomId_CreatesRequestTelemetry()
+        {
+            // Arrange
+            var spySink = new InMemoryLogSink();
+            string operationId = $"operation-id-{Guid.NewGuid()}";
+            ILogger logger = CreateLogger(
+                spySink, config => config.Enrich.WithProperty(ContextProperties.Correlation.OperationId, operationId));
+
+            var telemetryContext = new Dictionary<string, object>
+            {
+                ["Client"] = "https://localhost",
+                ["ContentType"] = "application/json",
+            };
+            var statusCode = HttpStatusCode.OK;
+            HttpRequest request = CreateStubRequest(HttpMethod.Get, "https", "localhost", "/api/v1/health");
+            HttpResponse response = CreateStubResponse(statusCode);
+            TimeSpan duration = TimeSpan.FromSeconds(5);
+            logger.LogRequest(request, response, duration, telemetryContext);
+
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            var requestId = Guid.NewGuid().ToString();
+            var converter = ApplicationInsightsTelemetryConverter.Create(new ApplicationInsightsSinkOptions
+            {
+                Request = { GenerateId = () => requestId }
+            });
+
+            // Act
+            IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
+
+            // Assert
+            AssertDoesContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
+            Assert.Collection(telemetries, telemetry =>
+            {
+                var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
+                Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
+                Assert.Equal(duration, requestTelemetry.Duration);
+                Assert.Equal(((int) statusCode).ToString(), requestTelemetry.ResponseCode);
+                Assert.True(requestTelemetry.Success);
+                Assert.Equal(requestId, requestTelemetry.Id);
                 Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
                 AssertOperationContext(requestTelemetry, operationId);
 
@@ -180,7 +330,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 ["Client"] = "https://localhost",
                 ["ContentType"] = "application/json",
             };
-            var statusCode = (int)HttpStatusCode.OK;
+            var statusCode = (int) HttpStatusCode.OK;
             HttpRequest request = CreateStubRequest(HttpMethod.Get, "https", "localhost", "/api/v1/health");
             TimeSpan duration = TimeSpan.FromSeconds(5);
             logger.LogRequest(request, statusCode, duration, telemetryContext);
@@ -202,7 +352,56 @@ namespace Arcus.Observability.Tests.Unit.Serilog
                 Assert.Equal(duration, requestTelemetry.Duration);
                 Assert.Equal(statusCode.ToString(), requestTelemetry.ResponseCode);
                 Assert.True(requestTelemetry.Success);
-                Assert.Equal(operationId, requestTelemetry.Id);
+                Assert.True(Guid.TryParse(requestTelemetry.Id, out Guid _));
+                Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
+                AssertOperationContext(requestTelemetry, operationId);
+
+                AssertContainsTelemetryProperty(requestTelemetry, "Client", "https://localhost");
+                AssertContainsTelemetryProperty(requestTelemetry, "ContentType", "application/json");
+            });
+        }
+        
+        [Fact]
+        public void LogRequest_WithRequestAndResponseStatusCodeWithCustomId_CreatesRequestTelemetry()
+        {
+            // Arrange
+            var spySink = new InMemoryLogSink();
+            string operationId = $"operation-id-{Guid.NewGuid()}";
+            ILogger logger = CreateLogger(
+                spySink, config => config.Enrich.WithProperty(ContextProperties.Correlation.OperationId, operationId));
+
+            var telemetryContext = new Dictionary<string, object>
+            {
+                ["Client"] = "https://localhost",
+                ["ContentType"] = "application/json",
+            };
+            var statusCode = (int) HttpStatusCode.OK;
+            HttpRequest request = CreateStubRequest(HttpMethod.Get, "https", "localhost", "/api/v1/health");
+            TimeSpan duration = TimeSpan.FromSeconds(5);
+            logger.LogRequest(request, statusCode, duration, telemetryContext);
+
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.NotNull(logEvent);
+
+            var requestId = Guid.NewGuid().ToString();
+            var converter = ApplicationInsightsTelemetryConverter.Create(new ApplicationInsightsSinkOptions()
+            {
+                Request = { GenerateId = () => requestId }
+            });
+
+            // Act
+            IEnumerable<ITelemetry> telemetries = converter.Convert(logEvent, formatProvider: null);
+
+            // Assert
+            AssertDoesContainLogProperty(logEvent, RequestTracking.RequestLogEntry);
+            Assert.Collection(telemetries, telemetry =>
+            {
+                var requestTelemetry = Assert.IsType<RequestTelemetry>(telemetry);
+                Assert.Equal("GET /api/v1/health", requestTelemetry.Name);
+                Assert.Equal(duration, requestTelemetry.Duration);
+                Assert.Equal(statusCode.ToString(), requestTelemetry.ResponseCode);
+                Assert.True(requestTelemetry.Success);
+                Assert.Equal(requestId, requestTelemetry.Id);
                 Assert.Equal(new Uri("https://localhost/api/v1/health"), requestTelemetry.Url);
                 AssertOperationContext(requestTelemetry, operationId);
 

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkRequestOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkRequestOptionsTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
+{
+    public class ApplicationInsightsSinkRequestOptionsTests
+    {
+        [Fact]
+        public void DefaultGenerateId_WithNoCustomFunction_Succeeds()
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkRequestOptions();
+            
+            // Act
+            string id = options.GenerateId();
+            
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(id));
+        }
+        
+        [Fact]
+        public void SetGenerateId_WithCustomFunction_Succeeds()
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkRequestOptions();
+            var id = Guid.NewGuid().ToString();
+            
+            // Act
+            options.GenerateId = () => id;
+            
+            // Assert
+            Assert.Equal(id, options.GenerateId());
+        }
+
+        [Fact]
+        public void SetGenerateId_WithoutFunction_Fails()
+        {
+            // Arrange
+            var options = new ApplicationInsightsSinkRequestOptions();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.GenerateId = null);
+        }
+    }
+}


### PR DESCRIPTION
Adds an configurable option to generate the telemetry request ID when tracking requests to Azure Application Insights.

Closes #248 