### PR TITLE
feat: add re-usable application name

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
+++ b/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core
+{
+    /// <summary>
+    /// Default <see cref="IAppName"/> implementation that uses a static name to set as application name.
+    /// </summary>
+    public class DefaultAppName : IAppName
+    {
+        private readonly string _componentName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultAppName" /> class.
+        /// </summary>
+        /// <param name="componentName">The functional name to identity the application.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="componentName"/> is blank.</exception>
+        public DefaultAppName(string componentName)
+        {
+            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank functional name to identity the application");
+            _componentName = componentName;
+        }
+
+        /// <summary>
+        /// Represents a way to retrieve the name of an application during the enrichment.
+        /// </summary>
+        public string GetApplicationName()
+        {
+            return _componentName;
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/IAppName.cs
+++ b/src/Arcus.Observability.Telemetry.Core/IAppName.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Observability.Telemetry.Core
+{
+    /// <summary>
+    /// Represents a way to retrieve the name of an application during the enrichment.
+    /// </summary>
+    public interface IAppName
+    {
+        /// <summary>
+        /// Represents a way to retrieve the name of an application during the enrichment.
+        /// </summary>
+        string GetApplicationName();
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationTelemetryInitializer.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationTelemetryInitializer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
+{
+    /// <summary>
+    /// Represents an <see cref="ITelemetryInitializer"/> that configures the application information.
+    /// </summary>
+    public class ApplicationTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly IAppName _applicationName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationTelemetryInitializer" /> class.
+        /// </summary>
+        /// <param name="applicationName">The instance to retrieve the application name.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationName"/> is <c>null</c>.</exception>
+        public ApplicationTelemetryInitializer(IAppName applicationName)
+        {
+            Guard.NotNull(applicationName, nameof(applicationName), $"Requires an application name ({nameof(IAppName)}) implementation to retrieve the application name to initialize in the telemetry");
+            _applicationName = applicationName;
+        }
+
+        /// <summary>
+        /// Initializes properties of the specified <see cref="T:Microsoft.ApplicationInsights.Channel.ITelemetry" /> object.
+        /// </summary>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry?.Context?.Cloud != null)
+            {
+                string componentName = _applicationName.GetApplicationName();
+                telemetry.Context.Cloud.RoleName = componentName; 
+            }
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
+using GuardNet;
+using Microsoft.ApplicationInsights.Extensibility;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> related to Application Insights.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+         /// <summary>
+        /// Adds an <see cref="IAppName"/> implementation to the application which can be used to retrieve the current application's name.
+        /// </summary>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppName"/> implementation to.</param>
+        /// <param name="componentName">The functional name to identity the application.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="componentName"/> is blank.</exception>
+        public static IServiceCollection AddAppName(
+            this IServiceCollection services,
+            string componentName)
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
+            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank functional name to identity the application");
+
+            return AddAppName(services, provider => new DefaultAppName(componentName));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAppName"/> implementation to the application which can be used to retrieve the current application's name.
+        /// </summary>
+        /// <param name="services">The collection of registered services to add the <see cref="IAppName"/> implementation to.</param>
+        /// <param name="implementationFactory">The factory function to create the <see cref="IAppName"/> implementation.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddAppName(
+            this IServiceCollection services,
+            Func<IServiceProvider, IAppName> implementationFactory)
+        {
+            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), $"Requires a factory function to create the '{nameof(IAppName)}' implementation");
+
+            return services.AddSingleton(implementationFactory)
+                           .AddSingleton<ITelemetryInitializer, ApplicationTelemetryInitializer>();
+        }
+    }
+}


### PR DESCRIPTION
Extract application/component name so that both Arcus and Microsoft functionality can benefit from this.

Closes https://github.com/arcus-azure/arcus.observability/issues/470