### PR TITLE
chore: add readme to nuget packages + feature docs project URL

### DIFF
--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Correlation</PackageTags>
-    <PackageId>Arcus.Observability.Correlation</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to use correlation in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog;ASP.NET;Core</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.AspNetCore</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Arcus.Observability.Telemetry.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve ASP.NET Core telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve telemetry with Serilog in Azure Functions applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Azure Functions</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.AzureFunctions</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.Core</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
+++ b/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog;IoT</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.IoT</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
+++ b/src/Arcus.Observability.Telemetry.IoT/Arcus.Observability.Telemetry.IoT.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve IoT telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Arcus.Observability.Telemetry.Serilog.Enrichers.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.Serilog.Enrichers</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.Serilog.Filters</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />

--- a/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Filters/Arcus.Observability.Telemetry.Serilog.Filters.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to reduce telemetry with Serilog filters</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve telemetry with Serilog that is sent to Azure Application Insights</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -11,13 +11,17 @@
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Azure;Observability;Telemetry;Serilog;Sql</PackageTags>
-    <PackageId>Arcus.Observability.Telemetry.Sql</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />

--- a/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
+++ b/src/Arcus.Observability.Telemetry.Sql/Arcus.Observability.Telemetry.Sql.csproj
@@ -7,7 +7,7 @@
     <Description>Provides capability to improve SQL telemetry with Serilog in applications</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.observability/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.observability</PackageProjectUrl>
+    <PackageProjectUrl>https://observability.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.observability</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>


### PR DESCRIPTION
Adds the GitHub README file to the NuGet package generation of the projects.
Adds feature docs project URL instead of GitHub URL to NuGet package.

Relates to https://github.com/arcus-azure/arcus/issues/209
Relates to https://github.com/arcus-azure/arcus/issues/208