### PR TITLE
feat: add dependency id to az servicebus queue tracking

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerExtensions.cs
@@ -1363,6 +1363,32 @@ namespace Microsoft.Extensions.Logging
         /// Logs an Azure Service Bus Dependency.
         /// </summary>
         /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="queueName">The name of the Service Bus queue.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measuring the latency to call the Service Bus dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="queueName"/> is blank.</exception>
+        public static void LogServiceBusQueueDependency(
+            this ILogger logger,
+            string queueName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank Azure Service Bus Queue name to track an Azure Service Bus Queue dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus Queue when tracking the Azure Service Bus Queue dependency");
+
+            LogServiceBusQueueDependency(logger, queueName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Service Bus Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="queueName">Name of the Service Bus queue</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
@@ -1384,6 +1410,35 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Queue operation");
             
             LogServiceBusDependency(logger, queueName, isSuccessful, startTime, duration, ServiceBusEntityType.Queue, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Service Bus Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="queueName">Name of the Service Bus queue</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="queueName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogServiceBusQueueDependency(
+            this ILogger logger,
+            string queueName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank Azure Service Bus Queue name to track an Azure Service Bus Queue dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Queue operation");
+
+            LogServiceBusDependency(logger, queueName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Queue, context);
         }
 
         /// <summary>
@@ -1519,6 +1574,34 @@ namespace Microsoft.Extensions.Logging
         /// Logs an Azure Service Bus Dependency.
         /// </summary>
         /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="entityName">The name of the Service Bus entity.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measuring the latency to call the Service Bus dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="entityType">The type of the Service Bus entity.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> is blank.</exception>
+        public static void LogServiceBusDependency(
+            this ILogger logger,
+            string entityName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
+
+            LogServiceBusDependency(logger, entityName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, entityType, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Service Bus Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="entityName">Name of the Service Bus entity</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
@@ -1542,17 +1625,51 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
             
             context = context ?? new Dictionary<string, object>();
+            
+            LogServiceBusDependency(logger, entityName, isSuccessful, startTime, duration, dependencyId: null, entityType, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Service Bus Dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="entityName">Name of the Service Bus entity</param>
+        /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
+        /// <param name="startTime">Point in time when the interaction with the dependency was started</param>
+        /// <param name="duration">Duration of the operation</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="entityType">Type of the Service Bus entity</param>
+        /// <param name="context">Context that provides more insights on the dependency that was measured</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogServiceBusDependency(
+            this ILogger logger,
+            string entityName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
+
+            context = context ?? new Dictionary<string, object>();
             context[ContextProperties.DependencyTracking.ServiceBus.EntityType] = entityType;
 
             logger.LogWarning(DependencyFormat, new DependencyLogEntry(
-                dependencyType: "Azure Service Bus", 
-                dependencyName: entityName, 
-                dependencyData: null, 
-                targetName: entityName, 
-                duration: duration, 
-                startTime: startTime, 
+                dependencyType: "Azure Service Bus",
+                dependencyName: entityName,
+                dependencyData: null,
+                dependencyId: dependencyId,
+                targetName: entityName,
+                duration: duration,
+                startTime: startTime,
                 resultCode: null,
-                isSuccessful: isSuccessful, 
+                isSuccessful: isSuccessful,
                 context: context));
         }
 

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1331,7 +1331,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusDependency(entityName, isSuccessful, startTime, duration, entityType));
         }
 
-
         [Fact]
         public void LogServiceBusDependencyWithDependencyId_WithNegativeDuration_Fails()
         {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/ILoggerExtensionsTests.cs
@@ -1290,6 +1290,33 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogServiceBusDependencyWithDependencyId_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            const ServiceBusEntityType entityType = ServiceBusEntityType.Queue;
+            string entityName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogServiceBusDependency(entityName, isSuccessful, startTime, duration, dependencyId, entityType);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(entityName, dependency.TargetName);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+            Assert.Equal("Azure Service Bus", dependency.DependencyType);
+            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
+            Assert.Equal(entityType.ToString(), entityTypeItem.Value);
+        }
+
+        [Fact]
         public void LogServiceBusDependency_WithNegativeDuration_Fails()
         {
             // Arrange
@@ -1302,6 +1329,23 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusDependency(entityName, isSuccessful, startTime, duration, entityType));
+        }
+
+
+        [Fact]
+        public void LogServiceBusDependencyWithDependencyId_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            const ServiceBusEntityType entityType = ServiceBusEntityType.Queue;
+            string entityName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            var startTime = DateTimeOffset.UtcNow;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusDependency(entityName, isSuccessful, startTime, duration, dependencyId, entityType));
         }
 
         [Fact]
@@ -1360,6 +1404,36 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Equal(entityType.ToString(), entityTypeItem.Value);
         }
 
+        [Fact]
+        public void LogServiceBusDependencyWithDependencyIdWithDurationMeasurement_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var entityType = _bogusGenerator.Random.Enum<ServiceBusEntityType>();
+            string entityName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DurationMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogServiceBusDependency(entityName, isSuccessful, measurement, dependencyId, entityType);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(entityName, dependency.TargetName);
+            Assert.Equal("Azure Service Bus", dependency.DependencyType);
+            Assert.Equal(entityName, dependency.DependencyName);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
+            Assert.Equal(entityType.ToString(), entityTypeItem.Value);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogServiceBusDependencyWithDurationMeasurement_WithoutEntityName_Fails(string entityName)
@@ -1376,6 +1450,23 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
                 () => logger.LogServiceBusDependency(entityName, isSuccessful, measurement, entityType));
         }
 
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogServiceBusDependencyWithDependencyIdWithDurationMeasurement_WithoutEntityName_Fails(string entityName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var entityType = _bogusGenerator.Random.Enum<ServiceBusEntityType>();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogServiceBusDependency(entityName, isSuccessful, measurement, dependencyId, entityType));
+        }
+
         [Fact]
         public void LogServiceBusDependencyWithDurationMeasurement_WithoutMeasurement_Fails()
         {
@@ -1390,6 +1481,23 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             // Act
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogServiceBusDependency(entityName, isSuccessful, measurement: (DurationMeasurement) null, entityType));
+        }
+
+        [Fact]
+        public void LogServiceBusDependencyWithDependencyIdWithDurationMeasurement_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string entityName = _bogusGenerator.Commerce.Product();
+            var entityType = _bogusGenerator.Random.Enum<ServiceBusEntityType>();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogServiceBusDependency(entityName, isSuccessful, measurement: (DurationMeasurement) null, dependencyId, entityType));
         }
 
         [Fact]
@@ -1418,6 +1526,33 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
         }
 
         [Fact]
+        public void LogServiceBusQueueDependencyWithDependencyId_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            var startTime = DateTimeOffset.UtcNow;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration, dependencyId);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(queueName, dependency.TargetName);
+            Assert.Equal("Azure Service Bus", dependency.DependencyType);
+            Assert.Equal(queueName, dependency.DependencyName);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
+            Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
+        }
+
+        [Fact]
         public void LogServiceBusQueueDependency_WithNegativeDuration_Fails()
         {
             // Arrange
@@ -1429,6 +1564,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogServiceBusQueueDependencyWithDependencyId_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            TimeSpan duration = GeneratePositiveDuration().Negate();
+            var startTime = DateTimeOffset.UtcNow;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, startTime, duration, dependencyId));
         }
 
         [Fact]
@@ -1485,6 +1635,35 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
         }
 
+        [Fact]
+        public void LogServiceBusQueueDependencyWithDependencyIdWithDurationMeasurement_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DurationMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogServiceBusQueueDependency(queueName, isSuccessful, measurement, dependencyId);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(queueName, dependency.TargetName);
+            Assert.Equal("Azure Service Bus", dependency.DependencyType);
+            Assert.Equal(queueName, dependency.DependencyName);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
+            Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogServiceBusQueueDependencyWithDurationMeasurement_WithoutQueueName_Fails(string queueName)
@@ -1499,6 +1678,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
             Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, measurement));
         }
 
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogServiceBusQueueDependencyWithDependencyIdWithDurationMeasurement_WithoutQueueName_Fails(string queueName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, measurement, dependencyId));
+        }
+
         [Fact]
         public void LogServiceBusQueueDependencyWithDurationMeasurement_WithoutMeasurement_Fails()
         {
@@ -1509,6 +1703,19 @@ namespace Arcus.Observability.Tests.Unit.Telemetry
 
             // Act
             Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, measurement: (DurationMeasurement) null));
+        }
+
+        [Fact]
+        public void LogServiceBusQueueDependencyWithDependencyIdWithDurationMeasurement_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string queueName = _bogusGenerator.Commerce.Product();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogServiceBusQueueDependency(queueName, isSuccessful, measurement: (DurationMeasurement) null, dependencyId));
         }
 
         [Fact]


### PR DESCRIPTION
Adds the capability to add a dependency ID when tracking Azure Service Bus queue dependencies.

Related to #243