### PR TITLE
fix: do not alter original telemetry context pt.1

### DIFF
--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.RequestFormat,
                 RequestLogEntry.CreateForHttpRequest(request.Method,

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
 
-            context = context ?? new Dictionary<string, object>();
             LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, measurement, dependencyId: null, context);
         }
 
@@ -135,7 +134,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
 
-            context = context ?? new Dictionary<string, object>();
             LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
 
@@ -168,7 +166,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
 
-            context = context ?? new Dictionary<string, object>();
             LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -203,7 +200,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure key vault",

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -158,7 +156,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             string dependencyName = $"{accountName}/{containerName}";
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name of the event to track an security event");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context["EventType"] = "Security";
 
             LogCustomEvent(logger, name, context);

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -152,8 +152,6 @@ namespace Microsoft.Extensions.Logging
             Guard.For(() => request.RequestUri is null, new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request)));
             Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request)));
 
-            context = context ?? new Dictionary<string, object>();
-
             LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
         }
 
@@ -220,7 +218,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
             Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             Uri requestUri = request.RequestUri;
             string targetName = requestUri.Host;

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
@@ -113,8 +113,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the IoT Hub operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -141,8 +139,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
             Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
             Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to measure the duration of interaction with the IoT Hub dependency");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogIotHubDependencyWithConnectionString(logger, iotHubConnectionString, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -171,8 +167,6 @@ namespace Microsoft.Extensions.Logging
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
             Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
-
-            context = context ?? new Dictionary<string, object>();
 
             var result = IotHubConnectionStringParser.Parse(iotHubConnectionString);
             LogIotHubDependency(logger, iotHubName: result.HostName, isSuccessful, startTime, duration, dependencyId, context);
@@ -204,7 +198,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the IoT Hub operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure IoT Hub",

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogCustomMetric(logger, name, value, DateTimeOffset.UtcNow, context);
         }
 
@@ -67,7 +65,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.MetricFormat, new MetricLogEntry(name, value, timestamp, context));
         }

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
@@ -307,8 +307,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -339,8 +337,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
         }
@@ -419,8 +415,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -457,7 +451,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.RequestFormat,
                 RequestLogEntry.CreateForHttpRequest(

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
@@ -307,8 +307,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogSqlDependency(logger, serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
 
@@ -345,7 +343,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the SQL dependency operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.SqlDependencyFormat, new DependencyLogEntry(
                 dependencyType: "Sql",

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogTableStorageDependency(logger, accountName, tableName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -158,7 +156,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             string dependencyName = $"{accountName}/{tableName}";
 

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureBlobStorageDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureBlobStorageDependencyLoggingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Bogus;
@@ -196,7 +197,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var measurement = DurationMeasurement.Start();
             measurement.Dispose();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement));
         }
@@ -214,7 +215,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             measurement.Dispose();
             string dependencyId = _bogusGenerator.Lorem.Word();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement, dependencyId));
         }
@@ -231,7 +232,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             var measurement = DurationMeasurement.Start();
             measurement.Dispose();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement));
         }
@@ -249,7 +250,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             measurement.Dispose();
             string dependencyId = _bogusGenerator.Lorem.Word();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement, dependencyId));
         }
@@ -263,7 +264,7 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             string containerName = _bogusGenerator.Finance.AccountName();
             bool isSuccessful = _bogusGenerator.Random.Bool();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement: (DurationMeasurement)null));
         }
@@ -278,9 +279,48 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             bool isSuccessful = _bogusGenerator.Random.Bool();
             string dependencyId = _bogusGenerator.Lorem.Word();
 
-            // Act / 
+            // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement: null, dependencyId));
+        }
+
+        [Fact]
+        public void LogBlobStorageDependencyWithDurationMeasurement_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            string containerName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+            using var measurement = DurationMeasurement.Start();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, measurement, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogBlobStorageDependencyWithStartDuration_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string accountName = _bogusGenerator.Finance.AccountName();
+            string containerName = _bogusGenerator.Finance.AccountName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogBlobStorageDependency(accountName, containerName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureTableStorageDependencyTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureTableStorageDependencyTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Bogus;
@@ -281,6 +282,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogTableStorageDependency(accountName, tableName, isSuccessful, measurement: null, dependencyId));
+        }
+
+        [Fact]
+        public void LogTableStorageDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string accountName = _bogusGenerator.Commerce.ProductName();
+            string tableName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            string dependencyId = _bogusGenerator.Lorem.Word();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogTableStorageDependency(accountName, tableName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpDependencyLoggingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Arcus.Observability.Telemetry.Core;
@@ -581,6 +582,44 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => logger.LogHttpDependency(request, statusCode, DateTimeOffset.Now, TimeSpan.Zero, dependencyId));
         }
+
+        [Fact]
+        public void LogHttpDependencyWithDurationMeasurement_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var request = new HttpRequestMessage(HttpMethod.Get, BogusGenerator.Internet.Url());
+            var statusCode = (int) BogusGenerator.PickRandom<HttpStatusCode>();
+            string dependencyId = BogusGenerator.Random.Guid().ToString();
+            using var measurement = DurationMeasurement.Start();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogHttpDependency(request, statusCode, measurement, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogHttpDependencyWithStartDuration_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var request = new HttpRequestMessage(HttpMethod.Get, BogusGenerator.Internet.Url());
+            var statusCode = (int) BogusGenerator.PickRandom<HttpStatusCode>();
+            string dependencyId = BogusGenerator.Random.Guid().ToString();
+            var startTIme = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogHttpDependency(request, statusCode, startTIme, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
 
         private static HttpRequest CreateStubRequest(HttpMethod method, string host, string path, string scheme)
         {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
@@ -1375,6 +1375,30 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(() => logger.LogRequest(request, statusCode, operationName, startTime, duration));
         }
 
+        [Fact]
+        public void LogRequestMessage_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var scheme = "https";
+            var host = _bogusGenerator.Lorem.Word();
+            var path = _bogusGenerator.Lorem.Word();
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{scheme}://{host}/{path}");
+
+            var statusCode = _bogusGenerator.PickRandom<HttpStatusCode>();
+            string operationName = _bogusGenerator.Lorem.Word();
+
+            TimeSpan duration = _bogusGenerator.Date.Timespan();
+            DateTimeOffset startTime = _bogusGenerator.Date.RecentOffset();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogRequest(request, statusCode, operationName, startTime, duration, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
         private static HttpResponse CreateStubResponse(int statusCode)
         {
             var stubResponse = new Mock<HttpResponse>();

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/IoTHubDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/IoTHubDependencyLoggingTests.cs
@@ -559,5 +559,47 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             string dependencyName = iotHubName;
             Assert.Contains("Azure IoT Hub " + dependencyName, logMessage);
         }
+
+        [Fact]
+        public void LogIoTHubDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string iotHubName = BogusGenerator.Commerce.ProductName().Replace(" ", String.Empty);
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            string dependencyId = BogusGenerator.Random.Guid().ToString();
+
+            DateTimeOffset startTime = BogusGenerator.Date.RecentOffset();
+            TimeSpan duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogIotHubDependency(iotHubName: iotHubName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogIotHubDependencyConnectionString_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string iotHubName = BogusGenerator.Commerce.ProductName().Replace(" ", String.Empty);
+            string deviceId = BogusGenerator.Internet.Ip();
+            string sharedAccessKey = BogusGenerator.Random.Hash();
+            var iotHubConnectionString = $"HostName={iotHubName}.;DeviceId={deviceId};SharedAccessKey={sharedAccessKey}";
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            string dependencyId = BogusGenerator.Random.Guid().ToString();
+
+            using var measurement = DurationMeasurement.Start();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogIotHubDependencyWithConnectionString(iotHubConnectionString, isSuccessful: isSuccessful, measurement, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/MetricLoggingTests.cs
@@ -196,5 +196,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act & Arrange
             Assert.Throws<ArgumentException>(() => logger.LogCustomMetric(metricName, metricValue));
         }
+
+        [Fact]
+        public void LogCustomMetric_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string metricName = _bogusGenerator.Random.Word();
+            double metricValue = _bogusGenerator.Random.Double();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogCustomMetric(metricName, metricValue, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SecurityEventLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SecurityEventLoggingTests.cs
@@ -58,5 +58,19 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act & Assert
             Assert.Throws<ArgumentException>(() => logger.LogSecurityEvent(eventName));
         }
+
+        [Fact]
+        public void LogSecurityEvent_WithContext_DoesNotAlterContext()
+        {
+            var logger = new TestLogger();
+            const string message = "something was invalidated wrong";
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogSecurityEvent(message, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/SqlDependencyLoggingTests.cs
@@ -850,5 +850,93 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogSqlDependencyWithConnectionString(connectionString, sqlCommand, operationName, isSuccessful, measurement: null, dependencyId));
         }
+
+        [Fact]
+        public void LogSqlDependencyWithDurationMeasurement_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = "GET something FROM something";
+            string operationName = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            using var measurement = DurationMeasurement.Start();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithStartDuration_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            string sqlCommand = "GET something FROM something";
+            string operationName = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogSqlDependency(serverName, databaseName, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithConnectionStringWithDurationMeasurement_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string sqlCommand = "GET something FROM something";
+            string operationName = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            using var measurement = DurationMeasurement.Start();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogSqlDependencyWithConnectionString(connectionString, sqlCommand, operationName, isSuccessful, measurement, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogSqlDependencyWithConnectionStringWithStartDuration_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string serverName = BogusGenerator.Name.FullName();
+            string databaseName = BogusGenerator.Name.FullName();
+            var connectionString = $"Server={serverName};Database={databaseName};User=admin;Password=123";
+            string sqlCommand = "GET something FROM something";
+            string operationName = BogusGenerator.Name.FullName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogSqlDependencyWithConnectionString(connectionString, sqlCommand, operationName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }


### PR DESCRIPTION
Fixes the first set of telemetry extensions w/ a telemetry context that does not alter the original passed-in context. Split in two parts as there are a lot of extensions/tests to be changed.

Relates to #545 