### PR TITLE
chore: remove installation details from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,6 @@ Observability with Microsoft Azure in a breeze.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Installation
-Easy to install it via NuGet:
-
-- **Correlation**
-
-```shell
-PM > Install-Package Arcus.Observability.Correlation
-```
-
-- **Telemetry**
-
-```shell
-PM > Install-Package Arcus.Obervability.Telemetry.Core
-```
-
-- **Telemetry on Azure Functions**
-
-```shell
-PM > Install-Package Arcus.Observability.Telemetry.AzureFunctions
-```
-
-- **Serilog Application Insights sink**
-
-```shell
-PM > Install-Package Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights
-```
-
-For a more thorough overview, we recommend reading our [documentation](#documentation).
-
 # Documentation
 All documentation can be found on [here](https://observability.arcus-azure.net/).
 


### PR DESCRIPTION
It is hard to maintain and keep up to date and it does not provide enough added-value as it is a duplication of the documentation, so removed the installation details from the `README.md` file.