### PR TITLE
docs: use new sql dependency approach

### DIFF
--- a/docs/preview/03-Features/writing-different-telemetry-types.md
+++ b/docs/preview/03-Features/writing-different-telemetry-types.md
@@ -257,8 +257,8 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-logger.LogSqlDependency("sample-server", "sample-database", "my-table", "get-products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: {"DependencyType": "Sql", "DependencyName": "sample-database/my-table", "DependencyData": "get-products", "TargetName": "sample-server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
+logger.LogSqlDependency("Company SQL server", "Stock Database", "SELECT ProductName FROM Products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database", "DependencyData": "SELECT ProductName FROM Products", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
@@ -276,7 +276,7 @@ PM > Install-Package Arcus.Observability.Telemetry.Sql
 ```csharp
 using Microsoft.Extensions.Logging;
 
-string connectionString = "Server=sample-server;Database=sample-database;User=admin;Password=123";
+string connectionString = "Server=Company SQL Server;Database=Stock Database;User=admin;Password=123";
 var durationMeasurement = new Stopwatch();
 
 // Start measuring
@@ -286,8 +286,8 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-logger.LogSqlDependency(connectionString, "my-table", "get-products", isSuccessful: true, measurement: measurement);
-// Output: {"DependencyType": "Sql", "DependencyName": "sample-database/my-table", "DependencyData": "get-products", "TargetName": "sample-server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
+logger.LogSqlDependency(connectionString, "SELECT ProductName FROM Products", isSuccessful: true, startTime, durationMeasurement.Elapsed);
+// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database", "DependencyData": "SELECT ProductName FROM Proucts", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring custom dependencies


### PR DESCRIPTION
Use new overload for SQL dependency tracking that uses a pseudo SQL command instead of a fixed SQL table in the feature documentation page.

Closes #423