### PR TITLE
fix: nuget docker tests template ref

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -121,7 +121,7 @@ stages:
             inputs:
               packageType: 'sdk'
               version: '$(DotNet.Sdk.PreviousVersion)'
-          - template: templates/run-docker-project.yml
+          - template: templates/run-docker-integration-tests.yml
             parameters:
               dockerProjectName: '$(Project).Tests.Runtimes.AzureFunction'
               httpPort: '$(AzureFunctions.HttpPort)'


### PR DESCRIPTION
We use the wrong local template in the NuGet release.