### PR TITLE
feat: track http request data in http trigger

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2455,6 +2455,58 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -3134,9 +3186,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12640,9 +12692,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -13188,9 +13240,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dependencies": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -13257,27 +13309,20 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -16906,6 +16951,49 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@mdx-js/mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -17441,9 +17529,9 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
     },
     "acorn-import-assertions": {
       "version": "1.7.6",
@@ -24550,9 +24638,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -24975,9 +25063,9 @@
       "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -25030,20 +25118,14 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "terser": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-          "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+          "version": "5.14.2",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+          "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
           "requires": {
+            "@jridgewell/source-map": "^0.3.2",
+            "acorn": "^8.5.0",
             "commander": "^2.20.0",
-            "source-map": "~0.7.2",
-            "source-map-support": "~0.5.19"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-            }
+            "source-map-support": "~0.5.20"
           }
         }
       }

--- a/docs/preview/03-Features/writing-different-telemetry-types.md
+++ b/docs/preview/03-Features/writing-different-telemetry-types.md
@@ -555,7 +555,7 @@ using (var measurement = DurationMeasurement.Start())
 
 We provide overloads to configure the Azure EventHubs consumer group (default: `$Default`) and a functional operation name (default: `Process`).
 
-### Incoming HTTP requests
+### Incoming HTTP requests in API's
 Requests allow you to keep track of the HTTP requests that are performed against your API and what the response was that was sent out.
 
 **Installation**
@@ -592,6 +592,50 @@ using (var measurement = DurationMeasurement.Start())
 ```
 
 > 💡 Note that [Arcus Web API request tracking middleware](https://webapi.arcus-azure.net/features/logging#logging-incoming-requests) can already do this for you in a ASP.NET Core application
+
+### Incoming HTTP requests in Azure Function HTTP trigger
+Requests allow you to keep track of the HTTP requests that are performed against your Azure Function HTTP trigger and what the response was that was sent out.
+
+**Installation**
+
+If you want to track the `HttpRequestData` of an isolated Azure Functions HTTP trigger project, you'll have to install an additional package to include these dependencies:
+
+```shell
+PM > Install-Package Arcus.Observability.Telemetry.AzureFunctions
+```
+
+**Example**
+
+Here is how you can keep track of requests:
+
+```csharp
+using Sytem.Net;
+using Microsoft.Extensions.Logging;
+
+public async Task<HttpResponseData> Run(
+    [HttpTrigger(AuthorizationLevel.Function, "post", Route = "v1/order")] HttpRequestData request,
+    FunctionContext executionContext)
+{
+    var statusCode = default(HttpStatusCode);
+
+    // Start tracking request.
+    using (var measurement = DurationMeasurement.Start())
+    {
+        try
+        {
+            // Processing...
+
+            statusCode = HttpStatusCode.Ok;
+            return request.CreateResponse(statusCode)
+        }
+        finally
+        {
+            logger.LogRequest(request, statusCode, measurement);
+            // Output: {"RequestMethod": "POST", "RequestHost": "http://localhost:5000/", "RequestUri": "http://localhost:5000/v1/order", "ResponseStatusCode": 200, "RequestDuration": "00:00:00.0191554", "RequestTime": "03/23/2020 10:12:55 +00:00", "Context": {}}
+        }
+    }
+}
+```
 
 ## Traces & Exceptions
 Application Insights telemetry traces and exceptions are log messages not directly linked by an incoming request, outgoing dependency, or metric. 

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Arcus.Observability.Telemetry.AzureFunctions.csproj
@@ -26,11 +26,16 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Arcus.Observability.Telemetry.Core\Arcus.Observability.Telemetry.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using GuardNet;
+#if NET6_0
+using Microsoft.Azure.Functions.Worker.Http; 
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+#if NET6_0
+    /// <summary>
+    /// Telemetry extensions on the <see cref="ILogger"/> instance to write Application Insights compatible log messages.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class ILoggerRequestExtensions
+    {
+        /// <summary>
+        /// Logs an HTTP request.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">The incoming HTTP request that was processed.</param>
+        /// <param name="responseStatusCode">The HTTP status code returned by the service.</param>
+        /// <param name="measurement">The instance to measure the duration of the HTTP request.</param>
+        /// <param name="context">The context that provides more insights on the tracked HTTP request.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or the <paramref name="measurement"/>  is <c>null</c>.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestData request,
+            HttpStatusCode responseStatusCode,
+            DurationMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+
+            LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        /// Logs an HTTP request.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">The incoming HTTP request that was processed.</param>
+        /// <param name="responseStatusCode">The HTTP status code returned by the service.</param>
+        /// <param name="startTime">The time when the HTTP request was received.</param>
+        /// <param name="duration">The duration of the HTTP request processing operation.</param>
+        /// <param name="context">The context that provides more insights on the tracked HTTP request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestData request,
+            HttpStatusCode responseStatusCode,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+
+            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        }
+
+        /// <summary>
+        /// Logs an HTTP request.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">The incoming HTTP request that was processed.</param>
+        /// <param name="responseStatusCode">The HTTP status code returned by the service.</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="measurement">The instance to measure the duration of the HTTP request.</param>
+        /// <param name="context">The context that provides more insights on the tracked HTTP request.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="logger"/>, <paramref name="request"/>, or the <paramref name="measurement"/>  is <c>null</c>.
+        /// </exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestData request,
+            HttpStatusCode responseStatusCode,
+            string operationName,
+            DurationMeasurement measurement,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+
+            LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
+        }
+
+        /// <summary>
+        /// Logs an HTTP request.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="request">The incoming HTTP request that was processed.</param>
+        /// <param name="responseStatusCode">The HTTP status code returned by the service.</param>
+        /// <param name="operationName">The name of the operation of the request.</param>
+        /// <param name="startTime">The time when the HTTP request was received.</param>
+        /// <param name="duration">The duration of the HTTP request processing operation.</param>
+        /// <param name="context">The context that provides more insights on the tracked HTTP request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogRequest(
+            this ILogger logger,
+            HttpRequestData request,
+            HttpStatusCode responseStatusCode,
+            string operationName,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+
+            context = context ?? new Dictionary<string, object>();
+
+            logger.LogWarning(MessageFormats.RequestFormat,
+                RequestLogEntry.CreateForHttpRequest(request.Method,
+                    request.Url.Scheme,
+                    request.Url.Host,
+                    request.Url.AbsolutePath,
+                    operationName,
+                    (int) responseStatusCode,
+                    startTime,
+                    duration,
+                    context));
+        }
+    }
+#endif
+}

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
@@ -327,10 +327,7 @@ namespace Microsoft.Extensions.Logging
         ///     the <paramref name="request"/>'s scheme contains whitespace,
         ///     the <paramref name="request"/>'s host contains whitespace,
         /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///     Thrown when the <paramref name="responseStatusCode"/>'s status code is outside the 0-999 inclusively,
-        ///     the <paramref name="duration"/> is a negative time range.
-        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogRequest(
             this ILogger logger,
             HttpRequestMessage request,

--- a/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
+++ b/src/Arcus.Observability.Tests.Integration/Arcus.Observability.Tests.Integration.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Observability.Telemetry.AspNetCore\Arcus.Observability.Telemetry.AspNetCore.csproj" />
+    <ProjectReference Include="..\Arcus.Observability.Telemetry.AzureFunctions\Arcus.Observability.Telemetry.AzureFunctions.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Core\Arcus.Observability.Telemetry.Core.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Sql\Arcus.Observability.Telemetry.Sql.csproj" />
     <ProjectReference Include="..\Arcus.Observability.Telemetry.Serilog.Filters\Arcus.Observability.Telemetry.Serilog.Filters.csproj" />

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -138,7 +138,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 {
                     var client = new ApplicationInsightsClient(dataClient, ApplicationId);
                     await assertion(client);
-                }, timeout: TimeSpan.FromMinutes(7)); 
+                }, timeout: TimeSpan.FromMinutes(1)); 
             }
         }
 
@@ -152,18 +152,36 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
 
         private static async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion, TimeSpan timeout)
         {
+            Exception lastException = null;
             PolicyResult result =
                 await Policy.TimeoutAsync(timeout)
                             .WrapAsync(Policy.Handle<Exception>()
                                              .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1)))
-                            .ExecuteAndCaptureAsync(assertion);
+                            .ExecuteAndCaptureAsync(async () =>
+                            {
+                                try
+                                {
+                                    await assertion();
+                                }
+                                catch (Exception exception)
+                                {
+                                    lastException = exception;
+                                    throw;
+                                }
+                            });
 
             if (result.Outcome is OutcomeType.Failure)
             {
                 if (result.FinalException is TimeoutRejectedException
-                    && result.FinalException.InnerException != null)
+                    && result.FinalException.InnerException != null
+                    && result.FinalException.InnerException is not TaskCanceledException)
                 {
                     throw result.FinalException.InnerException;
+                }
+
+                if (lastException != null)
+                {
+                    throw lastException;
                 }
 
                 throw result.FinalException;

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -138,7 +138,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 {
                     var client = new ApplicationInsightsClient(dataClient, ApplicationId);
                     await assertion(client);
-                }, timeout: TimeSpan.FromMinutes(1)); 
+                }, timeout: TimeSpan.FromMinutes(8)); 
             }
         }
 

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpRequestDataTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpRequestDataTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Observability.Correlation;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights
+{
+    public class HttpRequestDataTests : ApplicationInsightsSinkTests
+    {
+        public HttpRequestDataTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+         [Fact]
+        public async Task LogRequest_SinksToApplicationInsightsWithCorrelation_ResultsInRequestTelemetry()
+        {
+            // Arrange
+            var correlation = new CorrelationInfo($"operation-{Guid.NewGuid()}", $"transaction-{Guid.NewGuid()}", $"parent-{Guid.NewGuid()}");
+            var accessor = new DefaultCorrelationInfoAccessor();
+            accessor.SetCorrelationInfo(correlation);
+            LoggerConfiguration.Enrich.WithCorrelationInfo(accessor);
+
+            var operationName = "sampleoperation";
+            HttpMethod httpMethod = GenerateHttpMethod();
+            var requestUri = new Uri(BogusGenerator.Internet.UrlWithPath());
+            HttpRequestData request = CreateStubRequest(httpMethod, requestUri.Scheme, requestUri.Host, requestUri.AbsolutePath);
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = DateTimeOffset.Now;
+            Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
+
+            // Act
+            Logger.LogRequest(request, statusCode, operationName, startTime, duration, telemetryContext);
+
+            // Assert
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
+            {
+                EventsRequestResult[] results = await client.GetRequestsAsync();
+                AssertX.Any(results, result =>
+                {
+                    Assert.Equal($"{requestUri.Scheme}://{requestUri.Host}{requestUri.AbsolutePath}", result.Request.Url);
+                    Assert.Equal(((int) statusCode).ToString(), result.Request.ResultCode);
+                    Assert.Equal($"{httpMethod.Method} {operationName}", result.Operation.Name);
+
+                    Assert.Equal(correlation.OperationId, result.Request.Id);
+                    Assert.Equal(correlation.TransactionId, result.Operation.Id);
+                    Assert.Equal(correlation.OperationParentId, result.Operation.ParentId);
+                });
+            });
+        }
+
+        private HttpMethod GenerateHttpMethod()
+        {
+            return BogusGenerator.PickRandom(
+                HttpMethod.Get,
+                HttpMethod.Delete,
+                HttpMethod.Head,
+                HttpMethod.Options,
+                HttpMethod.Patch,
+                HttpMethod.Post,
+                HttpMethod.Put,
+                HttpMethod.Trace);
+        }
+
+        private static HttpRequestData CreateStubRequest(HttpMethod method, string host, string path, string scheme)
+        {
+            var context = Mock.Of<FunctionContext>();
+
+            var stub = new Mock<HttpRequestData>(context);
+            stub.Setup(s => s.Method).Returns(method.Method);
+            stub.Setup(s => s.Url).Returns(new Uri(scheme + "://" + host + path));
+
+            return stub.Object;
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpRequestDataTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/HttpRequestDataTests.cs
@@ -33,7 +33,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             var operationName = "sampleoperation";
             HttpMethod httpMethod = GenerateHttpMethod();
             var requestUri = new Uri(BogusGenerator.Internet.UrlWithPath());
-            HttpRequestData request = CreateStubRequest(httpMethod, requestUri.Scheme, requestUri.Host, requestUri.AbsolutePath);
+            HttpRequestData request = CreateStubRequest(httpMethod, requestUri);
             var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
             
             TimeSpan duration = BogusGenerator.Date.Timespan();
@@ -73,13 +73,13 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 HttpMethod.Trace);
         }
 
-        private static HttpRequestData CreateStubRequest(HttpMethod method, string host, string path, string scheme)
+        private static HttpRequestData CreateStubRequest(HttpMethod method, Uri requestUri)
         {
             var context = Mock.Of<FunctionContext>();
 
             var stub = new Mock<HttpRequestData>(context);
             stub.Setup(s => s.Method).Returns(method.Method);
-            stub.Setup(s => s.Url).Returns(new Uri(scheme + "://" + host + path));
+            stub.Setup(s => s.Url).Returns(requestUri);
 
             return stub.Object;
         }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/RequestTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/RequestTests.cs
@@ -21,7 +21,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         {
         }
 
-         [Fact]
+        [Fact]
         public async Task LogRequest_SinksToApplicationInsightsWithCorrelation_ResultsInRequestTelemetry()
         {
             // Arrange

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestDataLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestDataLoggingTests.cs
@@ -1,0 +1,413 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
+using Bogus;
+#if NET6_0
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http; 
+#endif
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
+{
+#if NET6_0
+    public class HttpRequestDataDataLoggingTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_ValidArgumentsIncludingResponse_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogRequest(stubRequest, statusCode, measurement, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.StartsWith(scheme, entry.RequestHost);
+            Assert.EndsWith(host, entry.RequestHost);
+            Assert.Equal(path, entry.RequestUri);
+            Assert.Equal($"{method} {path}", entry.OperationName);
+            Assert.Equal((int) statusCode, entry.ResponseStatusCode);
+            Assert.Equal(measurement.Elapsed, entry.RequestDuration);
+            Assert.Equal(measurement.StartTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(value, Assert.Contains(key, entry.Context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithoutRequest_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (int)BogusGenerator.PickRandom<HttpStatusCode>();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, statusCode, measurement));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, measurement: null));
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, 0)]
+        [InlineData(999, int.MaxValue)]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithInvalidStatusCode_Fails(int min, int max)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (HttpStatusCode) BogusGenerator.Random.Int(min, max);
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, measurement));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithValidArgumentsWithResponse_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogRequest(stubRequest, statusCode, startTime, duration, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.StartsWith(scheme, entry.RequestHost);
+            Assert.EndsWith(host, entry.RequestHost);
+            Assert.Equal(path, entry.RequestUri);
+            Assert.Equal($"{method} {path}", entry.OperationName);
+            Assert.Equal(duration, entry.RequestDuration);
+            Assert.Equal((int) statusCode, entry.ResponseStatusCode);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(value, Assert.Contains(key, entry.Context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithoutRequest_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestData) null, statusCode, startTime, duration, context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, startTime, duration, context));
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, 0)]
+        [InlineData(999, int.MaxValue)]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithInvalidStatusCode_Fails(int min, int max)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (HttpStatusCode) BogusGenerator.Random.Int(min, max);
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, startTime, duration, context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithOperationNameValidArgumentsIncludingResponse_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            string operationName = BogusGenerator.Lorem.Word();
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogRequest(stubRequest, statusCode, operationName, measurement, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.StartsWith(scheme, entry.RequestHost);
+            Assert.EndsWith(host, entry.RequestHost);
+            Assert.Equal(path, entry.RequestUri);
+            Assert.Equal(operationName, entry.OperationName);
+            Assert.Equal(measurement.Elapsed, entry.RequestDuration);
+            Assert.Equal(measurement.StartTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(value, Assert.Contains(key, entry.Context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithOperationNameWithoutRequest_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (int)BogusGenerator.PickRandom<HttpStatusCode>();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            string operationName = BogusGenerator.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, statusCode, operationName, measurement));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithOperationNameWithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            string operationName = BogusGenerator.Lorem.Word();
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, operationName, measurement: null));
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, 0)]
+        [InlineData(999, int.MaxValue)]
+        public void LogRequestWithStatusCodeWithDurationMeasurement_WithOperationNameWithInvalidStatusCode_Fails(int min, int max)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = (HttpStatusCode) BogusGenerator.Random.Int(min, max);
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+
+            string operationName = BogusGenerator.Lorem.Word();
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, operationName, measurement));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithOperationNameWithValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            string operationName = BogusGenerator.Lorem.Word();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogRequest(stubRequest, statusCode, operationName, startTime, duration, context);
+
+            // Assert
+            RequestLogEntry entry = logger.GetMessageAsRequest();
+            Assert.StartsWith(scheme, entry.RequestHost);
+            Assert.EndsWith(host, entry.RequestHost);
+            Assert.Equal(path, entry.RequestUri);
+            Assert.Equal(operationName, entry.OperationName);
+            Assert.Equal(duration, entry.RequestDuration);
+            Assert.Equal((int) statusCode, entry.ResponseStatusCode);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), entry.RequestTime);
+            Assert.Equal(value, Assert.Contains(key, entry.Context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithOperationNameWithoutRequest_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            string operationName = BogusGenerator.Lorem.Word();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestData) null, statusCode, operationName, startTime, duration, context));
+        }
+
+        [Theory]
+        [InlineData(int.MinValue, 0)]
+        [InlineData(999, int.MaxValue)]
+        public void LogRequestWithStatusCodeWithDurationStartTime_WithOperationNameWithInvalidStatusCode_Fails(int min, int max)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            HttpMethod method = HttpMethod.Post;
+            string operationName = BogusGenerator.Lorem.Word();
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            var statusCode = (HttpStatusCode) BogusGenerator.Random.Int(min, max);
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, operationName, startTime, duration, context));
+        }
+
+        [Fact]
+        public void LogRequestWithStatusCodeDurationStartTime_WithOperationNameWithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var statusCode = BogusGenerator.PickRandom<HttpStatusCode>();
+            var path = $"/{BogusGenerator.Lorem.Word()}";
+            string host = BogusGenerator.Lorem.Word();
+            var scheme = "https";
+            string operationName = BogusGenerator.Lorem.Word();
+            HttpMethod method = HttpMethod.Post;
+
+            HttpRequestData stubRequest = CreateStubRequest(method, host, path, scheme);
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(stubRequest, statusCode, operationName, startTime, duration, context));
+        }
+
+        private static HttpRequestData CreateStubRequest(HttpMethod method, string host, string path, string scheme)
+        {
+            var context = Mock.Of<FunctionContext>();
+
+            var stub = new Mock<HttpRequestData>(context);
+            stub.Setup(s => s.Method).Returns(method.Method);
+            stub.Setup(s => s.Url).Returns(new Uri(scheme + "://" + host + path));
+
+            return stub.Object;
+        }
+    }
+#endif
+}

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
@@ -1158,7 +1158,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             measurement.Dispose();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, statusCode, measurement));
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestMessage) null, statusCode, measurement));
         }
 
         [Fact]
@@ -1220,7 +1220,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, responseStatusCode: statusCode, startTime: startTime, duration: duration));
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestMessage) null, responseStatusCode: statusCode, startTime: startTime, duration: duration));
         }
 
         [Fact]
@@ -1287,7 +1287,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             measurement.Dispose();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, statusCode, operationName, measurement));
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestMessage) null, statusCode, operationName, measurement));
         }
 
         [Fact]
@@ -1352,7 +1352,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: null, responseStatusCode: statusCode, operationName: operationName, startTime: startTime, duration: duration));
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request: (HttpRequestMessage) null, responseStatusCode: statusCode, operationName: operationName, startTime: startTime, duration: duration));
         }
 
         [Fact]

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
@@ -18,7 +18,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         {
             // Arrange
             var logger = new TestLogger();
-            string metricName = _bogusGenerator.Name.FullName();
+            string metricName = _bogusGenerator.Lorem.Word();
             double metricValue = _bogusGenerator.Random.Double();
 
             // Act
@@ -40,7 +40,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         {
             // Arrange
             var logger = new TestLogger();
-            string metricName = _bogusGenerator.Name.FullName();
+            string metricName = _bogusGenerator.Lorem.Word();
             double metricValue = _bogusGenerator.Random.Double();
 
             // Act

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
@@ -22,7 +22,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             double metricValue = _bogusGenerator.Random.Double();
 
             // Act
-            logger.LogMetric(metricName, metricValue);
+            logger.LogMetric(metricName, metricValue, context: null);
 
             // Assert
             MetricLogEntry metric = logger.GetMessageAsMetric();
@@ -182,7 +182,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             double metricValue = _bogusGenerator.Random.Double();
 
             // Act & Arrange
-            Assert.Throws<ArgumentException>(() => logger.LogMetric(metricName, metricValue));
+            Assert.Throws<ArgumentException>(() => logger.LogMetric(metricName, metricValue, context: null));
         }
 
         [Fact]


### PR DESCRIPTION
Adds HTTP request tracking for isolated Azure Functions HTTP trigger's `HttpRequestData`.

Closes #443