### PR TITLE
chore: Mark ClearProvidersExceptFunctionProviders as obsolete

### DIFF
--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using GuardNet;
+﻿using System;
+using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -15,10 +16,11 @@ namespace Microsoft.Extensions.Logging
         /// except the specific Azure Functions registrations.
         /// </summary>
         /// <param name="loggingBuilder">The builder containing the <see cref="ILoggerProvider"/> registrations.</param>
+        [Obsolete("Calling this method causes issues with correctly writing log-information to Application Insights")]
         public static ILoggingBuilder ClearProvidersExceptFunctionProviders(this ILoggingBuilder loggingBuilder)
         {
             Guard.NotNull(loggingBuilder, nameof(loggingBuilder));
-
+            
             // Kudos to katrash: https://stackoverflow.com/questions/45986517/remove-console-and-debug-loggers-in-asp-net-core-2-0-when-in-production-mode
             foreach (ServiceDescriptor serviceDescriptor in loggingBuilder.Services)
             {

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging
         /// except the specific Azure Functions registrations.
         /// </summary>
         /// <param name="loggingBuilder">The builder containing the <see cref="ILoggerProvider"/> registrations.</param>
-        [Obsolete("Calling this method causes issues with correctly writing log-information to Application Insights")]
+        [Obsolete("Calling this method causes issues with correctly writing log-information to Application Insights. It is advised to no longer use it.")]
         public static ILoggingBuilder ClearProvidersExceptFunctionProviders(this ILoggingBuilder loggingBuilder)
         {
             Guard.NotNull(loggingBuilder, nameof(loggingBuilder));

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging
         public static ILoggingBuilder ClearProvidersExceptFunctionProviders(this ILoggingBuilder loggingBuilder)
         {
             Guard.NotNull(loggingBuilder, nameof(loggingBuilder));
-            
+
             // Kudos to katrash: https://stackoverflow.com/questions/45986517/remove-console-and-debug-loggers-in-asp-net-core-2-0-when-in-production-mode
             foreach (ServiceDescriptor serviceDescriptor in loggingBuilder.Services)
             {

--- a/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Arcus.Observability.Correlation;
 using Xunit;
@@ -10,16 +8,16 @@ namespace Arcus.Observability.Tests.Unit.Correlation
     public class DefaultCorrelationInfoAccessorTests
     {
         [Fact]
-        public void SetCorrelationInfo_Twice_UsesMostRecentValue()
+        public async Task SetCorrelationInfo_Twice_UsesMostRecentValue()
         {
             // Arrange
             var firstOperationId = $"operation-{Guid.NewGuid()}";
             var secondOperationId = $"operation-{Guid.NewGuid()}";
             var transactionId = $"transaction-{Guid.NewGuid()}";
-            SetCorrelationInfo(firstOperationId, transactionId);
+            await SetCorrelationInfo(firstOperationId, transactionId);
 
             // Act
-            SetCorrelationInfo(secondOperationId, transactionId);
+            await SetCorrelationInfo(secondOperationId, transactionId);
 
             // Assert
             CorrelationInfo correlationInfo = DefaultCorrelationInfoAccessor.Instance.GetCorrelationInfo();
@@ -27,7 +25,10 @@ namespace Arcus.Observability.Tests.Unit.Correlation
             Assert.Equal(transactionId, correlationInfo.TransactionId);
         }
 
-        private void SetCorrelationInfo(string operationId, string transactionId)
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        // Disabled the warning since declaring this method as async was on-purpose
+        private async Task SetCorrelationInfo(string operationId, string transactionId)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             DefaultCorrelationInfoAccessor.Instance.SetCorrelationInfo(
                 new CorrelationInfo(operationId, transactionId));

--- a/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
@@ -10,13 +10,13 @@ namespace Arcus.Observability.Tests.Unit.Correlation
     public class DefaultCorrelationInfoAccessorTests
     {
         [Fact]
-        public async Task SetCorrelationInfo_Twice_UsesMostRecentValue()
+        public void SetCorrelationInfo_Twice_UsesMostRecentValue()
         {
             // Arrange
             var firstOperationId = $"operation-{Guid.NewGuid()}";
             var secondOperationId = $"operation-{Guid.NewGuid()}";
             var transactionId = $"transaction-{Guid.NewGuid()}";
-            await SetCorrelationInfo(firstOperationId, transactionId);
+            SetCorrelationInfo(firstOperationId, transactionId);
 
             // Act
             SetCorrelationInfo(secondOperationId, transactionId);

--- a/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/DefaultCorrelationInfoAccessorTests.cs
@@ -19,7 +19,7 @@ namespace Arcus.Observability.Tests.Unit.Correlation
             await SetCorrelationInfo(firstOperationId, transactionId);
 
             // Act
-            await SetCorrelationInfo(secondOperationId, transactionId);
+            SetCorrelationInfo(secondOperationId, transactionId);
 
             // Assert
             CorrelationInfo correlationInfo = DefaultCorrelationInfoAccessor.Instance.GetCorrelationInfo();
@@ -27,7 +27,7 @@ namespace Arcus.Observability.Tests.Unit.Correlation
             Assert.Equal(transactionId, correlationInfo.TransactionId);
         }
 
-        private async Task SetCorrelationInfo(string operationId, string transactionId)
+        private void SetCorrelationInfo(string operationId, string transactionId)
         {
             DefaultCorrelationInfoAccessor.Instance.SetCorrelationInfo(
                 new CorrelationInfo(operationId, transactionId));


### PR DESCRIPTION
This method is not correctly implemented and calling this method has the side-effect that logging to Application Insights is not working correctly.
It is advised to not longer use this method.

See also #336 