### PR TITLE
fix: use serilog scalar value when serializing string values

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using GuardNet;
 
@@ -211,19 +212,26 @@ namespace Serilog.Events
         {
             Guard.NotNull(logEventPropertyValue, nameof(logEventPropertyValue));
 
-            var propertyValueAsString = logEventPropertyValue.ToString().Trim();
-
-            if (propertyValueAsString.StartsWith("\""))
+            if (logEventPropertyValue is ScalarValue scalar)
             {
-                propertyValueAsString = propertyValueAsString.Remove(0, 1);
+                var result = scalar.Value.ToString();
+                return result;
             }
-
-            if (propertyValueAsString.EndsWith("\""))
+            else
             {
-                propertyValueAsString = propertyValueAsString.Remove(propertyValueAsString.Length - 1);
-            }
+                string propertyValueAsString = logEventPropertyValue.ToString().Trim();
+                if (propertyValueAsString.StartsWith("\""))
+                {
+                    propertyValueAsString = propertyValueAsString.Remove(0, 1);
+                }
 
-            return propertyValueAsString;
+                if (propertyValueAsString.EndsWith("\""))
+                {
+                    propertyValueAsString = propertyValueAsString.Remove(propertyValueAsString.Length - 1);
+                }
+
+                return propertyValueAsString;
+            }
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Fixture/Order.cs
+++ b/src/Arcus.Observability.Tests.Unit/Fixture/Order.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Arcus.Observability.Tests.Unit.Fixture
+{
+    public class Order
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("orderNumber")]
+        public int OrderNumber { get; set; }
+
+        [JsonPropertyName("scheduled")]
+        public DateTimeOffset Scheduled { get; set; }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Fixture/OrderGenerator.cs
+++ b/src/Arcus.Observability.Tests.Unit/Fixture/OrderGenerator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Bogus;
+using Moq;
+
+namespace Arcus.Observability.Tests.Unit.Fixture
+{
+    public static class OrderGenerator
+    {
+        public static Order Generate()
+        {
+            Order order = new Faker<Order>()
+                .RuleFor(model => model.Id, bogus => bogus.Random.Guid().ToString())
+                .RuleFor(model => model.OrderNumber, bogus => bogus.Random.Int())
+                .RuleFor(model => model.Scheduled, bogus => bogus.Date.RecentOffset())
+                .Generate();
+
+            return order;
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ApplicationInsightsTelemetryConverterTests.cs
@@ -901,14 +901,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog
             });
         }
 
-        //private static TTelemetry ConvertTelemetry<TTelemetry>(InMemoryLogSink spySink)
-        //{
-        //    LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
-        //    var converter = ApplicationInsightsTelemetryConverter.Create();
-
-        //    //converter.Convert(logEvent);
-        //}
-
         private static void AssertOperationContext<TTelemetry>(TTelemetry telemetry, string operationId) where TTelemetry : ITelemetry
         {
             Assert.NotNull(telemetry.Context);


### PR DESCRIPTION
Use the Serilog `ScalarValue` (represents simple value) when serializing the Serilog log property value to a `string` representation. This fix will make sure that we retrieve the original value (unescaped). This will make JSON values represents as their original values instead of escaped quotes (`\"`).

Closes #256  