### PR TITLE
(❗) fix: null-check on scalar value

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -214,7 +214,7 @@ namespace Serilog.Events
 
             if (logEventPropertyValue is ScalarValue scalar)
             {
-                var result = scalar.Value.ToString();
+                var result = scalar.Value?.ToString();
                 return result;
             }
             else

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/GeneralLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/GeneralLoggingTests.cs
@@ -62,6 +62,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         }
 
         [Fact]
+        public void LogInformation_WithNullScalarValue_FailSafe()
+        {
+            // Arrange
+            var message = "This is a log message!";
+            string key = BogusGenerator.Commerce.Product();
+            var context = new Dictionary<string, object> { [key] = null };
+            
+            // ACt
+            _logger.LogInformation(message, context);
+
+            // Assert
+            LogEvent logEvent = Assert.Single(_spySink.CurrentLogEmits);
+            Assert.Equal(LogEventLevel.Information, logEvent.Level);
+            Assert.Equal(message, logEvent.RenderMessage());
+            Assert.Null(Assert.Contains(key, logEvent.Properties).ToDecentString());
+        }
+
+        [Fact]
         public void LogInformationWithoutArgs_NotActivated_Ignores()
         {
             // Arrange


### PR DESCRIPTION
Reason why the Azure Functions didn't always tracked the request, was that the operation parent ID was `null` in the initial call and this `null` wasn't checked when parsing the Serilog values to typed variants.