### PR TITLE
feat: track az servicebus in app insights

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestSourceSystem.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestSourceSystem.cs
@@ -8,11 +8,11 @@
         /// <summary>
         /// Specifies that the request-source is an Azure Service Bus queue or topic.
         /// </summary>
-        AzureServiceBus, 
+        AzureServiceBus = 1, 
         
         /// <summary>
         /// Specifies that the request-source is a HTTP request
         /// </summary>
-        Http
+        Http = 2
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -184,18 +184,31 @@ namespace Serilog.Events
             return value;
         }
 
-        internal static TEnum GetAsEnum<TEnum>(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        /// <summary>
+        /// Gets a <typeparamref name="TValue"/> representation of a property in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The custom type to cast to.</typeparam>
+        /// <param name="properties">The properties containing the property value associated with the <paramref name="propertyKey"/>.</param>
+        /// <param name="propertyKey">The key the property is associated with.</param>
+        /// <returns>
+        ///     An <typeparamref name="TValue"/> representation when the property was found; <c>default</c> otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
+        internal static TValue GetAsObject<TValue>(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
             Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an enumeration representation");
             Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as an enumeration representation");
 
             LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
-            if (property != null && property.Value is TEnum value)
+            if (property != null 
+                && property.Value is ScalarValue scalarValue 
+                && scalarValue.Value is TValue value)
             {
                 return value;
             }
 
-            return default(TEnum);
+            return default(TValue);
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -183,5 +183,19 @@ namespace Serilog.Events
             bool value = bool.Parse(propertyValue);
             return value;
         }
+
+        internal static TEnum GetAsEnum<TEnum>(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an enumeration representation");
+            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as an enumeration representation");
+
+            LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
+            if (property != null && property.Value is TEnum value)
+            {
+                return value;
+            }
+
+            return default(TEnum);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusRequestTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusRequestTests.cs
@@ -43,7 +43,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, timespan: PastHalfHourTimeSpan);
                     Assert.NotNull(results.Value);
                     Assert.NotEmpty(results.Value);
                     AssertX.Any(results.Value, result =>
@@ -91,7 +91,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, timespan: PastHalfHourTimeSpan);
                     Assert.NotNull(results.Value);
                     Assert.NotEmpty(results.Value);
                     AssertX.Any(results.Value, result =>
@@ -99,6 +99,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                         Assert.Equal(operationName, result.Request.Name);
                         Assert.Contains(topicName, result.Request.Source);
                         Assert.Contains(serviceBusNamespace, result.Request.Source);
+                        Assert.Contains(serviceBusNamespaceSuffix, result.Request.Source);
                         Assert.Empty(result.Request.Url);
                         Assert.Equal(operationName, result.Operation.Name);
                         Assert.True(bool.TryParse(result.Request.Success, out bool success));
@@ -106,7 +107,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
                         AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityType, ServiceBusEntityType.Topic.ToString());
                         AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityName, topicName);
-                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Endpoint, serviceBusNamespace);
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Endpoint, serviceBusNamespace + serviceBusNamespaceSuffix);
                         AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName, subscriptionName);
                     });
                 });
@@ -139,7 +140,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, timespan: PastHalfHourTimeSpan);
                     Assert.NotNull(results.Value);
                     Assert.NotEmpty(results.Value);
                     AssertX.Any(results.Value, result =>

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusRequestTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusRequestTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Core;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights
+{
+    public class ServiceBusRequestTests : ApplicationInsightsSinkTests
+    {
+        public ServiceBusRequestTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+        [Fact]
+        public async Task LogServiceBusQueueRequest_SinksToApplicationInsights_ResultsInRequestTelemetry()
+        {
+            // Arrange
+            string queueName = BogusGenerator.Lorem.Word();
+            string serviceBusNamespace = $"{BogusGenerator.Lorem.Word()}.servicebus.windows.net";
+            string operationName = BogusGenerator.Lorem.Sentence();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.Now;
+            Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory())
+            {
+                ILogger logger = loggerFactory.CreateLogger<ServiceBusRequestTests>();
+
+                // Act
+                logger.LogServiceBusQueueRequest(serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, telemetryContext);
+            }
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    Assert.NotNull(results.Value);
+                    Assert.NotEmpty(results.Value);
+                    AssertX.Any(results.Value, result =>
+                    {
+                        Assert.Equal(operationName, result.Request.Name);
+                        Assert.Contains(queueName, result.Request.Source);
+                        Assert.Contains(serviceBusNamespace, result.Request.Source);
+                        Assert.Empty(result.Request.Url);
+                        Assert.Equal(operationName, result.Operation.Name);
+                        Assert.True(bool.TryParse(result.Request.Success, out bool success));
+                        Assert.Equal(isSuccessful, success);
+
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityType, ServiceBusEntityType.Queue.ToString());
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityName, queueName);
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Endpoint, serviceBusNamespace);
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public async Task LogServiceBusTopicRequestWithSuffix_SinksToApplicationInsights_ResultsInRequestTelemetry()
+        {
+            // Arrange
+            string topicName = BogusGenerator.Lorem.Word();
+            string subscriptionName = BogusGenerator.Lorem.Word();
+            string serviceBusNamespace = BogusGenerator.Lorem.Word();
+            string serviceBusNamespaceSuffix = ".servicebus.windows.de";
+            string operationName = BogusGenerator.Lorem.Sentence();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.Now;
+            Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory())
+            {
+                ILogger logger = loggerFactory.CreateLogger<ServiceBusRequestTests>();
+
+                // Act
+                logger.LogServiceBusTopicRequestWithSuffix(serviceBusNamespace, serviceBusNamespaceSuffix, topicName, subscriptionName, operationName, isSuccessful, duration, startTime, telemetryContext);
+            }
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    Assert.NotNull(results.Value);
+                    Assert.NotEmpty(results.Value);
+                    AssertX.Any(results.Value, result =>
+                    {
+                        Assert.Equal(operationName, result.Request.Name);
+                        Assert.Contains(topicName, result.Request.Source);
+                        Assert.Contains(serviceBusNamespace, result.Request.Source);
+                        Assert.Empty(result.Request.Url);
+                        Assert.Equal(operationName, result.Operation.Name);
+                        Assert.True(bool.TryParse(result.Request.Success, out bool success));
+                        Assert.Equal(isSuccessful, success);
+
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityType, ServiceBusEntityType.Topic.ToString());
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityName, topicName);
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Endpoint, serviceBusNamespace);
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName, subscriptionName);
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public async Task LogServiceBusRequest_SinksToApplicationInsights_ResultsInRequestTelemetry()
+        {
+            // Arrange
+            string entityName = BogusGenerator.Lorem.Word();
+            string serviceBusNamespace = $"{BogusGenerator.Lorem.Word()}.servicebus.windows.net";
+            string operationName = BogusGenerator.Lorem.Sentence();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.Now;
+            var entityType = BogusGenerator.PickRandom<ServiceBusEntityType>();
+            Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory())
+            {
+                ILogger logger = loggerFactory.CreateLogger<ServiceBusRequestTests>();
+
+                // Act
+                logger.LogServiceBusRequest(serviceBusNamespace, entityName, operationName, isSuccessful, duration, startTime, entityType, telemetryContext);
+            }
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    EventsResults<EventsRequestResult> results = await client.Events.GetRequestEventsAsync(ApplicationId, filter: OnlyLastHourFilter);
+                    Assert.NotNull(results.Value);
+                    Assert.NotEmpty(results.Value);
+                    AssertX.Any(results.Value, result =>
+                    {
+                        Assert.Equal(operationName, result.Request.Name);
+                        Assert.Contains(entityName, result.Request.Source);
+                        Assert.Contains(serviceBusNamespace, result.Request.Source);
+                        Assert.Empty(result.Request.Url);
+                        Assert.Equal(operationName, result.Operation.Name);
+                        Assert.True(bool.TryParse(result.Request.Success, out bool success));
+                        Assert.Equal(isSuccessful, success);
+
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityType, entityType.ToString());
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.EntityName, entityName);
+                        AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.RequestTracking.ServiceBus.Endpoint, serviceBusNamespace);
+                    });
+                });
+            }
+        }
+
+        private static void AssertContainsCustomDimension(EventsResultDataCustomDimensions customDimensions, string key, string expected)
+        {
+            Assert.True(customDimensions.TryGetValue(key, out string actual), $"Cannot find {key} in custom dimensions: {String.Join(", ", customDimensions.Keys)}");
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Complete the connection between Serilog logging <> Application Insights tracking of Azure Service Bus request.

Closes #244
Closes #245 