### PR TITLE
chore: use main in codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '41 10 * * 5'
 


### PR DESCRIPTION
Use default `main` branch in CodeQL workflow.

Relates to https://github.com/arcus-azure/arcus/issues/169