### PR TITLE
feat: add dependency id to az tabe storage dep tracking

### DIFF
--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/TableStorageDependencyTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Microsoft.Azure.ApplicationInsights.Query;
 using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Logging;
+using Serilog;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
-using LoggerEnrichmentConfigurationExtensions = Serilog.LoggerEnrichmentConfigurationExtensions;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights
 {
@@ -29,8 +29,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string tableName = BogusGenerator.Commerce.ProductName();
             string accountName = BogusGenerator.Finance.AccountName();
             string dependencyName = $"{accountName}/{tableName}";
+            string dependencyId = BogusGenerator.Random.Guid().ToString();
 
-            using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => LoggerEnrichmentConfigurationExtensions.WithComponentName(config.Enrich, componentName)))
+            using (ILoggerFactory loggerFactory = CreateLoggerFactory(config => config.Enrich.WithComponentName(componentName)))
             {
                 ILogger logger = loggerFactory.CreateLogger<ApplicationInsightsSinkTests>();
 
@@ -40,7 +41,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
                 // Act
-                logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, telemetryContext);
+                logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, dependencyId, telemetryContext);
             }
 
             // Assert
@@ -48,36 +49,48 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
-                    EventsResults<EventsDependencyResult> results =
-                        await client.Events.GetDependencyEventsAsync(ApplicationId, "PT30M");
+                    EventsResults<EventsDependencyResult> results = await client.Events.GetDependencyEventsAsync(ApplicationId, timespan: "PT30M");
                     Assert.NotEmpty(results.Value);
-                    Assert.Contains(results.Value, result =>
+                    AssertX.Any(results.Value, result =>
                     {
-                        return result.Dependency.Type == dependencyType
-                               && result.Dependency.Target == accountName
-                               && result.Dependency.Data == tableName
-                               && result.Cloud.RoleName == componentName
-                               && result.Dependency.Name == dependencyName;
+                        Assert.Equal(dependencyType, result.Dependency.Type);
+                        Assert.Equal(accountName, result.Dependency.Target);
+                        Assert.Equal(tableName, result.Dependency.Data);
+                        Assert.Equal(componentName, result.Cloud.RoleName);
+                        Assert.Equal(dependencyName, result.Dependency.Name);
+                        Assert.Equal(dependencyId, result.Dependency.Id);
                     });
                 });
             }
 
-            AssertX.Any(GetLogEventsFromMemory(), logEvent => {
+            AssertSerilogLogProperties(dependencyType, tableName, accountName, dependencyName);
+        }
+
+        private void AssertSerilogLogProperties(
+            string dependencyType,
+            string tableName,
+            string accountName,
+            string dependencyName)
+        {
+            IEnumerable<LogEvent> logEvents = GetLogEventsFromMemory();
+            AssertX.Any(logEvents, logEvent =>
+            {
                 StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
                 Assert.NotNull(logEntry);
-
-                var actualDependencyType = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyType));
+            
+                LogEventProperty actualDependencyType = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyType));
                 Assert.Equal(dependencyType, actualDependencyType.Value.ToDecentString());
-
-                var actualDependencyData = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyData));
+            
+                LogEventProperty actualDependencyData = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyData));
                 Assert.Equal(tableName, actualDependencyData.Value.ToDecentString());
-
-                var actualTargetName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
+            
+                LogEventProperty actualTargetName =
+                    Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.TargetName));
                 Assert.Equal(accountName, actualTargetName.Value.ToDecentString());
-
-                var actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
+            
+                LogEventProperty actualDependencyName = Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.DependencyName));
                 Assert.Equal(dependencyName, actualDependencyName.Value.ToDecentString());
-
+            
                 Assert.Single(logEntry.Properties, prop => prop.Name == nameof(DependencyLogEntry.Context));
             });
         }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureTableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureTableStorageDependencyTests.cs
@@ -39,6 +39,34 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         }
 
         [Fact]
+        public void LogTableStorageDependencyWithDependencyId_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string tableName = _bogusGenerator.Lorem.Word();
+            string accountName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, dependencyId);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.NotNull(dependency);
+            Assert.Equal("Azure table", dependency.DependencyType);
+            Assert.StartsWith(accountName, dependency.DependencyName);
+            Assert.EndsWith(tableName, dependency.DependencyName);
+            Assert.Equal(tableName, dependency.DependencyData);
+            Assert.Equal(accountName, dependency.TargetName);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+        }
+
+        [Fact]
         public void LogTableStorageDependency_WithNegativeDuration_Fails()
         {
             // Arrange
@@ -51,6 +79,22 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act
             Assert.ThrowsAny<ArgumentException>(() => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogTableStorageDependencyWithDependencyId_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            DateTimeOffset startTime = _bogusGenerator.Date.PastOffset();
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, dependencyId));
         }
 
         [Fact]
@@ -109,6 +153,37 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
         }
 
+        [Fact]
+        public void LogTableStorageDependencyWithDurationMeasurementWithDependencyId_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string tableName = _bogusGenerator.Lorem.Word();
+            string accountName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act
+            logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement, dependencyId);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.NotNull(dependency);
+            Assert.Equal("Azure table", dependency.DependencyType);
+            Assert.StartsWith(accountName, dependency.DependencyName);
+            Assert.EndsWith(tableName, dependency.DependencyName);
+            Assert.Equal(tableName, dependency.DependencyData);
+            Assert.Equal(accountName, dependency.TargetName);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogTableStorageDependencyWithDurationMeasurement_WithoutAccountName_Fails(string accountName)
@@ -128,6 +203,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void LogTableStorageDependencyWithDurationMeasurementDependencyId_WithoutAccountName_Fails(string accountName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement, dependencyId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void LogTableStorageDependencyWithDurationMeasurement_WithoutTableName_Fails(string tableName)
         {
             // Arrange
@@ -143,6 +236,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
                 () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement));
         }
 
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogTableStorageDependencyWithDurationMeasurementWithDependencyId_WithoutTableName_Fails(string tableName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string accountName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement, dependencyId));
+        }
+
         [Fact]
         public void LogTableStorageDependencyWithDurationMeasurement_WithoutMeasurement_Fails()
         {
@@ -155,6 +266,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement: (DurationMeasurement)null));
+        }
+
+        [Fact]
+        public void LogTableStorageDependencyWithDurationMeasurementWithDependencyId_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string accountName = _bogusGenerator.Commerce.ProductName();
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement: null, dependencyId));
         }
     }
 }


### PR DESCRIPTION
Adds dependency ID to Azure Table storage dependency tracking.

Relates to https://github.com/arcus-azure/arcus.observability/issues/243