### PR TITLE
chore: update appinsights nuget package

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrades Application Insights NuGet package to a non-deprecated version.

Closes #271  