### PR TITLE
chore: deprecated sql dep tracking overloads w/o sql command

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, <paramref name="tableName"/>, or <paramref name="operationName"/> is blank.
         /// </exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -156,6 +157,7 @@ namespace Microsoft.Extensions.Logging
         ///     Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, <paramref name="tableName"/>, or <paramref name="operationName"/> is blank.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,

--- a/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="tableName"/> or <paramref name="operationName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -135,6 +136,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="tableName"/> or <paramref name="operationName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,


### PR DESCRIPTION
Deprecate the SQL dependency tracking overloads without the SQL command but uses the table and operation name instead.

Follow-up of #286