### PR TITLE
docs: remove 'clear logging providers' from preview & published docs

### DIFF
--- a/docs/preview/03-Guidance/use-with-dotnet-and-functions.md
+++ b/docs/preview/03-Guidance/use-with-dotnet-and-functions.md
@@ -14,8 +14,6 @@ Some aspects we would like to highlight are:
 - Make sure to call [`UseSerilog`](https://www.nuget.org/packages/Serilog.AspNetCore) when creating a `IHostBuilder`
 - Remove default for logging including its configuration in `appsettings.json` *(if applicable)*
 
-If you cannot use `UseSerilog`, you can still configure it by using `AddSerilog` as a logging provider; but we recommend removing all other providers with `loggingBuilder.ClearProviders()` so that they don't interfere.
-
 ## Setting up Serilog with Azure Functions
 
 Using Serilog with Azure Functions requires some guidance and we've made it a bit easier to use.

--- a/docs/versioned_docs/version-v2.4/03-Guidance/use-with-dotnet-and-functions.md
+++ b/docs/versioned_docs/version-v2.4/03-Guidance/use-with-dotnet-and-functions.md
@@ -14,8 +14,6 @@ Some aspects we would like to highlight are:
 - Make sure to call [`UseSerilog`](https://www.nuget.org/packages/Serilog.AspNetCore) when creating a `IHostBuilder`
 - Remove default for logging including its configuration in `appsettings.json` *(if applicable)*
 
-If you cannot use `UseSerilog`, you can still configure it by using `AddSerilog` as a logging provider; but we recommend removing all other providers with `loggingBuilder.ClearProviders()` so that they don't interfere.
-
 ## Setting up Serilog with Azure Functions
 
 Using Serilog with Azure Functions requires some guidance and we've made it a bit easier to use.
@@ -54,15 +52,12 @@ namespace Arcus.Samples.AzureFunction
 
             builder.Services.AddLogging(loggingBuilder =>
             {
-                loggingBuilder.ClearProvidersExceptFunctionProviders();
                 loggingBuilder.AddSerilog(logger);
             });
         }
     }
 }
 ```
-
-> :bulb: Note that we are using `ClearProvidersExceptFunctionProviders` instead of `ClearProviders` given Azure Functions requires some logging providers to be available.
 
 Here is an example of how you can use ILogger to write multi-dimensional metrics with Arcus. If Serilog would not be setup correctly (see above), it would only report the metric without the dimensions.
 


### PR DESCRIPTION
Remove the 'Clear logging providers' extension call from the preview and recently published docs (v2.4).
This call is deprecated and should no longer be added to the 'recommanded' approach.