### PR TITLE
chore: correct nuget dependencies

### DIFF
--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1.8,5.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to use correlation in applications</Description>
@@ -15,12 +15,19 @@
     <PackageId>Arcus.Observability.Correlation</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve ASP.NET Core telemetry with Serilog in applications</Description>
@@ -15,8 +15,6 @@
     <PackageId>Arcus.Observability.Telemetry.AspNetCore</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Arcus.Observability.Telemetry.AspNetCore</AssemblyName>
-    <RootNamespace>Arcus.Observability.Telemetry.AspNetCore</RootNamespace>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
@@ -28,7 +26,11 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
     
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve telemetry with Serilog in Azure Functions applications</Description>
@@ -15,11 +15,17 @@
     <PackageId>Arcus.Observability.Telemetry.AzureFunctions</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve telemetry with Serilog in applications</Description>
@@ -15,14 +15,17 @@
     <PackageId>Arcus.Observability.Telemetry.Core</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Arcus.Observability.Telemetry.Core</AssemblyName>
-    <RootNamespace>Arcus.Observability.Telemetry.Core</RootNamespace>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
+++ b/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve IoT telemetry with Serilog in applications</Description>
@@ -15,16 +15,20 @@
     <PackageId>Arcus.Observability.Telemetry.IoT</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Arcus.Observability.Telemetry.IoT</AssemblyName>
-    <RootNamespace>Arcus.Observability.Telemetry.IoT</RootNamespace>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Guard.Net" Version="1.2.0" />
-      <PackageReference Include="Microsoft.Azure.Devices.Client" Version="[1.26.0,1.40.0)" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.39.0" />
+  </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.26.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
+++ b/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
@@ -21,7 +21,7 @@
 
     <ItemGroup>
       <PackageReference Include="Guard.Net" Version="1.2.0" />
-      <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.40.0" />
+      <PackageReference Include="Microsoft.Azure.Devices.Client" Version="[1.26.0,1.40.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="[2.1.3,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve telemetry with Serilog in applications</Description>
@@ -15,12 +15,20 @@
     <PackageId>Arcus.Observability.Telemetry.Serilog.Enrichers</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="[2.1.3,3.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to reduce telemetry with Serilog filters</Description>
@@ -15,11 +15,19 @@
     <PackageId>Arcus.Observability.Telemetry.Serilog.Filters</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Guard.Net" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve telemetry with Serilog that is sent to Azure Application Insights</Description>
@@ -15,11 +15,12 @@
     <PackageId>Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="[2.20.0,3.0.0)" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="[3.1.0,4.0.0)" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="[2.20.0,3.0.0)" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="[3.1.0,4.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides capability to improve SQL telemetry with Serilog in applications</Description>
@@ -15,16 +15,14 @@
     <PackageId>Arcus.Observability.Telemetry.Sql</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Arcus.Observability.Telemetry.Sql</AssemblyName>
-    <RootNamespace>Arcus.Observability.Telemetry.Sql</RootNamespace>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="System.Data.SqlClient" Version="[4.8.1,5.0.0)" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+  </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+      <PackageReference Include="System.Data.SqlClient" Version="[4.8.1,5.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
+++ b/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Testing.Logging" Version="0.3.0" />
     <PackageReference Include="Bogus" Version="34.0.1" />
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />


### PR DESCRIPTION
Correct the NuGet dependencies to start from the current minor and take every minor that follows till the next major.
Includes reverts of Renovate on IoT and Serilog.Enrichers.

Closes #330