### PR TITLE
(❗) fix: add operation name to sql dependency tracking

### DIFF
--- a/docs/preview/03-Features/writing-different-telemetry-types.md
+++ b/docs/preview/03-Features/writing-different-telemetry-types.md
@@ -257,8 +257,8 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-logger.LogSqlDependency("Company SQL server", "Stock Database", "SELECT ProductName FROM Products", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
-// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database", "DependencyData": "SELECT ProductName FROM Products", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
+logger.LogSqlDependency("Company SQL Server", "Stock Database", "GET ProductName FROM Products", "Get product names", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database/Get product names", "DependencyData": "GET ProductName FROM Products", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 Or alternatively, when one already got the SQL connection string, you can use the overload that takes this directly:
@@ -286,8 +286,8 @@ durationMeasurement.Start();
 // Interact with database
 var products = await _repository.GetProducts();
 
-logger.LogSqlDependency(connectionString, "SELECT ProductName FROM Products", isSuccessful: true, startTime, durationMeasurement.Elapsed);
-// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database", "DependencyData": "SELECT ProductName FROM Proucts", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
+logger.LogSqlDependency(connectionString, "GET ProductName FROM Products", "Get product names", isSuccessful: true, measurement: measurement);
+// Output: {"DependencyType": "Sql", "DependencyName": "Stock Database/Get product names", "DependencyData": "GET ProductName FROM Products", "TargetName": "Company SQL Server", "Duration": "00:00:01.2396312", "StartTime": "03/23/2020 09:32:02 +00:00", "IsSuccessful": true, "Context": {}}
 ```
 
 ### Measuring custom dependencies

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, <paramref name="tableName"/>, or <paramref name="operationName"/> is blank.
         /// </exception>
-        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -92,6 +92,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -122,6 +123,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -157,7 +159,7 @@ namespace Microsoft.Extensions.Logging
         ///     Thrown when the <paramref name="serverName"/>, <paramref name="databaseName"/>, <paramref name="tableName"/>, or <paramref name="operationName"/> is blank.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
-        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -206,6 +208,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -241,6 +244,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string serverName,
@@ -263,6 +267,89 @@ namespace Microsoft.Extensions.Logging
                 dependencyType: "Sql",
                 targetName: serverName,
                 dependencyName: databaseName,
+                dependencyData: sqlCommand,
+                duration: duration,
+                startTime: startTime,
+                dependencyId: dependencyId,
+                resultCode: null,
+                isSuccessful: isSuccessful,
+                context: context));
+        }
+
+        /// <summary>
+        /// Logs a SQL dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="serverName">The name of server hosting the database.</param>
+        /// <param name="databaseName">The name of database.</param>
+        /// <param name="sqlCommand">The pseudo SQL command information that gets executed against the SQL dependency.</param>
+        /// <param name="operationName">The functional description of the operation that was performed on the SQL database.</param>	
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measuring the latency to call the SQL dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger,
+            string serverName,
+            string databaseName,
+            string sqlCommand,
+            string operationName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
+
+            context = context ?? new Dictionary<string, object>();
+
+            LogSqlDependency(logger, serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs a SQL dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the telemetry.</param>
+        /// <param name="serverName">The name of server hosting the database.</param>
+        /// <param name="databaseName">The name of database.</param>
+        /// <param name="sqlCommand">The pseudo SQL command information that gets executed against the SQL dependency.</param>
+        /// <param name="operationName">The functional description of the operation that was performed on the SQL database.</param>	
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="startTime">The point in time when the interaction with the SQL dependency was started.</param>
+        /// <param name="duration">The duration of the operation.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="serverName"/> or <paramref name="databaseName"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger,
+            string serverName,
+            string databaseName,
+            string sqlCommand,
+            string operationName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
+            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
+            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the SQL dependency operation");
+
+            context = context ?? new Dictionary<string, object>();
+
+            logger.LogWarning(MessageFormats.SqlDependencyFormat, new DependencyLogEntry(
+                dependencyType: "Sql",
+                targetName: serverName,
+                dependencyName: databaseName + "/" + operationName,
                 dependencyData: sqlCommand,
                 duration: duration,
                 startTime: startTime,

--- a/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Sql/Extensions/ILoggerExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="tableName"/> or <paramref name="operationName"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -107,6 +108,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or the <paramref name="measurement"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -136,7 +138,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="tableName"/> or <paramref name="operationName"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command instead of specifying the table and operation name")]
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead of specifying the table name")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -167,6 +169,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -196,6 +199,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(LogSqlDependency) + " with a pseudo SQL command and operation name instead")]
         public static void LogSqlDependency(
             this ILogger logger,
             string connectionString,
@@ -210,7 +214,69 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
 
             var connection = new SqlConnectionStringBuilder(connectionString);
-            logger.LogSqlDependency(connection.DataSource, connection.InitialCatalog, sqlCommand, isSuccessful, startTime, duration, dependencyId, context);
+            logger.LogSqlDependency(connection.DataSource, connection.InitialCatalog, sqlCommand: sqlCommand, isSuccessful, startTime, duration, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs a SQL dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the SQL dependency.</param>
+        /// <param name="connectionString">The SQL connection string.</param>
+        /// <param name="sqlCommand">The pseudo SQL command information that gets executed against the SQL dependency.</param>
+        /// <param name="operationName">The functional description of the operation that was performed on the SQL database.</param>	
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measuring the latency to call the SQL dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger,
+            string connectionString,
+            string sqlCommand,
+            string operationName,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
+
+            LogSqlDependency(logger, connectionString, sqlCommand, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs a SQL dependency.
+        /// </summary>
+        /// <param name="logger">The logger to track the SQL dependency.</param>
+        /// <param name="connectionString">The SQL connection string.</param>
+        /// <param name="sqlCommand">The pseudo SQL command information that gets executed against the SQL dependency.</param>
+        /// <param name="operationName">The functional description of the operation that was performed on the SQL database.</param>	
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="startTime">The point in time when the interaction with the HTTP dependency was started</param>
+        /// <param name="duration">The duration of the operation</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static void LogSqlDependency(
+            this ILogger logger,
+            string connectionString,
+            string sqlCommand,
+            string operationName,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
+
+            var connection = new SqlConnectionStringBuilder(connectionString);
+            logger.LogSqlDependency(connection.DataSource, connection.InitialCatalog, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/SqlDependencyTests.cs
@@ -21,7 +21,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string dependencyType = "SQL";
             string serverName = BogusGenerator.Database.Engine();
             string databaseName = BogusGenerator.Database.Collation();
-            string sqlCommand = $"SELECT {BogusGenerator.Database.Column()} FROM Some_Table";
+            string column = BogusGenerator.Database.Column();
+            string sqlCommand = $"SELECT {column} FROM Some_Table";
+            string operationName = $"Get all {column}";
             string dependencyId = BogusGenerator.Random.Guid().ToString();
 
             bool isSuccessful = BogusGenerator.PickRandom(true, false);
@@ -30,7 +32,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
             // Act
-            Logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, startTime, duration, dependencyId, telemetryContext);
+            Logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, telemetryContext);
 
             // Assert
             await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
@@ -40,7 +42,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 {
                     Assert.Equal(dependencyType, result.Dependency.Type);
                     Assert.Equal(serverName, result.Dependency.Target);
-                    Assert.Equal($"{dependencyType}: {databaseName}", result.Dependency.Name);
+                    Assert.Contains($"{dependencyType}: {databaseName}", result.Dependency.Name);
+                    Assert.Contains(operationName, result.Dependency.Name);
                     Assert.Equal(dependencyId, result.Dependency.Id);
                 });
             });
@@ -54,7 +57,9 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             string serverName = BogusGenerator.Database.Engine();
             string databaseName = BogusGenerator.Database.Collation();
             var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
-            string sqlCommand = $"SELECT {BogusGenerator.Database.Column()} FROM Some_Table";
+            string column = BogusGenerator.Database.Column();
+            string sqlCommand = $"SELECT {column} FROM Some_Table";
+            string operationName = $"Get all {column}";
             string dependencyId = BogusGenerator.Random.Guid().ToString();
 
             bool isSuccessful = BogusGenerator.PickRandom(true, false);
@@ -63,7 +68,7 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
             Dictionary<string, object> telemetryContext = CreateTestTelemetryContext();
 
             // Act
-            Logger.LogSqlDependency(connectionString, sqlCommand, isSuccessful, startTime, duration, dependencyId, telemetryContext);
+            Logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, telemetryContext);
 
             // Assert
             await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
@@ -73,7 +78,8 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
                 {
                     Assert.Equal(dependencyType, result.Dependency.Type);
                     Assert.Equal(serverName, result.Dependency.Target);
-                    Assert.Equal($"{dependencyType}: {databaseName}", result.Dependency.Name);
+                    Assert.Contains($"{dependencyType}: {databaseName}", result.Dependency.Name);
+                    Assert.Contains(operationName, result.Dependency.Name);
                     Assert.Equal(dependencyId, result.Dependency.Id);
                 });
             });

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
@@ -73,6 +73,39 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         }
 
         [Fact]
+        public void LogSqlDependencyWithSqlCommandAndOperationName_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Lorem.Word();
+            string databaseName = BogusGenerator.Lorem.Word();
+            string sqlCommand = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            string dependencyId = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            DateTimeOffset startTime = BogusGenerator.Date.PastOffset();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(serverName, dependency.TargetName);
+            Assert.Contains(databaseName, dependency.DependencyName);
+            Assert.Contains(operationName, dependency.DependencyName);
+            Assert.Equal(sqlCommand, dependency.DependencyData);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(value, Assert.Contains(key, dependency.Context));
+            Assert.Equal(dependencyId, dependency.DependencyId);
+        }
+
+        [Fact]
         public void LogSqlDependencyWithSqlCommandWithDependencyId_ValidArguments_Succeeds()
         {
             // Arrange
@@ -89,7 +122,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var context = new Dictionary<string, object> { [key] = value };
 
             // Act
-            logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, startTime, duration, dependencyId, context);
+            logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, startTime, duration, dependencyId, context);
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
@@ -118,6 +151,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, tableName, operationName, isSuccessful, startTime, duration));
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithSqlCommandAndOperationName_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            DateTimeOffset startTime = BogusGenerator.Date.PastOffset();
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId));
         }
 
         [Fact]
@@ -238,7 +289,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var context = new Dictionary<string, object> { [key] = value };
 
             // Act
-            logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, measurement, dependencyId, context);
+            logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, measurement, dependencyId, context);
 
             // Assert
             DependencyLogEntry dependency = logger.GetMessageAsDependency();
@@ -305,7 +356,27 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, measurement, dependencyId));
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, measurement, dependencyId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogSqlDependencyWithSqlCommandAndOperationNameWithDurationMeasurement_WithoutServerName_Fails(string serverName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement, dependencyId));
         }
 
         [Theory]
@@ -361,7 +432,27 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, measurement, dependencyId));
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, measurement, dependencyId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogSqlDependencyWithSqlCommandAndOperationNameWithDurationMeasurementWithDependencyId_WithoutDatabaseName_Fails(string databaseName)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement, dependencyId));
         }
 
         [Theory]
@@ -446,7 +537,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, measurement: null, dependencyId));
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, measurement: null, dependencyId));
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithSqlCommandAndOperationNameWithDurationMeasurementWithDependencyId_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement: null, dependencyId));
         }
 
         [Fact]
@@ -581,6 +689,45 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(value, Assert.Contains(key, dependency.Context));
         }
 
+        [Fact]
+        public void LogSqlDependencyConnectionStringWithSqlCommandAndOperationNameWithDurationMeasurementWithDependencyId_ValidArguments_Succeeds()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Lorem.Word();
+            string databaseName = BogusGenerator.Lorem.Word();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string sqlCommand = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            string dependencyId = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            DateTimeOffset startTime = measurement.StartTime;
+            measurement.Dispose();
+            TimeSpan duration = measurement.Elapsed;
+
+            string key = BogusGenerator.Lorem.Word();
+            string value = BogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object> { [key] = value };
+
+            // Act
+            logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, measurement, dependencyId, context);
+
+            // Assert
+            DependencyLogEntry dependency = logger.GetMessageAsDependency();
+            Assert.Equal(serverName, dependency.TargetName);
+            Assert.Contains(databaseName, dependency.DependencyName);
+            Assert.Contains(operationName, dependency.DependencyName);
+            Assert.Equal(sqlCommand, dependency.DependencyData);
+            Assert.Equal(dependencyId, dependency.DependencyId);
+            Assert.Equal(startTime.ToString(FormatSpecifiers.InvariantTimestampFormat), dependency.StartTime);
+            Assert.Equal(duration, dependency.Duration);
+            Assert.Equal(isSuccessful, dependency.IsSuccessful);
+            Assert.Equal(value, Assert.Contains(key, dependency.Context));
+        }
+
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogSqlDependencyConnectionStringWithDurationMeasurement_WithoutConnectionString_Fails(string connectionString)
@@ -632,6 +779,25 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogSqlDependency(connectionString, sqlCommand, isSuccessful, measurement, dependencyId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void LogSqlDependencyConnectionStringWithSqlCommandAndOperationNameWithDurationMeasurementWithDependencyId_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, measurement, dependencyId));
         }
 
         [Theory]
@@ -725,6 +891,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
         }
 
         [Fact]
+        public void LogSqlDependencyConnectionStringWithSqlCommandAndOperationNameWithDurationMeasurementWithDependencyId_WithoutMeasurement_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, measurement: null, dependencyId));
+        }
+
+        [Fact]
         public void LogSqlDependencyConnectionString_WithNegativeDuration_Fails()
         {
             // Arrange
@@ -777,6 +961,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(connectionString, sqlCommand, isSuccessful, startTime, duration, dependenyId));
         }
 
+        [Fact]
+        public void LogSqlDependencyConnectionStringWithSqlCommandAndOperationNameWithDependencyId_WithNegativeDuration_Fails()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            DateTimeOffset startTime = BogusGenerator.Date.PastOffset();
+            TimeSpan duration = TimeSpanGenerator.GeneratePositiveDuration().Negate();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId));
+        }
+
+        
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogSqlDependencyConnectionString_EmptyConnectionString_Fails(string connectionString)
@@ -859,7 +1063,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var duration = BogusGenerator.Date.Timespan();
 
             // Act & Arrange
-            Assert.Throws<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, startTime, duration, dependencyId));
+            Assert.Throws<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, startTime, duration, dependencyId));
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithSqlCommandAndOperationNameWithDependencyId_NoServerNameWasSpecified_ThrowsException()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = null;
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            DateTimeOffset startTime = BogusGenerator.Date.PastOffset();
+            var duration = BogusGenerator.Date.Timespan();
+
+            // Act & Arrange
+            Assert.Throws<ArgumentException>(
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId));
         }
 
         [Fact]
@@ -909,7 +1132,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var duration = BogusGenerator.Date.Timespan();
 
             // Act & Arrange
-            Assert.Throws<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, sqlCommand, isSuccessful, startTime, duration, dependencyId));
+            Assert.Throws<ArgumentException>(() => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, isSuccessful, startTime, duration, dependencyId));
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithSqlCommandAndOperationNameWithDependencyId_NoDatabaseNameWasSpecified_ThrowsException()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = null;
+            string sqlCommand = BogusGenerator.Name.FullName();
+            string operationName = BogusGenerator.Name.FullName();
+            string dependencyId = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            DateTimeOffset startTime = BogusGenerator.Date.PastOffset();
+            var duration = BogusGenerator.Date.Timespan();
+
+            // Act & Arrange
+            Assert.Throws<ArgumentException>(
+                () => logger.LogSqlDependency(serverName, databaseName, sqlCommand: sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId));
         }
 
         [Fact]

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
@@ -727,7 +727,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Equal(value, Assert.Contains(key, dependency.Context));
         }
 
-
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogSqlDependencyConnectionStringWithDurationMeasurement_WithoutConnectionString_Fails(string connectionString)
@@ -980,7 +979,6 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(() => logger.LogSqlDependency(connectionString, sqlCommand: sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId));
         }
 
-        
         [Theory]
         [ClassData(typeof(Blanks))]
         public void LogSqlDependencyConnectionString_EmptyConnectionString_Fails(string connectionString)


### PR DESCRIPTION
Make the dependency name unique by adding a functional description of the operation.

Closes #419