### PR TITLE
feat: add operation parent generate id option

### DIFF
--- a/docs/preview/02-Features/correlation.md
+++ b/docs/preview/02-Features/correlation.md
@@ -151,6 +151,18 @@ public void ConfigureServices(IServiceCollection services)
         // The function that will generate the operation ID header value.
         // (default: new `Guid`).
         options.Operation.GenerateId = () => $"Operation-{Guid.NewGuid()}";
+
+        // Configuration on the operation parent ID.
+        // -----------------------------------------
+
+        // Whether to extract the operation parent ID from the request or not (default: true).
+        options.OperationParent.ExtractFromRequest = false;
+
+        // The header that will contain the full operation parent ID (default: Request-Id).
+        options.OperationParent.OperationParentHeaderName = "Request-Id";
+        
+        // The function that will generate the operation parent ID when it shouldn't be extracted from the request.
+        options.OperationParent.GenerateId = () => $"Parent-{Guid.newGuid()}";
     });
 }
 ```

--- a/src/Arcus.Observability.Correlation/CorrelationInfoUpstreamServiceOptions.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoUpstreamServiceOptions.cs
@@ -9,6 +9,7 @@ namespace Arcus.Observability.Correlation
     public class CorrelationInfoUpstreamServiceOptions
     {
         private string _operationParentIdHeaderName = "Request-Id";
+        private Func<string> _generateId = () => Guid.NewGuid().ToString();
 
         /// <summary>
         /// Gets or sets the flag indicating whether or not the upstream service information should be extracted from the <see cref="OperationParentIdHeaderName"/> following the W3C Trace-Context standard. 
@@ -26,6 +27,20 @@ namespace Arcus.Observability.Correlation
             {
                 Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the operation parent ID request header name");
                 _operationParentIdHeaderName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the function to generate the operation parent ID without extracting from the request.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="value"/> is <c>null</c>.</exception>
+        public Func<string> GenerateId
+        {
+            get => _generateId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Requires a function to generate the operation parent ID");
+                _generateId = value;
             }
         }
     }

--- a/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoOptionsTests.cs
@@ -28,5 +28,15 @@ namespace Arcus.Observability.Tests.Unit.Correlation
             Assert.ThrowsAny<ArgumentException>(() =>
                 options.OperationParent.OperationParentIdHeaderName = operationIdPropertyName);
         }
+
+        [Fact]
+        public void OperationParentId_WithoutGeneration_Fails()
+        {
+            // Arrange
+            var options = new CorrelationInfoOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.OperationParent.GenerateId = null);
+        }
     }
 }


### PR DESCRIPTION
If the operation parent ID shouldn't be extracted from the request (not default), we should allow generation like the other correlation options.