### PR TITLE
(❗) chore: update w/o invalid operation exception throwal

### DIFF
--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
@@ -54,15 +54,11 @@ namespace Microsoft.Extensions.Logging
             ServiceDescriptor descriptor = 
                 builder.Services.FirstOrDefault(service => service.ImplementationType?.Name == "ApplicationInsightsLoggerProvider");
             
-            if (descriptor is null)
+            if (descriptor != null)
             {
-                throw new InvalidOperationException(
-                    "Cannot find the type 'ApplicationInsightsLoggerProvider' in the registered logging providers " 
-                    + "so can't guarantee a correct Arcus implementation that sinks telemetry to Microsoft Application Insights , "
-                    + "please remove this logger provider before sending telemetry via the Arcus Application Insights logging");
+                builder.Services.Remove(descriptor);
             }
 
-            builder.Services.Remove(descriptor);
             return builder;
         }
     }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/AzureFunctions/ILoggerBuilderExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/AzureFunctions/ILoggerBuilderExtensionsTests.cs
@@ -53,8 +53,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.AzureFunctions
             var services = new ServiceCollection();
             
             // Act / Assert
-            Assert.ThrowsAny<InvalidOperationException>(() =>
-                services.AddLogging(logging => logging.RemoveMicrosoftApplicationInsightsLoggerProvider()));
+            services.AddLogging(logging => logging.RemoveMicrosoftApplicationInsightsLoggerProvider());
         }
     }
 }


### PR DESCRIPTION
The newest Azure Functions SDK doesn't have this logger provider anymore in the default registered logger providers, so we should remove the invalid operation throwal.

Closes #441