### PR TITLE
docs: fix correct az servicebus message sending usage

### DIFF
--- a/docs/preview/02-Guidance/Service-to-service Correlation/use-service-to-service-correlation-in-service-bus.md
+++ b/docs/preview/02-Guidance/Service-to-service Correlation/use-service-to-service-correlation-in-service-bus.md
@@ -91,7 +91,8 @@ public class OrderController : ControllerBase
     public async Task<IActionResult> Post([FromBody] ProductOrderRequest productRequest)
     {
         var order = new Order(productRequest);
-        var message = new ServiceBusMessage(order);
+        var data = BinaryData.FromObjectAsJson(order);
+        var message = new ServiceBusMessage(data);
 
         await _serviceBusSender.SendMessageAsync(message);
     }
@@ -215,9 +216,10 @@ public class OrderController : ControllerBase
     public async Task<IActionResult> Post([FromBody] ProductOrderRequest productRequest)
     {
         var order = new Order(productRequest);
-
         var data = BinaryData.FromObjectAsJson(order);
-        await _serviceBusSender.SendMessageAsync(data);
+        var message = new ServiceBusMessage(data);
+
+        await _serviceBusSender.SendMessageAsync(message);
 
         return Accepted();
     }

--- a/docs/versioned_docs/version-v2.6.0/02-Guidance/Service-to-service Correlation/use-service-to-service-correlation-in-service-bus.md
+++ b/docs/versioned_docs/version-v2.6.0/02-Guidance/Service-to-service Correlation/use-service-to-service-correlation-in-service-bus.md
@@ -91,7 +91,8 @@ public class OrderController : ControllerBase
     public async Task<IActionResult> Post([FromBody] ProductOrderRequest productRequest)
     {
         var order = new Order(productRequest);
-        var message = new ServiceBusMessage(order);
+        var data = BinaryData.FromObjectAsJson(order);
+        var message = new ServiceBusMessage(data);
 
         await _serviceBusSender.SendMessageAsync(message);
     }


### PR DESCRIPTION
Use `BinaryData` correctly when sending Azure Service Bus messages in the service-to-service correlation user guide.