### PR TITLE
fix: discard `/docs` folder

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
     "enabled": true
   },
    "ignorePaths": [
-    "/docs/**"
+    "**/docs/**"
   ],
   "vulnerabilityAlerts": {
     "enabled": true


### PR DESCRIPTION
Seems that the wildcard doesn't work, let's try this one.