### PR TITLE
feat: track custom request

### DIFF
--- a/docs/preview/03-Features/writing-different-telemetry-types.md
+++ b/docs/preview/03-Features/writing-different-telemetry-types.md
@@ -593,6 +593,38 @@ using (var measurement = DurationMeasurement.Start())
 
 > 💡 Note that [Arcus Web API request tracking middleware](https://webapi.arcus-azure.net/features/logging#logging-incoming-requests) can already do this for you in a ASP.NET Core application
 
+### Incoming custom requests
+Requests allow you to keep track of incoming messages. We provide an extension to track type of requests that aren't out-of-the-box so you can track your custom systems.
+
+Here is how you can log a custom request on an event that's being processed:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+bool isSuccessful = false;
+
+// Start measuring.
+using (var measurement = DurationMeasurement.Start())
+{
+    try
+    {
+        // Processing message.
+
+        // End processing.
+        
+        isSuccessful = true;
+    }
+    finally
+    {
+        logger.LogCustomRequest("<my-request-source>", "<operation-name>", isSuccessful, measurement);
+        // Output: Custom <my-request-source> from Process completed in 0.00:12:20.8290760 at 2021-10-26T05:36:03.6067975 +02:00 - (IsSuccessful: True, Context: {[TelemetryType, Request]})
+    }
+}
+```
+
+The `<my-request-source>` will reflect the `Source` in Application Insights telemetry. This is set automatically in our HTTP, Azure Service Bus, Azure EventHubs, etc. requests but is configurable when you track custom requests.
+We provide overloads to configure the functional operation name (default: `Process`).
+
 ## Traces & Exceptions
 Application Insights telemetry traces and exceptions are log messages not directly linked by an incoming request, outgoing dependency, or metric. 
 These traces are also linked with correlation and are therefore part of the whole application component in Application Insights.

--- a/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
+++ b/src/Arcus.Observability.Telemetry.Core/ContextProperties.cs
@@ -65,7 +65,9 @@ namespace Arcus.Observability.Telemetry.Core
             public const string ResponseStatusCode = "ResponseStatusCode";
             public const string RequestDuration = "RequestDuration";
             public const string RequestTime = "RequestTime";
-            
+
+            public const string DefaultOperationName = "Process";
+
             public static class ServiceBus
             {
                 public const string Endpoint = "ServiceBus-Endpoint";

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
             Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure EventHubs request process latency duration");
 
-            LogEventHubsRequest(logger, eventHubsNamespace, eventHubsName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
+            LogEventHubsRequest(logger, eventHubsNamespace, eventHubsName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
@@ -47,18 +47,19 @@ namespace Microsoft.Extensions.Logging
         /// <param name="eventHubsNamespace">The namespace in which the Azure EventHUbs is located.</param>
         /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
         /// <param name="isSuccessful">The indication whether or not the Azure EventHubs request was successfully processed.</param>
-        /// <param name="duration">The duration it took to process the Azure EventHubs request.</param>
         /// <param name="startTime">The time when the request was received.</param>
+        /// <param name="duration">The duration it took to process the Azure EventHubs request.</param>
         /// <param name="context">The telemetry context that provides more insights on the Azure EventHubs request.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsNamespace"/>, <paramref name="eventHubsName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogEventHubsRequest(
             this ILogger logger,
             string eventHubsNamespace,
             string eventHubsName,
             bool isSuccessful,
-            TimeSpan duration,
             DateTimeOffset startTime,
+            TimeSpan duration,
             Dictionary<string, object> context = null)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
@@ -66,7 +67,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure EventHubs request operation");
 
-            LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful, duration, startTime, context);
+            LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
             Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure EventHubs request process latency duration");
 
-            LogEventHubsRequest(logger, eventHubsNamespace, consumerGroup, eventHubsName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
+            LogEventHubsRequest(logger, eventHubsNamespace, consumerGroup, eventHubsName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
         /// <summary>
@@ -112,13 +113,14 @@ namespace Microsoft.Extensions.Logging
         /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
         /// <param name="operationName">The optional logical name that can be used to identify the operation that consumes the message.</param>
         /// <param name="isSuccessful">The indication whether or not the Azure EventHubs request was successfully processed.</param>
-        /// <param name="duration">The duration it took to process the Azure EventHubs request.</param>
         /// <param name="startTime">The time when the request was received.</param>
+        /// <param name="duration">The duration it took to process the Azure EventHubs request.</param>
         /// <param name="context">The telemetry context that provides more insights on the Azure EventHubs request.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="eventHubsNamespace"/>, <paramref name="consumerGroup"/>, <paramref name="eventHubsName"/> is blank.
         /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogEventHubsRequest(
             this ILogger logger,
             string eventHubsNamespace,
@@ -126,8 +128,8 @@ namespace Microsoft.Extensions.Logging
             string eventHubsName,
             string operationName,
             bool isSuccessful,
-            TimeSpan duration,
             DateTimeOffset startTime,
+            TimeSpan duration,
             Dictionary<string, object> context = null)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Telemetry extensions on the <see cref="ILogger"/> instance to write Application Insights compatible log messages.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static partial class ILoggerExtensions
+    {
+        /// <summary>
+        /// Logs a custom request.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the telemetry.</param>
+        /// <param name="requestSource">The source for the request telemetry to identifying the caller (ex. entity name of Azure Service Bus).</param>
+        /// <param name="isSuccessful">The indication whether or not the custom request was successfully processed.</param>
+        /// <param name="measurement">The instance to measure the duration of the custom request.</param>
+        /// <param name="context">The telemetry context that provides more insights on the custom request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="requestSource"/> is blank.</exception>
+        public static void LogCustomRequest(
+            this ILogger logger,
+            string requestSource,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+
+            LogCustomRequest(logger, requestSource, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        /// Logs a custom request.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the telemetry.</param>
+        /// <param name="requestSource">The source for the request telemetry to identifying the caller (ex. entity name of Azure Service Bus).</param>
+        /// <param name="isSuccessful">The indication whether or not the custom request was successfully processed.</param>
+        /// <param name="startTime">The time when the request was received.</param>
+        /// <param name="duration">The duration it took to process the custom request.</param>
+        /// <param name="context">The telemetry context that provides more insights on the custom request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="requestSource"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogCustomRequest(
+            this ILogger logger,
+            string requestSource,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the custom request operation");
+
+            LogCustomRequest(logger, requestSource, operationName: null, isSuccessful, startTime, duration, context);
+        }
+
+        /// <summary>
+        /// Logs a custom request.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the telemetry.</param>
+        /// <param name="requestSource">The source for the request telemetry to identifying the caller (ex. entity name of Azure Service Bus).</param>
+        /// <param name="operationName">The optional logical name that can be used to identify the operation that consumes the message.</param>
+        /// <param name="isSuccessful">The indication whether or not the custom request was successfully processed.</param>
+        /// <param name="measurement">The instance to measure the duration of the custom request.</param>
+        /// <param name="context">The telemetry context that provides more insights on the custom request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="requestSource"/> is blank.</exception>
+        public static void LogCustomRequest(
+            this ILogger logger,
+            string requestSource,
+            string operationName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+
+            LogCustomRequest(logger, requestSource, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        /// Logs a custom request.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the telemetry.</param>
+        /// <param name="requestSource">The source for the request telemetry to identifying the caller (ex. entity name of Azure Service Bus).</param>
+        /// <param name="operationName">The optional logical name that can be used to identify the operation that consumes the message.</param>
+        /// <param name="isSuccessful">The indication whether or not the custom request was successfully processed.</param>
+        /// <param name="startTime">The time when the request was received.</param>
+        /// <param name="duration">The duration it took to process the custom request.</param>
+        /// <param name="context">The telemetry context that provides more insights on the custom request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="requestSource"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogCustomRequest(
+            this ILogger logger, 
+            string requestSource,
+            string operationName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the custom request operation");
+
+            if (string.IsNullOrWhiteSpace(operationName))
+            {
+                operationName = ContextProperties.RequestTracking.DefaultOperationName;
+            }
+
+            context = context ?? new Dictionary<string, object>();
+
+            logger.LogWarning(MessageFormats.RequestFormat, RequestLogEntry.CreateForCustomRequest(requestSource, operationName, isSuccessful, duration, startTime, context));
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestSourceSystem.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestSourceSystem.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// Specifies that the request-source is an Azure EventHubs.
         /// </summary>
-        AzureEventHubs = 4
+        AzureEventHubs = 4,
+
+        /// <summary>
+        /// Specifies that the request-source is a custom system.
+        /// </summary>
+        Custom = 8
     }
 }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomRequestTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/CustomRequestTests.cs
@@ -6,26 +6,23 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
-using static Arcus.Observability.Telemetry.Core.ContextProperties.RequestTracking;
 
 namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights
 {
-    public class EventHubsRequestTests : ApplicationInsightsSinkTests
+    public class CustomRequestTests : ApplicationInsightsSinkTests
     {
-        public EventHubsRequestTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        public CustomRequestTests(ITestOutputHelper outputWriter) : base(outputWriter)
         {
         }
 
         [Fact]
-        public async Task LogEventHubsRequest_SinksToApplicationInsights_ResultsInEventHubsRequestTelemetry()
+        public async Task LogCustomRequest_SinksToApplicationInsights_ResultsInCustomRequestTelemetry()
         {
             // Arrange
             string componentName = BogusGenerator.Commerce.ProductName();
             LoggerConfiguration.Enrich.WithComponentName(componentName);
 
-            string eventHubsNamespace = BogusGenerator.Lorem.Word();
-            string eventHubsConsumerGroup = BogusGenerator.Lorem.Word();
-            string eventHubsName = BogusGenerator.Lorem.Word();
+            string customRequestSource = BogusGenerator.Lorem.Word();
             string operationName = BogusGenerator.Lorem.Word();
 
             bool isSuccessful = BogusGenerator.Random.Bool();
@@ -34,7 +31,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
             // Act
-            Logger.LogEventHubsRequest(eventHubsNamespace, eventHubsConsumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration, telemetryContext);
+            Logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration, telemetryContext);
 
             // Assert
             await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
@@ -43,25 +40,14 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 AssertX.Any(requests, result =>
                 {
                     Assert.Equal(operationName, result.Request.Name);
-                    Assert.Contains(eventHubsName, result.Request.Source);
-                    Assert.Contains(eventHubsNamespace, result.Request.Source);
+                    Assert.Contains(customRequestSource, result.Request.Source);
                     Assert.Empty(result.Request.Url);
                     Assert.Equal(operationName, result.Operation.Name);
                     Assert.True(bool.TryParse(result.Request.Success, out bool success));
                     Assert.Equal(isSuccessful, success);
                     Assert.Equal(componentName, result.Cloud.RoleName);
-
-                    AssertContainsCustomDimension(result.CustomDimensions, EventHubs.Namespace, eventHubsNamespace);
-                    AssertContainsCustomDimension(result.CustomDimensions, EventHubs.ConsumerGroup, eventHubsConsumerGroup);
-                    AssertContainsCustomDimension(result.CustomDimensions, EventHubs.Name, eventHubsName);
                 });
             });
-        }
-
-        private static void AssertContainsCustomDimension(EventsResultDataCustomDimensions customDimensions, string key, string expected)
-        {
-            Assert.True(customDimensions.TryGetValue(key, out string actual), $"Cannot find {key} in custom dimensions: {String.Join(", ", customDimensions.Keys)}");
-            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
+++ b/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
@@ -100,7 +100,7 @@ namespace Arcus.Observability.Tests.Unit
             }
             else
             {
-                const string pattern = @"(Azure Service Bus|Azure EventHubs) from (?<operationname>[\w\s]+) completed in (?<duration>(\d{1}\.)?\d{2}:\d{2}:\d{2}\.\d{7}) at (?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7} \+\d{2}:\d{2}) - \(IsSuccessful: (?<issuccessful>(True|False)), Context: \{(?<context>((\[[\w\-]+, [\w\$]+\])(; \[[\w\-]+, [\w\$\.]+\])*))\}\)$";
+                const string pattern = @"(Azure Service Bus|Azure EventHubs|Custom \w+) from (?<operationname>[\w\s]+) completed in (?<duration>(\d{1}\.)?\d{2}:\d{2}:\d{2}\.\d{7}) at (?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7} \+\d{2}:\d{2}) - \(IsSuccessful: (?<issuccessful>(True|False)), Context: \{(?<context>((\[[\w\-]+, [\w\$]+\])(; \[[\w\-]+, [\w\$\.]+\])*))\}\)$";
                 Match match = Regex.Match(logger.WrittenMessage, pattern);
 
                 string operationName = match.GetGroupValue("operationname");
@@ -117,6 +117,14 @@ namespace Arcus.Observability.Tests.Unit
                 if (logger.WrittenMessage.StartsWith("Azure EventHubs"))
                 {
                     return RequestLogEntry.CreateForEventHubs(operationName, isSuccessful, duration, startTime, context);
+                }
+
+                if (logger.WrittenMessage.StartsWith("Custom"))
+                {
+                    int length = logger.WrittenMessage.IndexOf(" from ", StringComparison.CurrentCulture);
+                    int startIndex = "Custom ".Length;
+                    string customRequestSource = logger.WrittenMessage.Substring(startIndex, length - startIndex);
+                    return RequestLogEntry.CreateForCustomRequest(customRequestSource, operationName, isSuccessful, duration, startTime, context);
                 }
 
                 throw new InvalidOperationException("Cannot determine request source system during parsing of logged request");

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomRequestLoggingTests.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using Bogus;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using static Arcus.Observability.Telemetry.Core.ContextProperties.RequestTracking;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
+{
+    public class CustomRequestLoggingTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void LogWithoutOperationNameWithDurationMeasurement_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogCustomRequest(customRequestSource, isSuccessful, measurement, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.Equal(RequestSourceSystem.Custom, entry.SourceSystem);
+            Assert.Equal(customRequestSource, entry.CustomRequestSource);
+            Assert.Equal(DefaultOperationName, entry.OperationName);
+            Assert.Equal(isSuccessful, entry.ResponseStatusCode is 200);
+            Assert.Equal(measurement.StartTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(measurement.Elapsed, entry.RequestDuration);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogWithoutOperationNameWithDurationMeasurement_WithoutEventHubsNamespace_Fails(string customRequestSource)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, isSuccessful, measurement));
+        }
+
+        [Fact]
+        public void LogWithoutOperationNameWithDurationMeasurement_WithoutDurationMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string eventHubsName = BogusGenerator.Lorem.Word();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, eventHubsName, isSuccessful, measurement: null));
+        }
+
+        [Fact]
+        public void LogWithoutOperationName_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogCustomRequest(customRequestSource, isSuccessful, startTime, duration, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.Equal(RequestSourceSystem.Custom, entry.SourceSystem);
+            Assert.Equal(customRequestSource, entry.CustomRequestSource);
+            Assert.Equal(DefaultOperationName, entry.OperationName);
+            Assert.Equal(isSuccessful, entry.ResponseStatusCode is 200);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(duration, entry.RequestDuration);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogWithoutOperationName_WithoutEventHubsNamespace_Fails(string customRequestSource)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogWithoutOperationName_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan().Negate();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, isSuccessful, startTime, duration));
+        }
+
+         [Fact]
+        public void LogWithOperationNameWithDurationMeasurement_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, measurement, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.Equal(RequestSourceSystem.Custom, entry.SourceSystem);
+            Assert.Equal(customRequestSource, entry.CustomRequestSource);
+            Assert.Equal(operationName, entry.OperationName);
+            Assert.Equal(isSuccessful, entry.ResponseStatusCode is 200);
+            Assert.Equal(measurement.StartTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(measurement.Elapsed, entry.RequestDuration);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogWithOperationNameWithDurationMeasurement_WithoutEventHubsNamespace_Fails(string customRequestSource)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, measurement));
+        }
+
+        [Fact]
+        public void LogWithOperationNameWithDurationMeasurement_WithoutDurationMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, measurement: null));
+        }
+
+        [Fact]
+        public void LogWithOperationName_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.Equal(RequestSourceSystem.Custom, entry.SourceSystem);
+            Assert.Equal(customRequestSource, entry.CustomRequestSource);
+            Assert.Equal(operationName, entry.OperationName);
+            Assert.Equal(isSuccessful, entry.ResponseStatusCode is 200);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(duration, entry.RequestDuration);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogWithOperationName_WithoutEventHubsNamespace_Fails(string customRequestSource)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogWithOperationName_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            TimeSpan duration = BogusGenerator.Date.Timespan().Negate();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration));
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsRequestLoggingTests.cs
@@ -106,7 +106,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var context = new Dictionary<string, object> { [key] = value };
 
             // Act
-            logger.LogEventHubsRequest(@namespace, name, isSuccessful, duration, startTime, context);
+            logger.LogEventHubsRequest(@namespace, name, isSuccessful, startTime, duration, context);
 
             // Assert
             RequestLogEntry entry = logger.GetMessageAsRequest();
@@ -133,7 +133,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, startTime, duration));
         }
 
         [Theory]
@@ -149,7 +149,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, eventHubsName, isSuccessful, startTime, duration));
         }
 
          [Fact]
@@ -269,7 +269,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var context = new Dictionary<string, object> { [key] = value };
 
             // Act
-            logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, duration, startTime, context);
+            logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration, context);
 
             // Assert
             RequestLogEntry entry = logger.GetMessageAsRequest();
@@ -299,7 +299,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration));
         }
 
         [Theory]
@@ -317,7 +317,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration));
         }
 
         [Fact]
@@ -335,7 +335,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, duration, startTime));
+                () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration));
         }
     }
 }


### PR DESCRIPTION
Adds extensions to track custom requests (like we can track custom dependencies) to let users make use of Observability outside provided systems we provide request tracking (API, Service Bus, EventHubs).

Closes #438 