### PR TITLE
feat: add upstream service correlation options

### DIFF
--- a/src/Arcus.Observability.Correlation/CorrelationInfoOptions.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoOptions.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// Gets the correlation options specific for the upstream service.
         /// </summary>
-        public CorrelationInfoUpstreamServiceOptions UpstreamService { get; } = new CorrelationInfoUpstreamServiceOptions();
+        public CorrelationInfoUpstreamServiceOptions OperationParent { get; } = new CorrelationInfoUpstreamServiceOptions();
     }
 }

--- a/src/Arcus.Observability.Correlation/CorrelationInfoOptions.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoOptions.cs
@@ -14,5 +14,10 @@
         /// Gets the correlation options specific for the operation ID.
         /// </summary>
         public CorrelationInfoOperationOptions Operation { get; } = new CorrelationInfoOperationOptions();
+
+        /// <summary>
+        /// Gets the correlation options specific for the upstream service.
+        /// </summary>
+        public CorrelationInfoUpstreamServiceOptions UpstreamService { get; } = new CorrelationInfoUpstreamServiceOptions();
     }
 }

--- a/src/Arcus.Observability.Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.Observability.Correlation
+{
+    /// <summary>
+    /// Correlation options specific to the upstream services, used in the <see cref="CorrelationInfoOptions"/>.
+    /// </summary>
+    public class CorrelationInfoUpstreamServiceOptions
+    {
+        private string _operationParentIdHeaderName = "Request-Id";
+
+        /// <summary>
+        /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/> following the W3C Trace-Context standard. 
+        /// </summary>
+        public bool ExtractFromRequest { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the request header name where te operation parent ID is located (default: <c>"Request-Id"</c>).
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string OperationParentIdHeaderName
+        {
+            get => _operationParentIdHeaderName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the operation parent ID request header name");
+                _operationParentIdHeaderName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoOptionsTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Arcus.Observability.Correlation;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Correlation
+{
+    [Trait("Category", "Unit")]
+    public class CorrelationInfoOptionsTests
+    {
+        [Fact]
+        public void OperationParentIdPropertyName_HasDefault_Succeeds()
+        {
+            // Arrange
+            var options = new CorrelationInfoOptions();
+
+            // Act / Assert
+            Assert.NotEmpty(options.OperationParent.OperationParentIdHeaderName);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void SetOperationParentIdPropertyName_WithBlankValue_Fails(string operationIdPropertyName)
+        {
+            // Arrange
+            var options = new CorrelationInfoOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                options.OperationParent.OperationParentIdHeaderName = operationIdPropertyName);
+        }
+    }
+}


### PR DESCRIPTION
This will also make things a better streamlined as the operation parent ID was already in the Serilog correlation enrichers but not in the correlation model itself.
Currently, only the HTTP correlation properties has this upstream service, but with this in place, we wouldn't need that anymore.

Related to https://github.com/arcus-azure/arcus.templates/issues/575