### PR TITLE
chore: remove unnecessary deprecation

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -55,7 +55,6 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// </summary>
         /// <param name="logEvent">The log event to extract the properties from.</param>
         /// <param name="telemetry">The destination telemetry instance to add the properties to.</param>
-        [Obsolete("Telemetry context properties are not available anymore at the root of the Serilog properties but on a sub-level custom log entry objects")]
         protected void AssignTelemetryContextProperties(LogEvent logEvent, ISupportProperties telemetry)
         {
             AssignContextPropertiesFromDictionaryProperty(logEvent, telemetry, ContextProperties.TelemetryContext);


### PR DESCRIPTION
We only need to remove the call to add the telemetry properties from the `ContextProperties.EventTracking.EventContext` Serilog log property, and since we moved it to `ContextProperties.TelemetryContext`, we can still use this method.