### PR TITLE
 (❗) fix: servicebus entityname as dependency targetname

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -29,7 +29,8 @@ namespace Arcus.Observability.Telemetry.Core
 
             public static class ServiceBus
             {
-                public const string EntityType = "EntityType";
+                public const string EntityType = "ServiceBus-EntityType";
+                public const string Endpoint = "ServiceBus-Endpoint";
             }
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
@@ -450,13 +450,14 @@ namespace Microsoft.Extensions.Logging
 
             context = context ?? new Dictionary<string, object>();
             context[ContextProperties.DependencyTracking.ServiceBus.EntityType] = entityType;
+            context[ContextProperties.DependencyTracking.ServiceBus.Endpoint] = serviceBusNamespaceEndpoint;
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Service Bus",
                 dependencyName: entityName,
                 dependencyData: null,
                 dependencyId: dependencyId,
-                targetName: $"{serviceBusNamespaceEndpoint} | {entityName}",
+                targetName: entityName,
                 duration: duration,
                 startTime: startTime,
                 resultCode: null,

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ServiceBusDependencyTests.cs
@@ -48,12 +48,12 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 AssertX.Any(results, result =>
                 {
                     Assert.Equal(dependencyType, result.Dependency.Type);
-                    Assert.Contains(namespaceEndpoint, result.Dependency.Target);
                     Assert.Contains(entityName, result.Dependency.Target);
                     Assert.Equal(dependencyName, result.Dependency.Name);
                     Assert.Equal(dependencyId, result.Dependency.Id);
 
                     AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.DependencyTracking.ServiceBus.EntityType, entityType.ToString());
+                    AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.DependencyTracking.ServiceBus.Endpoint, namespaceEndpoint);
 
                     Assert.Equal(correlation.OperationId, result.Operation.ParentId);
                     Assert.Equal(correlation.TransactionId, result.Operation.Id);
@@ -87,12 +87,12 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 AssertX.Any(results, result =>
                 {
                     Assert.Equal(dependencyType, result.Dependency.Type);
-                    Assert.Contains(namespaceEndpoint, result.Dependency.Target);
                     Assert.Contains(entityName, result.Dependency.Target);
                     Assert.Equal(dependencyName, result.Dependency.Name);
                     Assert.Equal(dependencyId, result.Dependency.Id);
 
                     AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.DependencyTracking.ServiceBus.EntityType, entityType.ToString());
+                    AssertContainsCustomDimension(result.CustomDimensions, ContextProperties.DependencyTracking.ServiceBus.Endpoint, namespaceEndpoint);
                 });
             });
         }

--- a/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
+++ b/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
@@ -35,7 +35,7 @@ namespace Arcus.Observability.Tests.Unit
                     "Cannot parse the written message as a telemetry dependency because no log message was written to this test logger");
             }
 
-            const string pattern = @"^(?<dependencytype>[\w\s]+) (?<dependencyname>[\w\s\.\/\/:\-]+)? (?<dependencydata>[\w\s\-\,\/]+)? named (?<targetname>[\w\s\.\/\/:\|\-]+)? with ID (?<dependencyid>[\w\s\-]*)? in (?<duration>(\d{1}\.)?\d{2}:\d{2}:\d{2}\.\d{7}) at (?<starttime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7} \+\d{2}:\d{2}) \(IsSuccessful: (?<issuccessful>(True|False)) - ResultCode: (?<resultcode>\d*) - Context: \{(?<context>((\[\w+, \w+\])(; \[[\w\-]+, \w+\])*))\}\)$";
+            const string pattern = @"^(?<dependencytype>[\w\s]+) (?<dependencyname>[\w\s\.\/\/:\-]+)? (?<dependencydata>[\w\s\-\,\/]+)? named (?<targetname>[\w\s\.\/\/:\|\-]+)? with ID (?<dependencyid>[\w\s\-]*)? in (?<duration>(\d{1}\.)?\d{2}:\d{2}:\d{2}\.\d{7}) at (?<starttime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7} \+\d{2}:\d{2}) \(IsSuccessful: (?<issuccessful>(True|False)) - ResultCode: (?<resultcode>\d*) - Context: \{(?<context>((\[[\w\-]+, \w+\])(; \[[\w\-]+, \w+\])*))\}\)$";
             Match match = Regex.Match(logger.WrittenMessage, pattern);
 
             string dependencyType = match.GetGroupValue("dependencytype");

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusDependencyLoggingTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Bogus;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using static Arcus.Observability.Telemetry.Core.ContextProperties.DependencyTracking;
 
 namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 {
@@ -57,15 +57,14 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
-            Assert.Contains(entityName, dependency.TargetName);
+            Assert.Equal(entityName, dependency.TargetName);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(dependencyId, dependency.DependencyId);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(entityType.ToString(), entityTypeItem.Value);
+            Assert.Equal(entityType.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Fact]
@@ -152,8 +151,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(entityType.ToString(), entityTypeItem.Value);
+            Assert.Equal(entityType.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
         }
 
         [Fact]
@@ -162,8 +160,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Arrange
             var logger = new TestLogger();
             var entityType = BogusGenerator.Random.Enum<ServiceBusEntityType>();
-            string namespaceEndpoint = BogusGenerator.Commerce.Product();
-            string entityName = BogusGenerator.Commerce.Product();
+            string namespaceEndpoint = BogusGenerator.Lorem.Word();
+            string entityName = BogusGenerator.Lorem.Word();
             bool isSuccessful = BogusGenerator.PickRandom(true, false);
             var measurement = DurationMeasurement.Start();
             DateTimeOffset startTime = measurement.StartTime;
@@ -176,16 +174,15 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
-            Assert.Contains(entityName, dependency.TargetName);
+            Assert.Equal(entityName, dependency.TargetName);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
             Assert.Equal(entityName, dependency.DependencyName);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(dependencyId, dependency.DependencyId);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(entityType.ToString(), entityTypeItem.Value);
+            Assert.Equal(entityType.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Theory]
@@ -316,7 +313,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
             Assert.Contains(queueName, dependency.TargetName);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
             Assert.Equal(queueName, dependency.DependencyName);
@@ -324,8 +320,8 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(dependencyId, dependency.DependencyId);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Queue.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Fact]
@@ -408,8 +404,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Queue.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
         }
 
         [Fact]
@@ -431,16 +426,15 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
-            Assert.Contains(queueName, dependency.TargetName);
+            Assert.Equal(queueName, dependency.TargetName);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
             Assert.Equal(queueName, dependency.DependencyName);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(dependencyId, dependency.DependencyId);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Queue.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Queue.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Theory]
@@ -557,16 +551,15 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
-            Assert.Contains(topicName, dependency.TargetName);
+            Assert.Equal(topicName, dependency.TargetName);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
             Assert.Equal(topicName, dependency.DependencyName);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(dependencyId, dependency.DependencyId);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Topic.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Topic.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Theory]
@@ -699,8 +692,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Topic.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Topic.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
         }
 
         [Fact]
@@ -722,16 +714,15 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
-            Assert.Contains(namespaceEndpoint, dependency.TargetName);
-            Assert.Contains(topicName, dependency.TargetName);
+            Assert.Equal(topicName, dependency.TargetName);
             Assert.Equal("Azure Service Bus", dependency.DependencyType);
             Assert.Equal(topicName, dependency.DependencyName);
             Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
             Assert.Equal(duration, dependency.Duration);
             Assert.Equal(isSuccessful, dependency.IsSuccessful);
             Assert.Equal(dependencyId, dependency.DependencyId);
-            KeyValuePair<string, object> entityTypeItem = Assert.Single(dependency.Context, item => item.Key == ContextProperties.DependencyTracking.ServiceBus.EntityType);
-            Assert.Equal(ServiceBusEntityType.Topic.ToString(), entityTypeItem.Value);
+            Assert.Equal(ServiceBusEntityType.Topic.ToString(), Assert.Contains(ServiceBus.EntityType, dependency.Context));
+            Assert.Equal(namespaceEndpoint, Assert.Contains(ServiceBus.Endpoint, dependency.Context));
         }
 
         [Theory]


### PR DESCRIPTION
We should use the Azure ServiceBus entity name as the telemetry dependency target name when tracking Azure Service Bus dependencies because otherwise the request/dependency will not recognize the relationship as the same component/resource.