### PR TITLE
fix: do not alter telemetry ctx pt.2

### DIFF
--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -127,8 +127,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
         }
 
@@ -193,7 +191,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
             Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             string requestUri = request.Path;
             string targetName = request.Host.Host;

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
             Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, response, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -98,8 +96,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
             Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogRequest(logger, request, response.StatusCode, operationName: null, startTime, duration, context);
         }
@@ -160,8 +156,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
             Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, response, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -190,8 +184,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request operation");
             Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
         }
@@ -254,8 +246,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -286,8 +276,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
         }
@@ -353,8 +341,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -388,7 +374,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.RequestFormat, 
                 RequestLogEntry.CreateForHttpRequest(

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
 
@@ -98,8 +96,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
             Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
 
@@ -128,8 +124,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
             Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
-
-            context = context ?? new Dictionary<string, object>();
 
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
@@ -162,7 +156,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Search",

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
@@ -136,8 +136,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -173,7 +171,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             string data = $"{database}/{container}";
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
@@ -636,8 +636,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, dependencyId: null, context);
         }
 
@@ -676,7 +674,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType,

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.EventFormat, new EventLogEntry(name, context));
         }

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
 
-            context = context ?? new Dictionary<string, object>();
-
             LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId: null, context);
         }
 
@@ -158,7 +156,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
                 dependencyType: "Azure Event Hubs",

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Logging
                 operationName = ContextProperties.RequestTracking.EventHubs.DefaultOperationName;
             }
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.EventHubs.Namespace] = eventHubsNamespace;
             context[ContextProperties.RequestTracking.EventHubs.ConsumerGroup] = consumerGroup;
             context[ContextProperties.RequestTracking.EventHubs.Name] = eventHubsName;

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Logging
                 operationName = ContextProperties.RequestTracking.DefaultOperationName;
             }
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.RequestFormat, RequestLogEntry.CreateForCustomRequest(requestSource, operationName, isSuccessful, duration, startTime, context));
         }

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
@@ -448,7 +448,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.DependencyTracking.ServiceBus.EntityType] = entityType;
             context[ContextProperties.DependencyTracking.ServiceBus.Endpoint] = serviceBusNamespaceEndpoint;
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus topic request operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName] = subscriptionName;
 
             LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, topicName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Topic, context);
@@ -159,7 +159,7 @@ namespace Microsoft.Extensions.Logging
             Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
             Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus topic request operation");
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName] = subscriptionName;
 
             LogServiceBusRequest(logger, serviceBusNamespace, topicName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Topic, context);
@@ -431,7 +431,7 @@ namespace Microsoft.Extensions.Logging
                 operationName = ContextProperties.RequestTracking.ServiceBus.DefaultOperationName;
             }
 
-            context = context ?? new Dictionary<string, object>();
+            context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.ServiceBus.Endpoint] = serviceBusNamespace;
             context[ContextProperties.RequestTracking.ServiceBus.EntityName] = entityName;
             context[ContextProperties.RequestTracking.ServiceBus.EntityType] = entityType;

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureSearchDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureSearchDependencyLoggingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Bogus;
@@ -306,6 +307,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogAzureSearchDependency(searchServiceName, operationName, isSuccessful, measurement: (DurationMeasurement)null, dependencyId));
+        }
+
+        [Fact]
+        public void LogAzureSearchDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string searchServiceName = _bogusGenerator.Commerce.ProductName();
+            string operationName = _bogusGenerator.Commerce.ProductName();
+            bool isSuccessful = _bogusGenerator.PickRandom(true, false);
+            string dependencyId = _bogusGenerator.Lorem.Word();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogAzureSearchDependency(searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusDependencyLoggingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Bogus;
@@ -800,6 +801,27 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogServiceBusTopicDependency(namespaceEndpoint, topicName, isSuccessful, measurement: null, dependencyId));
+        }
+
+        [Fact]
+        public void LogServiceBusDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string namespaceEndpoint = BogusGenerator.Commerce.Product();
+            string topicName = BogusGenerator.Commerce.Product();
+            bool isSuccessful = BogusGenerator.PickRandom(true, false);
+            string dependencyId = BogusGenerator.Lorem.Word();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var entityType = BogusGenerator.PickRandom<ServiceBusEntityType>();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusDependency(namespaceEndpoint, topicName, isSuccessful, startTime, duration, dependencyId, entityType, context);
+
+            // Assert
+            Assert.Empty(context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/AzureServiceBusRequestLoggingTests.cs
@@ -1764,5 +1764,115 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogServiceBusRequestWithSuffix(serviceBusNamespace, serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, negativeDuration, startTime, entryType, context));
         }
+
+        [Fact]
+        public void LogServiceBusTopicRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            // Arrange
+            var logger = new TestLogger();
+            string serviceBusNamespace = _bogusGenerator.Lorem.Word();
+            string topicName = _bogusGenerator.Lorem.Word();
+            string subscriptionName = _bogusGenerator.Lorem.Word();
+            string operationName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusTopicRequest(serviceBusNamespace, topicName, subscriptionName, operationName, isSuccessful, duration, startTime, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogServiceBusTopicRequestWithSuffix_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            // Arrange
+            var logger = new TestLogger();
+            string serviceBusNamespace = _bogusGenerator.Lorem.Word();
+            string suffix = _bogusGenerator.Lorem.Word();
+            string topicName = _bogusGenerator.Lorem.Word();
+            string subscriptionName = _bogusGenerator.Lorem.Word();
+            string operationName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusTopicRequestWithSuffix(serviceBusNamespace, suffix, topicName, subscriptionName, operationName, isSuccessful, duration, startTime, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogServiceBusQueueRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            // Arrange
+            var logger = new TestLogger();
+            string serviceBusNamespace = _bogusGenerator.Lorem.Word();
+            string queueName = _bogusGenerator.Lorem.Word();
+            string operationName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusQueueRequest(serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogServiceBusQueueRequestWithSuffix_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            // Arrange
+            var logger = new TestLogger();
+            string serviceBusNamespace = _bogusGenerator.Lorem.Word();
+            string suffix = _bogusGenerator.Lorem.Word();
+            string queueName = _bogusGenerator.Lorem.Word();
+            string operationName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusQueueRequestWithSuffix(serviceBusNamespace, suffix, queueName, operationName, isSuccessful, duration, startTime, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
+        [Fact]
+        public void LogServiceBusRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            // Arrange
+            var logger = new TestLogger();
+            string serviceBusNamespace = _bogusGenerator.Lorem.Word();
+            string entityName = _bogusGenerator.Lorem.Word();
+            string operationName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var entityType = _bogusGenerator.Random.Enum<ServiceBusEntityType>();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogServiceBusRequest(serviceBusNamespace, entityName, operationName, isSuccessful, duration, startTime, entityType, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CosmosSqlDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CosmosSqlDependencyLoggingTests.cs
@@ -349,5 +349,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogCosmosSqlDependency(accountName, database, container, isSuccessful, measurement: null, dependencyId));
         }
+
+        [Fact]
+        public void LogCosmosSqlDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string database = BogusGenerator.Commerce.ProductName();
+            string container = BogusGenerator.Commerce.ProductName();
+            string accountName = BogusGenerator.Finance.AccountName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogCosmosSqlDependency(accountName, database, container, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomDependencyLoggingTests.cs
@@ -1474,5 +1474,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => logger.LogDependency(dependencyType, dependencyData, targetName, isSuccessful, measurement: null, dependencyId));
         }
+
+        [Fact]
+        public void LogDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string dependencyType = _bogusGenerator.Lorem.Word();
+            var dependencyData = _bogusGenerator.Random.Int().ToString();
+            string targetName = _bogusGenerator.Lorem.Word();
+            bool isSuccessful = _bogusGenerator.Random.Bool();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            string dependencyId = _bogusGenerator.Random.Guid().ToString();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogDependency(dependencyType, dependencyData, isSuccessful, targetName, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/CustomRequestLoggingTests.cs
@@ -239,5 +239,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration));
         }
+
+        [Fact]
+        public void LogCustomRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string customRequestSource = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogCustomRequest(customRequestSource, operationName, isSuccessful, startTime, duration, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsDependencyLoggingTests.cs
@@ -365,5 +365,25 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogEventHubsDependency(namespaceName, eventHubName, isSuccessful, measurement: null, dependencyId));
         }
+
+        [Fact]
+        public void LogEventHubsDependency_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string namespaceName = BogusGenerator.Commerce.ProductName();
+            string eventHubName = BogusGenerator.Commerce.ProductName();
+            bool isSuccessful = BogusGenerator.Random.Bool();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogEventHubsDependency(namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventHubsRequestLoggingTests.cs
@@ -337,5 +337,26 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.ThrowsAny<ArgumentException>(
                 () => logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration));
         }
+
+        [Fact]
+        public void LogEventHubsRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string @namespace = BogusGenerator.Lorem.Word();
+            string consumerGroup = BogusGenerator.Lorem.Word();
+            string eventHubsName = BogusGenerator.Lorem.Word();
+            string operationName = BogusGenerator.Lorem.Word();
+            bool isSuccessful = BogusGenerator.PickRandom(false, true);
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogEventHubsRequest(@namespace, consumerGroup, eventHubsName, operationName, isSuccessful, startTime, duration, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/EventLoggingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Bogus;
 using Microsoft.Extensions.Logging;
@@ -63,6 +64,21 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
 
             // Act & Arrange
             Assert.Throws<ArgumentException>(() => logger.LogCustomEvent(eventName));
+        }
+
+        [Fact]
+        public void LogCustomEvent_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            string eventName = _bogusGenerator.Lorem.Word();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogCustomEvent(eventName, context);
+
+            // Assert
+            Assert.Empty(context);
         }
     }
 }

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpDependencyLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpDependencyLoggingTests.cs
@@ -620,6 +620,24 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Empty(context);
         }
 
+        [Fact]
+        public void LogHttpDependencyWithRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            HttpRequest request = CreateStubRequest(HttpMethod.Get, "host", "/path", "https");
+            int statusCode = (int) BogusGenerator.PickRandom<HttpStatusCode>();
+            var startTime = BogusGenerator.Date.RecentOffset();
+            var duration = BogusGenerator.Date.Timespan();
+            var dependencyId = BogusGenerator.Random.Guid().ToString();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogHttpDependency(request, statusCode, startTime, duration, dependencyId, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
 
         private static HttpRequest CreateStubRequest(HttpMethod method, string host, string path, string scheme)
         {

--- a/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Telemetry/Logging/HttpRequestLoggingTests.cs
@@ -1399,6 +1399,25 @@ namespace Arcus.Observability.Tests.Unit.Telemetry.Logging
             Assert.Empty(context);
         }
 
+        [Fact]
+        public void LogRequestWithHttpRequest_WithContext_DoesNotAlterContext()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            HttpRequest request = CreateStubRequest(HttpMethod.Get, "host", "/path", "https");
+            var statusCode = (int) _bogusGenerator.PickRandom<HttpStatusCode>();
+            string operationName = _bogusGenerator.Lorem.Word();
+            var startTime = _bogusGenerator.Date.RecentOffset();
+            var duration = _bogusGenerator.Date.Timespan();
+            var context = new Dictionary<string, object>();
+
+            // Act
+            logger.LogRequest(request, statusCode, operationName, startTime, duration, context);
+
+            // Assert
+            Assert.Empty(context);
+        }
+
         private static HttpResponse CreateStubResponse(int statusCode)
         {
             var stubResponse = new Mock<HttpResponse>();


### PR DESCRIPTION
Fixes the second set of telemetry extensions w/ a telemetry context that does not alter the original passed-in context. Split in two parts as there are a lot of extensions/tests to be changed.

Relates to #545