### PR TITLE
feat: add 'AddSerilog' extension overload with 'IServiceProvider'

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Extensions on the <see cref="ILoggingBuilder"/>
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class ILoggingBuilderExtensions
+    {
+        /// <summary>
+        /// Add Serilog to the logging pipeline.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder" /> to add logging provider to.</param>
+        /// <param name="implementationFactory">The factory function to create an Serilog logger implementation.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        public static ILoggingBuilder AddSerilog(
+            this ILoggingBuilder builder,
+            Func<IServiceProvider, Serilog.ILogger> implementationFactory)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires an implementation factory to built up the Serilog logger");
+
+            builder.Services.AddSingleton<ILoggerProvider>(provider =>
+            {
+                return new SerilogLoggerProvider(implementationFactory(provider), dispose: true);
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Logging
             Func<IServiceProvider, Serilog.ILogger> implementationFactory)
         {
             Guard.NotNull(builder, nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires an implementation factory to built up the Serilog logger");
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires an implementation factory to build up the Serilog logger");
 
             builder.Services.AddSingleton<ILoggerProvider>(provider =>
             {

--- a/src/Arcus.Observability.Tests.Unit/Serilog/ILoggingBuilderExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/ILoggingBuilderExtensionsTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Arcus.Observability.Correlation;
+using Arcus.Observability.Tests.Unit.Telemetry.AzureFunctions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Unit.Serilog
+{
+    // ReSharper disable once InconsistentNaming
+    public class ILoggingBuilderExtensionsTests
+    {
+        [Fact]
+        public void AddSerilog_WithImplementationFactory_IncludesSerilogLogger()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddCorrelation();
+
+            // Act
+            services.AddLogging(builder => builder.AddSerilog(provider =>
+            {
+                var accessor = provider.GetRequiredService<ICorrelationInfoAccessor>();
+                return new LoggerConfiguration()
+                       .Enrich.WithCorrelationInfo(accessor)
+                       .WriteTo.Console()
+                       .CreateLogger();
+            }));
+
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var loggerProvider = serviceProvider.GetService<ILoggerProvider>();
+            Assert.NotNull(loggerProvider);
+            Assert.IsType<SerilogLoggerProvider>(loggerProvider);
+            Assert.NotNull(serviceProvider.GetService<ILogger<ILoggerBuilderExtensionsTests>>());
+        }
+
+        [Fact]
+        public void AddSerilog_WithoutImplementationFactory_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddLogging(builder => builder.AddSerilog(implementationFactory: null)));
+        }
+    }
+}


### PR DESCRIPTION
Add `logging.AddSerilog` overload that can take in an `IServiceProvider` so that we can add our correlation enricher more easily in in-process Azure Functions environments.

Closes #481 