### PR TITLE
feat: assign telemetry client in serilog sink

### DIFF
--- a/docs/preview/03-Features/sinks/azure-application-insights.md
+++ b/docs/preview/03-Features/sinks/azure-application-insights.md
@@ -38,7 +38,7 @@ ILogger logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-> ⚡ When you want to initialize Microsoft's `TelemetryClient` directly from the sink, you can pass in the `IServiceProvider` so that the sink registration re-uses your registered `TelemetryClient`.
+> ⚡ When you want to re-use an already registered `TelemetryClient`, pass in the `IServiceProvider` to the method that registers the Application Insights sink. `TelemetryClient`s are automatically registered behind the scenes when using W3C correlation in Arcus Web API middleware (>= v1.7) or Arcus Messaging (>= v1.4).
 
 ```csharp
 using Serilog;

--- a/docs/preview/03-Features/sinks/azure-application-insights.md
+++ b/docs/preview/03-Features/sinks/azure-application-insights.md
@@ -38,6 +38,18 @@ ILogger logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+> ⚡ When you want to initialize Microsoft's `TelemetryClient` directly from the sink, you can pass in the `IServiceProvider` so that the sink registration re-uses your registered `TelemetryClient`.
+
+```csharp
+using Serilog;
+using Serilog.Configuration;
+
+ILogger logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .WriteTo.AzureApplicationInsightsWithConnectionString(serviceProvider, "<connection-string>", restrictedToMinimumLevel: LogEventLevel.Warning)
+    .CreateLogger();
+```
+
 For more information on this sink: [see this section](#azure-application-insights-sink).
 
 ## Installation
@@ -208,7 +220,7 @@ string connectionString = await secretProvider.GetRawSecretAsync("APPLICATIONINS
 var reloadLogger = (ReloadableLogger) Log.Logger;
 reloadLogger.Reload(config =>
 {
-    return config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString);
+    return config.WriteTo.AzureApplicationInsightsWithConnectionString(host.Services, connectionString);
 });
 
 // Start application.

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
 using GuardNet;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog.Events;
 
 // ReSharper disable once CheckNamespace
@@ -208,6 +209,117 @@ namespace Serilog.Configuration
         ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
         /// </remarks>
         /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithInstrumentationKey(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string instrumentationKey)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithInstrumentationKey(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string instrumentationKey,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose, configureOptions);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithInstrumentationKey(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string instrumentationKey,
+            LogEventLevel restrictedToMinimumLevel)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="instrumentationKey">The required Application Insights key.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="instrumentationKey"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithInstrumentationKey(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string instrumentationKey,
+            LogEventLevel restrictedToMinimumLevel,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            var options = new ApplicationInsightsSinkOptions();
+            configureOptions?.Invoke(options);
+
+            return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, "InstrumentationKey=" + instrumentationKey, restrictedToMinimumLevel, configureOptions);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
         /// <param name="connectionString">The required Application Insights connection string.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
@@ -290,6 +402,128 @@ namespace Serilog.Configuration
             configureOptions?.Invoke(options);
 
             var client = new TelemetryClient(TelemetryConfiguration.CreateDefault());
+            client.TelemetryConfiguration.ConnectionString = connectionString;
+
+            return loggerSinkConfiguration.ApplicationInsights(client, ApplicationInsightsTelemetryConverter.Create(options), restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="connectionString">The required Application Insights connection string.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithConnectionString(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string connectionString)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, configureOptions: null);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="connectionString">The required Application Insights connection string.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithConnectionString(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string connectionString,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, LogEventLevel.Verbose, configureOptions);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="connectionString">The required Application Insights connection string.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithConnectionString(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string connectionString,
+            LogEventLevel restrictedToMinimumLevel)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, restrictedToMinimumLevel, configureOptions: null);
+        }
+
+        /// <summary>
+        ///     Adds a Serilog sink that writes <see cref="T:Serilog.Events.LogEvent">log events</see> to Azure Application Insights.
+        /// </summary>
+        /// <remarks>
+        ///     Supported telemetry types are Traces, Dependencies, Events, Requests and Metrics for which we provide extensions on <see cref="ILogger" />.
+        /// </remarks>
+        /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+        /// <param name="serviceProvider">
+        ///     The provider instance to retrieve the <see cref="TelemetryClient"/> in the application services.
+        ///     Note that this is only required when the application requires W3C correlation.
+        /// </param>
+        /// <param name="connectionString">The required Application Insights connection string.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="configureOptions">The optional function to configure additional options to influence the behavior of how the telemetry is logged to Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="loggerSinkConfiguration"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public static LoggerConfiguration AzureApplicationInsightsWithConnectionString(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            IServiceProvider serviceProvider,
+            string connectionString,
+            LogEventLevel restrictedToMinimumLevel,
+            Action<ApplicationInsightsSinkOptions> configureOptions)
+        {
+            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+
+            var options = new ApplicationInsightsSinkOptions();
+            configureOptions?.Invoke(options);
+
+            var client = serviceProvider.GetService<TelemetryClient>();
+            if (client is null)
+            {
+                throw new InvalidOperationException(
+                    "Could not retrieve Microsoft telemetry client from the application registered services, this happens when the Application Insights services are not registered in the application services," 
+                    + "please use one of Arcus' extensions like 'services.AddHttpCorrelation()' to automatically register the Application Insights when using the W3C correlation system, "
+                    + $"when using the Hierarchical correlation system, use the {nameof(AzureApplicationInsightsWithConnectionString)} extension without the service provider instead");
+            }
+
             client.TelemetryConfiguration.ConnectionString = connectionString;
 
             return loggerSinkConfiguration.ApplicationInsights(client, ApplicationInsightsTelemetryConverter.Create(options), restrictedToMinimumLevel);

--- a/src/Arcus.Observability.Tests.Runtimes.AzureFunction/Arcus.Observability.Tests.Runtimes.AzureFunction.csproj
+++ b/src/Arcus.Observability.Tests.Runtimes.AzureFunction/Arcus.Observability.Tests.Runtimes.AzureFunction.csproj
@@ -6,6 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Bogus;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -8,6 +10,116 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
 {
     public class LoggerConfigurationExtensionsTests
     {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void AzureApplicationInsightsWithInstrumentationKey_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(provider, "<key>"));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithInstrumentationKeyWithLogLevel_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(provider, "<key>", level));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithInstrumentationKeyWithOptions_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(provider, "<key>", options => { }));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithInstrumentationKeyWithLevelAndOptions_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(provider, "<key>", level, options => { }));
+        }
+
+         [Fact]
+        public void AzureApplicationInsightsWithConnectionString_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(provider, "<connection-string>"));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithConnectionStringWithLogLevel_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(provider, "<connection-string>", level));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithConnectionStringWithOptions_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(provider, "<connection-striong>", options => { }));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsWithConnectionStringWithLevelAndOptions_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(provider, "<connection-string>", level, options => { }));
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AzureApplicationInsights_WithoutInstrumentationKey_Fails(string instrumentationKey)


### PR DESCRIPTION
Assign the connection string to the previously registered Microsoft `TelemetryClient` right from the Azure Application Insights Serilog sink.

Closes #471