### PR TITLE
chore: prepare yaml pipelines for .net 8 w/o preview version

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -53,12 +53,12 @@ stages:
             inputs:
               packageType: 'sdk'
               version: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
           - template: 'build/build-solution.yml@templates'
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               versionSuffix: '$(packageVersion)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:
@@ -93,7 +93,7 @@ stages:
           - template: test/run-unit-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Unit'
 
   - stage: IntegrationTests
@@ -119,7 +119,7 @@ stages:
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Integration'
               category: 'Integration'
 

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -35,7 +35,7 @@ stages:
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               version: $(Build.BuildNumber)
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
           - task: UseDotNet@2
             displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
             inputs:
@@ -75,7 +75,7 @@ stages:
           - template: test/run-unit-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Unit'
 
   - stage: IntegrationTests
@@ -101,7 +101,7 @@ stages:
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              includePreviewVersions: true
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
               projectName: '$(Project).Tests.Integration'
               category: 'Integration'
 

--- a/build/templates/run-docker-integration-tests.yml
+++ b/build/templates/run-docker-integration-tests.yml
@@ -20,7 +20,7 @@ steps:
     inputs:
       packageType: 'sdk'
       version: '$(DotNet.Sdk.Version)'
-      includePreviewVersions: true
+      includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
   - task: Docker@1
     displayName: 'Build Docker image from ${{ parameters.dockerProjectName }}'
     inputs:
@@ -41,7 +41,7 @@ steps:
   - template: test/run-integration-tests.yml@templates
     parameters:
       dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-      includePreviewVersions: true
+      includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
       projectName: '$(Project).Tests.Integration'
       category: 'Docker'
   - task: Bash@3

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,5 +1,6 @@
 variables:
   DotNet.Sdk.Version: '8.0.x'
   DotNet.Sdk.PreviousVersion: '6.0.100'
+  DotNet.Sdk.IncludePreviewVersions: false
   Project: 'Arcus.Observability'
   Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
Prepare the YAML pipelines to not include a preview .NET version anymore, since there is a new major version for .NET 8 available now.