### PR TITLE
feat: add dependency id to az search

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -1276,6 +1276,37 @@ namespace Microsoft.Extensions.Logging
         /// Logs an Azure Search Dependency.
         /// </summary>
         /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="searchServiceName">The name of the Azure Search service.</param>
+        /// <param name="operationName">The name of the operation to execute on the Azure Search service.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measuring the latency to call the dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="searchServiceName"/> or <paramref name="operationName"/> is blank.</exception>
+        public static void LogAzureSearchDependency(
+            this ILogger logger,
+            string searchServiceName,
+            string operationName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Search dependency");
+            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+
+            context = context ?? new Dictionary<string, object>();
+
+            LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Search Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="searchServiceName">Name of the Azure Search service</param>
         /// <param name="operationName">Name of the operation to execute on the Azure Search service</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
@@ -1300,10 +1331,44 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
 
+            LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Search Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="searchServiceName">Name of the Azure Search service</param>
+        /// <param name="operationName">Name of the operation to execute on the Azure Search service</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="searchServiceName"/> or <paramref name="operationName"/> is blank.</exception>
+        public static void LogAzureSearchDependency(
+            this ILogger logger,
+            string searchServiceName,
+            string operationName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
+
+            context = context ?? new Dictionary<string, object>();
+
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Search",
                 dependencyName: searchServiceName,
                 dependencyData: operationName,
+                dependencyId: dependencyId,
                 targetName: searchServiceName,
                 duration: duration,
                 startTime: startTime,

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1187,7 +1187,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Equal(searchServiceName, dependency.TargetName);
         }
 
-
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogAzureSearchDependencyWithDependencyId_WithoutSearchServiceName_Fails(string searchServiceName)

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1183,6 +1183,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(dependencyId, dependency.DependencyId);
             Assert.Equal("Azure Search", dependency.DependencyType);
             Assert.Equal(searchServiceName, dependency.TargetName);
         }
@@ -1315,6 +1316,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(measurement.StartTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(measurement.Elapsed, dependency.Duration);
+            Assert.Equal(dependencyId, dependency.DependencyId);
             Assert.Equal("Azure Search", dependency.DependencyType);
             Assert.Equal(searchServiceName, dependency.TargetName);
         }


### PR DESCRIPTION
Adds the capability to add a dependency ID when tracking Azure Search dependencies.

Related to #243