### PR TITLE
feat: deprecate iot hub project in favor of dedicated parsing

### DIFF
--- a/docs/preview/03-Features/writing-different-telemetry-types.md
+++ b/docs/preview/03-Features/writing-different-telemetry-types.md
@@ -111,14 +111,6 @@ logger.LogIotHubDependency(iotHubName: "sensors", isSuccessful: true, startTime:
 
 Or, alternatively you can pass along the IoT connection string itself so the host name will be selected for you.
 
-**Installation**
-
-This feature requires to install our NuGet package
-
-```shell
-PM > Install-Package Arcus.Observability.Telemetry.IoT
-```
-
 **Example**
 
 Here is how you can report a dependency call:
@@ -132,9 +124,11 @@ var durationMeasurement = new Stopwatch();
 durationMeasurement.Start();
 var startTime = DateTimeOffset.UtcNow;
 
-logger.LogIotHubDependency(iotHubConnectionString: "Hostname=sensors;", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
+logger.LogIotHubDependencyWithConnectionString(iotHubConnectionString: "HostName=sensors.azure-devices.net;...", isSuccessful: true, startTime: startTime, duration: durationMeasurement.Elapsed);
 // Output: {"DependencyType": "Azure IoT Hub", "TargetName": "sensors", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {}}
 ```
+
+> ⚠ Previously, an `LogIotHubDependency` IoT Hub connection string overload was available in the `Arcus.Observability.Telemetry.IoT` package but is now deprecated and renamed to `LogIotHubDependencyWithConnectionString` which is located in the `Arcus.Observability.Telemetry.Core` package.
 
 ### Measuring Azure Key Vault dependencies
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Iot;
 using Arcus.Observability.Telemetry.Core.Logging;
 using GuardNet;
 
@@ -115,6 +116,66 @@ namespace Microsoft.Extensions.Logging
             context = context ?? new Dictionary<string, object>();
 
             LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Iot Hub Dependency.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the IoT Hub dependency.</param>
+        /// <param name="iotHubConnectionString">The connection string to interact with an IoT Hub resource.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="measurement">The measurement of the duration to call the dependency.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
+        /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        public static void LogIotHubDependencyWithConnectionString(
+            this ILogger logger,
+            string iotHubConnectionString,
+            bool isSuccessful,
+            DurationMeasurement measurement,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
+            Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
+            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to measure the duration of interaction with the IoT Hub dependency");
+
+            context = context ?? new Dictionary<string, object>();
+
+            LogIotHubDependencyWithConnectionString(logger, iotHubConnectionString, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
+
+        /// <summary>
+        /// Logs an Azure Iot Hub Dependency.
+        /// </summary>
+        /// <param name="logger">The logger instance to track the IoT Hub dependency.</param>
+        /// <param name="iotHubConnectionString">The connection string to interact with an IoT Hub resource.</param>
+        /// <param name="isSuccessful">The indication whether or not the operation was successful.</param>
+        /// <param name="startTime">The point in time when the interaction with the dependency was started.</param>
+        /// <param name="duration">The duration of the operation.</param>
+        /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
+        /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
+        /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        public static void LogIotHubDependencyWithConnectionString(
+            this ILogger logger,
+            string iotHubConnectionString,
+            bool isSuccessful,
+            DateTimeOffset startTime,
+            TimeSpan duration,
+            string dependencyId,
+            Dictionary<string, object> context = null)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
+            Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
+
+            context = context ?? new Dictionary<string, object>();
+
+            var result = IotHubConnectionStringParser.Parse(iotHubConnectionString);
+            LogIotHubDependency(logger, iotHubName: result.HostName, isSuccessful, startTime, duration, dependencyId, context);
         }
 
         /// <summary>

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Iot
+{
+    /// <summary>
+    /// Represents the instance to parse the IoT Hub connection string to a strongly-typed <see cref="IotHubConnectionStringParserResult"/>.
+    /// </summary>
+    internal static class IotHubConnectionStringParser
+    {
+        /// <summary>
+        /// Parses the incoming IoT Hub <paramref name="connectionString"/> to a strongly-typed result of IoT Hub properties.
+        /// </summary>
+        /// <param name="connectionString">The connection string based on the hostname of the IoT Hub service.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        internal static IotHubConnectionStringParserResult Parse(string connectionString)
+        {
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank connection string based on the hostname of the IoT Hub service");
+
+            string hostNameProperty =
+                connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                                .FirstOrDefault(part => part.StartsWith("HostName", StringComparison.OrdinalIgnoreCase));
+
+            if (hostNameProperty is null)
+            {
+                throw new FormatException(
+                    "Cannot parse IoT Hub connection string because cannot find 'HostName' in IoT Hub connection string");
+            }
+
+            string hostName = 
+                string.Join("", hostNameProperty.SkipWhile(ch => ch != '=').Skip(1));
+
+            return new IotHubConnectionStringParserResult(hostName);
+        }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.Observability.Telemetry.Core.Iot
+{
+    /// <summary>
+    /// Represents the result of the <see cref="IotHubConnectionStringParser"/> when parsing an IoT Hub connection string.
+    /// </summary>
+    internal class IotHubConnectionStringParserResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IotHubConnectionStringParserResult" /> class.
+        /// </summary>
+        /// <param name="hostName">The fully-qualified DNS hostname of the IoT Hub service.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="hostName"/> is blank.</exception>
+        internal IotHubConnectionStringParserResult(string hostName)
+        {
+            Guard.NotNullOrWhitespace(hostName, nameof(hostName), "Requires a non-blank fully-qualified DNS hostname of the IoT Hub service");
+            HostName = hostName;
+        }
+
+        /// <summary>
+        /// Gets the value of the fully-qualified DNS hostname of the IoT Hub service.
+        /// </summary>
+        internal string HostName { get; }
+    }
+}

--- a/src/Arcus.Observability.Telemetry.IoT/Extensions/ILoggerExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.IoT/Extensions/ILoggerExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        [Obsolete("Use the 'LogIotHubDependencyWithConnectionString' instead in the 'Arcus.Observability.Telemetry.Core' package and remove the 'Arcus.Observability.Telemetry.IoT' package from your project")]
         public static void LogIotHubDependency(
             this ILogger logger,
             string iotHubConnectionString,
@@ -69,6 +70,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        [Obsolete("Use the 'LogIotHubDependencyWithConnectionString' instead in the 'Arcus.Observability.Telemetry.Core' package and remove the 'Arcus.Observability.Telemetry.IoT' package from your project")]
         public static void LogIotHubDependency(
             this ILogger logger,
             string iotHubConnectionString,
@@ -98,6 +100,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        [Obsolete("Use the 'LogIotHubDependencyWithConnectionString' instead in the 'Arcus.Observability.Telemetry.Core' package and remove the 'Arcus.Observability.Telemetry.IoT' package from your project")]
         public static void LogIotHubDependency(
             this ILogger logger,
             string iotHubConnectionString,
@@ -127,6 +130,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="iotHubConnectionString"/> is blank or is invalid.</exception>
         /// <exception cref="FormatException">Thrown when the <paramref name="iotHubConnectionString"/> is invalid.</exception>
+        [Obsolete("Use the 'LogIotHubDependencyWithConnectionString' instead in the 'Arcus.Observability.Telemetry.Core' package and remove the 'Arcus.Observability.Telemetry.IoT' package from your project")]
         public static void LogIotHubDependency(
             this ILogger logger,
             string iotHubConnectionString,

--- a/src/Arcus.Observability.Tests.Unit/Iot/IotHubConnectionStringParserTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Iot/IotHubConnectionStringParserTests.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Iot;
+using Bogus;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Observability.Tests.Unit.Iot
+{
+    public class IotHubConnectionStringParserTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+        private static readonly Faker Bogus = new Faker();
+
+        [Flags]
+        private enum ExcludeIotHubProperty { None = 0, HostName = 1, DeviceId = 2, SharedAccessKey = 4, SharedAccessKeyName = 8 }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IotHubConnectionStringParserTests" /> class.
+        /// </summary>
+        public IotHubConnectionStringParserTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        public static IEnumerable<object[]> ConnectionString =>
+            Enumerable.Range(1, 100)
+                      .Select(i => new object[] { RandomConnectionString() });
+
+        [Theory]
+        [MemberData(nameof(ConnectionString))]
+        public void ParseOriginal_WithRandomIotHubConnectionString_Succeeds(string connectionString)
+        {
+            _outputWriter.WriteLine("ConnectionString: {0}", connectionString);
+            var builder = IotHubConnectionStringBuilder.Create(connectionString);
+
+            Assert.NotNull(builder.HostName);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionString))]
+        public void Parse_WithIotHubConnectionString_Succeeds(string connectionString)
+        {
+            // Arrange
+            _outputWriter.WriteLine("ConnectionString: {0}", connectionString);
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            DateTimeOffset startTime = Bogus.Date.RecentOffset();
+            TimeSpan duration = Bogus.Date.Timespan();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            // Act
+            logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, startTime, duration, dependencyId);
+
+            // Assert
+            var builder = IotHubConnectionStringBuilder.Create(connectionString);
+            Assert.StartsWith($"Azure IoT Hub {builder.HostName}", logger.WrittenMessage);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionString))]
+        public void ParseWithDurationMeasurement_WithIotHubConnectionString_Succeeds(string connectionString)
+        {
+            // Arrange
+            _outputWriter.WriteLine("ConnectionString: {0}", connectionString);
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            // Act
+            logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, measurement, dependencyId);
+
+            // Assert
+            var builder = IotHubConnectionStringBuilder.Create(connectionString);
+            Assert.StartsWith($"Azure IoT Hub {builder.HostName}", logger.WrittenMessage);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public static void Parse_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            DateTimeOffset startTime = Bogus.Date.RecentOffset();
+            TimeSpan duration = Bogus.Date.Timespan();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, startTime, duration, dependencyId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public static void ParseWithDurationMeasurement_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            Assert.ThrowsAny<ArgumentException>(
+                () => logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, measurement, dependencyId));
+        }
+
+        public static IEnumerable<object[]> ConnectionStringWithoutHostName =>
+            Enumerable.Range(1, 100)
+                      .Select(i => new object[] { RandomConnectionString(ExcludeIotHubProperty.HostName) });
+
+        [Theory]
+        [MemberData(nameof(ConnectionStringWithoutHostName))]
+        public void Parse_WithoutHostName_Fails(string connectionString)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            DateTimeOffset startTime = Bogus.Date.RecentOffset();
+            TimeSpan duration = Bogus.Date.Timespan();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            // Act / Assert
+            Assert.ThrowsAny<FormatException>(
+                () => logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, startTime, duration, dependencyId));
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStringWithoutHostName))]
+        public void ParseWithDurationMeasurement_WithoutHostName_Fails(string connectionString)
+        {
+            // Arrange
+            var logger = new TestLogger();
+            bool isSuccessful = Bogus.Random.Bool();
+            var measurement = DurationMeasurement.Start();
+            measurement.Dispose();
+            var dependencyId = Bogus.Random.Guid().ToString();
+
+            // Act / Assert
+            Assert.ThrowsAny<FormatException>(
+                () => logger.LogIotHubDependencyWithConnectionString(connectionString, isSuccessful, measurement, dependencyId));
+        }
+
+        private static string RandomConnectionString(ExcludeIotHubProperty exclude = ExcludeIotHubProperty.None)
+        {
+            string[] alphanumericInputs =
+                Enumerable.Range('a', 26)
+                          .Concat(Enumerable.Range('A', 26))
+                          .Concat(Enumerable.Range('0', 10))
+                          .Select(char.ConvertFromUtf32)
+                          .ToArray();
+
+            string hostName = PickRandom(alphanumericInputs.Concat(new[] { "_", "-" }), 100);
+            string iotHubName = PickRandom(alphanumericInputs.Concat(new[] { "_", "-" }), 100);
+
+            string hostNameProperty = CreateProperty("HostName", $"{iotHubName}.{hostName}");
+            string deviceIdProperty = CreateProperty("DeviceId", 
+                PickRandom(alphanumericInputs.Concat(new[] { "-", ":", ".", "+", "%", "_", "#", "*", "?", "!", "(", ")", ",", "=", "@", "$", "'" }), 128));
+            
+            string sharedAccessKey =
+                Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes(
+                        Bogus.Random.String(length: Bogus.Random.Int(1, 100))));
+            string sharedAccessKeyProperty = CreateProperty("SharedAccessKey", sharedAccessKey);
+            string sharedAccessKeyNameProperty = CreateOptionalProperty("SharedAccessKeyName", PickRandom(alphanumericInputs.Concat(new[] { ".", "_", "-", "@" }), 100));
+
+            return CombineProperties(
+                exclude.HasFlag(ExcludeIotHubProperty.HostName) ? null : hostNameProperty,
+                exclude.HasFlag(ExcludeIotHubProperty.DeviceId) ? null : deviceIdProperty,
+                exclude.HasFlag(ExcludeIotHubProperty.SharedAccessKeyName) ? null : sharedAccessKeyNameProperty,
+                exclude.HasFlag(ExcludeIotHubProperty.SharedAccessKey) ? null : sharedAccessKeyProperty);
+        }
+
+        private static string PickRandom(IEnumerable<string> inputs, int maxLength)
+        {
+            inputs = inputs.ToArray();
+            return string.Join("",
+                Enumerable.Range(1, Bogus.Random.Int(1, maxLength))
+                          .Select(i => Bogus.PickRandom(inputs)));
+        }
+
+        private static string CreateProperty(string key, object value)
+        {
+            return RandomCase(key) + "=" + value;
+        }
+
+        private static string CreateOptionalProperty(string key, object value)
+        {
+            string name = RandomCase(key).OrNull(Bogus);
+            if (name is null)
+            {
+                return null;
+            }
+
+            return name + "=" + value;
+        }
+
+        private static string RandomCase(string item)
+        {
+            return string.Join("", item.ToCharArray().Select(ch =>
+            {
+                if (Bogus.Random.Bool())
+                {
+                    return char.ToUpper(ch);
+                }
+
+                return char.ToLower(ch);
+            }));
+        }
+
+        private static string CombineProperties(params string[] properties)
+        {
+            return string.Join(";", Bogus.Random.Shuffle(properties.Where(prop => prop != null)));
+        }
+    }
+}


### PR DESCRIPTION
Deprecate the `Arcus.Observability.Telemetry.IoT` functionality in favor of our own IoT Hub connection string parsing in the `.Core` project.

Closes #507