### PR TITLE
feat: add managed identity support to app insights serilog sink

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -21,10 +21,11 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/src/Arcus.Observability.Tests.Integration/Fixture/Extensions/IConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Tests.Integration/Fixture/Extensions/IConfigurationExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Extensions on the <see cref="IConfiguration"/> to use reliable test input values.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IConfigurationExtensions
+    {
+        /// <summary>
+        /// Gets an required integration test configuration value with a given <paramref name="keyName"/>
+        /// from the current integration test configuration instance.
+        /// </summary>
+        /// <param name="config">The current loaded integration test instance.</param>
+        /// <param name="keyName">The name of the integration test key value within the loaded integration test instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="keyName"/> is blank.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the <paramref name="config"/> does not have a valid entry for the <paramref name="keyName"/> loaded.</exception>
+        public static string GetRequiredValue(this IConfiguration config, string keyName)
+        {
+            Guard.NotNull(config, nameof(config));
+            Guard.NotNullOrWhitespace(keyName, nameof(keyName));
+
+            var keyValue = config.GetValue<string>(keyName);
+            if (string.IsNullOrWhiteSpace(keyValue))
+            {
+                throw new KeyNotFoundException(
+                    $"Cannot find an integration test configuration value with the key name: '{keyName}' because the value is blank, " +
+                    $"please make sure to add one in your 'appsettings.json' and add a local variant in the 'appsettings.local.json'");
+            }
+
+            if (keyValue.StartsWith("#{") && keyValue.EndsWith("}#"))
+            {
+                throw new KeyNotFoundException(
+                    $"Cannot find an integration test value with the key name: '{keyName}' because the value still contains the tokens '#{{ ... }}#', " +
+                    $"please make sure to add a local variant in the 'appsettings.local.json'");
+            }
+
+            return keyValue;
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
+++ b/src/Arcus.Observability.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Arcus.Observability.Tests.Core;
+using GuardNet;
+using Xunit;
+
+namespace Arcus.Observability.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents a temporary authenticated connection as a managed identity to an Azure resource.
+    /// </summary>
+    public class TemporaryManagedIdentityConnection : IDisposable
+    {
+        private const string TenantIdName = "AZURE_TENANT_ID",
+                             ClientIdName = "AZURE_CLIENT_ID",
+                             ClientSecretName = "AZURE_CLIENT_SECRET";
+
+        private readonly TemporaryEnvironmentVariable[] _variables;
+
+        private TemporaryManagedIdentityConnection(
+            string clientId,
+            params TemporaryEnvironmentVariable[] variables)
+        {
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId));
+            Guard.NotNull(variables, nameof(variables));
+            Guard.NotAny(variables, nameof(variables));
+
+            _variables = variables;
+            ClientId = clientId;
+        }
+
+        /// <summary>
+        /// Gets the ID of the service principal within this temporary managed identity connection.
+        /// </summary>
+        public string ClientId { get; }
+
+        /// <summary>
+        /// Creates a temporary authenticated connection as a managed identity to an Azure resource.
+        /// </summary>
+        /// <param name="tenantId">The Azure tenant ID where the interaction takes place.</param>
+        /// <param name="clientId">The ID of the service principal in this managed identity authentication.</param>
+        /// <param name="clientSecret">The secret of the service principal in this managed identity authentication.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="tenantId"/>, <paramref name="clientId"/>, or the <paramref name="clientSecret"/> is blank.</exception>
+        public static TemporaryManagedIdentityConnection Create(string tenantId, string clientId, string clientSecret)
+        {
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId));
+            Guard.NotNullOrWhitespace(clientSecret, nameof(clientSecret));
+
+            return new TemporaryManagedIdentityConnection(
+                clientId,
+                TemporaryEnvironmentVariable.Create(TenantIdName, tenantId),
+                TemporaryEnvironmentVariable.Create(ClientIdName, clientId),
+                TemporaryEnvironmentVariable.Create(ClientSecretName, clientSecret));
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Assert.All(_variables, v => v.Dispose());
+        }
+    }
+}

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -132,13 +132,26 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         {
             Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to correctly verify if the logged telemetry is tracked in Application Insights");
 
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(8));
+        }
+
+        /// <summary>
+        /// Asserts on whether the logged telemetry availability on Application Insights by retrying the provided <paramref name="assertion"/>.
+        /// </summary>
+        /// <param name="assertion">The assertion function that takes in an Application Insights client which provides access to the available telemetry.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="assertion"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutRejectedException">Thrown when the <paramref name="assertion"/> failed to be verified within the configured timeout.</exception>
+        protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<ApplicationInsightsClient, Task> assertion, TimeSpan timeout)
+        {
+            Guard.NotNull(assertion, nameof(assertion), "Requires an assertion function to correctly verify if the logged telemetry is tracked in Application Insights");
+
             using (ApplicationInsightsDataClient dataClient = CreateApplicationInsightsClient())
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
                     var client = new ApplicationInsightsClient(dataClient, ApplicationId);
                     await assertion(client);
-                }, timeout: TimeSpan.FromMinutes(8)); 
+                }, timeout: timeout); 
             }
         }
 

--- a/src/Arcus.Observability.Tests.Integration/appsettings.json
+++ b/src/Arcus.Observability.Tests.Integration/appsettings.json
@@ -1,10 +1,18 @@
 ﻿{
+  "Arcus": {
+    "TenantId": "#{Arcus.TenantId}#",
+    "ServicePrincipal": {
+      "ClientId": "#{Arcus.ServicePrincipal.ClientId}#",
+      "ClientSecret": "#{Arcus.ServicePrincipal.ClientSecret}#"
+    }
+  },
   "ApplicationInsights": {
     "InstrumentationKey": "#{ApplicationInsights.InstrumentationKey}#",
+    "ConnectionString": "#{ApplicationInsights.ConnectionString}#",
     "ApiKey": "#{ApplicationInsights.ApiKey}#",
     "ApplicationId": "#{ApplicationInsights.ApplicationId}#"
   },
   "AzureFunctions": {
-    "HttpPort":  "#{AzureFunctions.HttpPort}#" 
-  } 
+    "HttpPort": "#{AzureFunctions.HttpPort}#"
+  }
 }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Identity;
 using Bogus;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
@@ -11,6 +12,166 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
     public class LoggerConfigurationExtensionsTests
     {
         private static readonly Faker BogusGenerator = new Faker();
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingManagedIdentity_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingManagedIdentity(provider, connectionString, "<client-id>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingManagedIdentityWithLevel_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingManagedIdentity(provider, connectionString, "<client-id>", level));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingManagedIdentityWithOptions_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingManagedIdentity(provider, connectionString, "<client-id>", level, opt => { }));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsUsingManagedIdentity_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingManagedIdentity(provider, "<connection-string>", "<client-id>"));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsUsingAuthentication_WithoutTokenCredential_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, "<connection-string>", tokenCredential: null));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsUsingAuthenticationWithLogLevel_WithoutTokenCredential_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, "<connection-string>", tokenCredential: null, level));
+        }
+        
+        [Fact]
+        public void AzureApplicationInsightsUsingAuthenticationWithOptions_WithoutTokenCredential_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, "<connection-string>", tokenCredential: null, level, opt => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingAuthentication_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var credential = new DefaultAzureCredential();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, connectionString, credential));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingAuthenticationWithLevel_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var credential = new DefaultAzureCredential();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, connectionString, credential, level));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AzureApplicationInsightsUsingAuthenticationWithOptions_WithoutConnectionString_Fails(string connectionString)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var provider = services.BuildServiceProvider();
+            var credential = new DefaultAzureCredential();
+            var config = new LoggerConfiguration();
+            var level = BogusGenerator.PickRandom<LogEventLevel>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, connectionString, credential, level, opt => { }));
+        }
+
+        [Fact]
+        public void AzureApplicationInsightsUsingAuthentication_WithoutTelemetryClient_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+            var credential = new DefaultAzureCredential();
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => config.WriteTo.AzureApplicationInsightsUsingAuthentication(provider, "<connection-string>", credential));
+        }
 
         [Fact]
         public void AzureApplicationInsightsWithInstrumentationKey_WithoutTelemetryClient_Fails()


### PR DESCRIPTION
Adds managed identity support to the Serilog Application Insights sink that lets you provide a client ID together with the ingestion connection string towards Azure Application Insights.

Closes #541 