### PR TITLE
refactor: Removing all dependency to Guard.NET.

### DIFF
--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>

--- a/src/Arcus.Observability.Correlation/CorrelationInfo.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfo.cs
@@ -29,7 +29,7 @@ namespace Arcus.Observability.Correlation
         {
             if (string.IsNullOrEmpty(operationId))
             {
-                throw new ArgumentNullException(nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
+                throw new ArgumentException("Requires a non-blank operation ID to create a correlation instance", nameof(operationId));
             }
 
             OperationId = operationId;
@@ -46,7 +46,7 @@ namespace Arcus.Observability.Correlation
         /// Gets the unique ID information of the request.
         /// </summary>
         public string OperationId { get; }
-        
+
         /// <summary>
         /// Gets the ID of the original service that initiated this request.
         /// </summary>

--- a/src/Arcus.Observability.Correlation/CorrelationInfo.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Correlation
 {
@@ -28,7 +27,10 @@ namespace Arcus.Observability.Correlation
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
         public CorrelationInfo(string operationId, string transactionId, string operationParentId)
         {
-            Guard.NotNullOrEmpty(operationId, nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
+            if (string.IsNullOrEmpty(operationId))
+            {
+                throw new ArgumentNullException(nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
+            }
 
             OperationId = operationId;
             TransactionId = transactionId;

--- a/src/Arcus.Observability.Correlation/CorrelationInfoAccessorProxy.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoAccessorProxy.cs
@@ -1,4 +1,4 @@
-﻿using GuardNet;
+﻿using System;
 
 namespace Arcus.Observability.Correlation
 {
@@ -16,7 +16,10 @@ namespace Arcus.Observability.Correlation
         /// </summary>
         internal CorrelationInfoAccessorProxy(ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor)
         {
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor));
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor));
+            }
 
             _correlationInfoAccessor = correlationInfoAccessor;
         }

--- a/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -17,11 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The services collection containing the dependency injection services.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation(this IServiceCollection services)
-        {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the default correlation accessor to the application services");
-
-            return AddCorrelation<CorrelationInfo>(services);
-        }
+            => AddCorrelation<CorrelationInfo>(services);
 
         /// <summary>
         /// Adds operation and transaction correlation to the application using the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/>
@@ -30,15 +25,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The services collection containing the dependency injection services.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation<TCorrelationInfo>(
-            this IServiceCollection services) 
+            this IServiceCollection services)
             where TCorrelationInfo : CorrelationInfo
-        {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the default correlation accessor to the application services");
-
-            return AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo>(
-                services, 
+            => AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo>(
+                services,
                 provider => new DefaultCorrelationInfoAccessor<TCorrelationInfo>());
-        }
+
 
         /// <summary>
         /// Adds operation and transaction correlation to the application.
@@ -48,15 +40,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="createCustomCorrelationAccessor">The custom <see cref="ICorrelationInfoAccessor"/> implementation factory to retrieve the <see cref="CorrelationInfo"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="createCustomCorrelationAccessor"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation<TAccessor>(
-            this IServiceCollection services, 
+            this IServiceCollection services,
             Func<IServiceProvider, TAccessor> createCustomCorrelationAccessor)
-            where TAccessor : class, ICorrelationInfoAccessor
-        {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
-            Guard.NotNull(createCustomCorrelationAccessor, nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");
-
-            return AddCorrelation<TAccessor, CorrelationInfo>(services, createCustomCorrelationAccessor);
-        }
+            where TAccessor : class, ICorrelationInfoAccessor 
+                => AddCorrelation<TAccessor, CorrelationInfo>(services, createCustomCorrelationAccessor);
 
         /// <summary>
         /// Adds operation and transaction correlation to the application.
@@ -72,8 +59,14 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAccessor : class, ICorrelationInfoAccessor<TCorrelationInfo>
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
-            Guard.NotNull(createCustomCorrelationAccessor, nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
+            }
+            if (createCustomCorrelationAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");
+            }
 
             services.AddScoped<ICorrelationInfoAccessor<TCorrelationInfo>>(createCustomCorrelationAccessor);
             services.AddScoped<ICorrelationInfoAccessor>(serviceProvider =>

--- a/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The services collection containing the dependency injection services.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation(this IServiceCollection services)
-            => AddCorrelation<CorrelationInfo>(services);
+        {
+            return AddCorrelation<CorrelationInfo>(services);
+        }
 
         /// <summary>
         /// Adds operation and transaction correlation to the application using the <see cref="DefaultCorrelationInfoAccessor{TCorrelationInfo}"/>
@@ -27,9 +29,11 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddCorrelation<TCorrelationInfo>(
             this IServiceCollection services)
             where TCorrelationInfo : CorrelationInfo
-            => AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo>(
-                services,
-                provider => new DefaultCorrelationInfoAccessor<TCorrelationInfo>());
+        {
+            return AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo>(
+                        services,
+                        provider => new DefaultCorrelationInfoAccessor<TCorrelationInfo>());
+        }
 
 
         /// <summary>
@@ -42,8 +46,10 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddCorrelation<TAccessor>(
             this IServiceCollection services,
             Func<IServiceProvider, TAccessor> createCustomCorrelationAccessor)
-            where TAccessor : class, ICorrelationInfoAccessor 
-                => AddCorrelation<TAccessor, CorrelationInfo>(services, createCustomCorrelationAccessor);
+            where TAccessor : class, ICorrelationInfoAccessor
+        {
+            return AddCorrelation<TAccessor, CorrelationInfo>(services, createCustomCorrelationAccessor);
+        }
 
         /// <summary>
         /// Adds operation and transaction correlation to the application.
@@ -63,6 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
             }
+
             if (createCustomCorrelationAccessor is null)
             {
                 throw new ArgumentNullException(nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Extensions.Logging
             HttpStatusCode statusCode,
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
+        {
+            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency.
@@ -58,7 +60,9 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        {
+            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency.
@@ -80,7 +84,9 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        {
+            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -103,7 +109,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
+        {
+            LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -128,7 +136,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
+        {
+            LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -158,17 +168,30 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (request is null)
             {
                 throw new ArgumentNullException(nameof(request), "Requires a HTTP request message to track a HTTP dependency");
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
             }
+
             if (statusCode < 100 || statusCode > 599)
             {
                 throw new ArgumentException("Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive", nameof(statusCode));
+            }
+
+            if (request.Method is null)
+            {
+                throw new ArgumentException("Requires a HTTP method", nameof(request));
+            }
+
+            if (!request.Path.HasValue)
+            {
+                throw new ArgumentException("Requires a request URI in the request", nameof(request));
             }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 
 // ReSharper disable once CheckNamespace
@@ -37,13 +36,7 @@ namespace Microsoft.Extensions.Logging
             HttpStatusCode statusCode,
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
-
-            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
-        }
+                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
 
         /// <summary>
         /// Logs an HTTP dependency.
@@ -65,13 +58,7 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
-
-            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
-        }
+                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
 
         /// <summary>
         /// Logs an HTTP dependency.
@@ -93,13 +80,7 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
-
-            LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
-        }
+                => LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -122,13 +103,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-
-            LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
-        }
+                => LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -153,13 +128,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-
-            LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
-        }
+                => LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -185,11 +154,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request message to track a HTTP dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
+            }
+            if (statusCode < 100 || statusCode > 599)
+            {
+                throw new ArgumentException("Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive", nameof(statusCode));
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 using Microsoft.AspNetCore.Http;
 
 // ReSharper disable once CheckNamespace
@@ -31,10 +30,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, response, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -60,14 +59,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            LogRequest(logger, request, response.StatusCode, operationName: null, startTime, duration, context);
-        }
+                => LogRequest(logger, request, response.StatusCode, operationName: null, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -88,10 +80,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, response, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -116,14 +108,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request operation");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request operation");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
-        }
+                => LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -142,11 +127,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
-            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -172,15 +156,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
-
-            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
-        }
+                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -201,11 +177,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
-            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -234,11 +209,22 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotLessThan(responseStatusCode, 0, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(responseStatusCode, 999, nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP request");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry")/
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            }
+            if (responseStatusCode < 0 || responseStatusCode > 999)
+            {
+                throw new ArgumentOutOfRangeException(nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP request");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AspNetCore/Extensions/ILoggerRequestExtensions.cs
@@ -59,7 +59,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, response.StatusCode, operationName: null, startTime, duration, context);
+        {
+            LogRequest(logger, request, response.StatusCode, operationName: null, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -108,7 +110,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
+        {
+            LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -156,7 +160,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        {
+            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -211,16 +217,19 @@ namespace Microsoft.Extensions.Logging
         {
             if (logger is null)
             {
-                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry")/
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (request is null)
             {
                 throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance to track a HTTP request");
             }
+
             if (responseStatusCode < 0 || responseStatusCode > 999)
             {
                 throw new ArgumentOutOfRangeException(nameof(responseStatusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP request");

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -22,7 +21,10 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="InvalidOperationException">Thrown when no 'ApplicationInsightsLoggerProvider' instance can be found in the <paramref name="builder"/>.</exception>
         public static ILoggingBuilder RemoveMicrosoftApplicationInsightsLoggerProvider(this ILoggingBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an instance of the logging builder to remove Microsoft's 'ApplicationInsightsLoggerProvider'");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires an instance of the logging builder to remove Microsoft's 'ApplicationInsightsLoggerProvider'");
+            }
 
             ServiceDescriptor descriptor = 
                 builder.Services.FirstOrDefault(service => service.ImplementationType?.Name == "ApplicationInsightsLoggerProvider");

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 #if !(NETSTANDARD2_1)
 using Microsoft.Azure.Functions.Worker.Http; 
 #endif
@@ -36,9 +35,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,13 +61,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
-        }
+                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -89,9 +83,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -117,9 +112,18 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance to track a HTTP request");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.AzureFunctions/Extensions/ILoggerHttpRequestDataExtensions.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        {
+            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -116,10 +118,12 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (request is null)
             {
                 throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance to track a HTTP request");
             }
+            
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");

--- a/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
+++ b/src/Arcus.Observability.Telemetry.Core/Arcus.Observability.Telemetry.Core.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core
 {
@@ -35,7 +34,10 @@ namespace Arcus.Observability.Telemetry.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="consumerType"/> is <c>null</c>.</exception>
         public AssemblyAppVersion(Type consumerType)
         {
-            Guard.NotNull(consumerType, nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
+            if (consumerType is null)
+            {
+                throw new ArgumentNullException(nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
+            }
 
             Assembly executingAssembly = consumerType.Assembly;
             _assemblyVersion = new Lazy<string>(() => GetAssemblyVersion(executingAssembly));

--- a/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
+++ b/src/Arcus.Observability.Telemetry.Core/AssemblyAppVersion.cs
@@ -18,6 +18,7 @@ namespace Arcus.Observability.Telemetry.Core
         public AssemblyAppVersion()
         {
             var executingAssembly = Assembly.GetEntryAssembly();
+
             if (executingAssembly is null)
             {
                 throw new InvalidOperationException(

--- a/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
+++ b/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core
 {
@@ -17,7 +16,11 @@ namespace Arcus.Observability.Telemetry.Core
         /// <exception cref="ArgumentException">Thrown when the <paramref name="componentName"/> is blank.</exception>
         public DefaultAppName(string componentName)
         {
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank functional name to identity the application");
+            if (string.IsNullOrWhiteSpace(componentName))
+            {
+                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank functional name to identify the application");
+            }
+
             _componentName = componentName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
+++ b/src/Arcus.Observability.Telemetry.Core/DefaultAppName.cs
@@ -18,7 +18,7 @@ namespace Arcus.Observability.Telemetry.Core
         {
             if (string.IsNullOrWhiteSpace(componentName))
             {
-                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank functional name to identify the application");
+                throw new ArgumentException("Requires a non-blank functional name to identify the application", nameof(componentName));
             }
 
             _componentName = componentName;

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
@@ -96,7 +96,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Key Vault dependency.
@@ -128,14 +130,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
             }
+
             if (string.IsNullOrWhiteSpace(vaultUri))
             {
-                throw new ArgumentNullException(nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
+                throw new ArgumentException("Requires a non-blank URI for the Azure Key Vault", nameof(vaultUri));
             }
+
             if (string.IsNullOrWhiteSpace(secretName))
             {
-                throw new ArgumentNullException(nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
+                throw new ArgumentException("Requires a non-blank secret name for the Azure Key Vault", nameof(secretName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureKeyVaultDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -34,10 +33,11 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
-            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
+            }
+
 
             LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, measurement, dependencyId: null, context);
         }
@@ -65,10 +65,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
-            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Key Vault when tracking an Azure Key Vault dependency");
+            }
 
             LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -96,14 +96,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
-            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
-
-            LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogAzureKeyVaultDependency(logger, vaultUri, secretName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Key Vault dependency.
@@ -131,10 +124,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
-            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires an logger instance to write the Azure Key Vault dependency");
+            }
+            if (string.IsNullOrWhiteSpace(vaultUri))
+            {
+                throw new ArgumentNullException(nameof(vaultUri), "Requires a non-blank URI for the Azure Key Vault");
+            }
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentNullException(nameof(secretName), "Requires a non-blank secret name for the Azure Key Vault");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Key Vault operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -32,10 +32,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Search dependency");
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+            }
 
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,10 +61,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Search dependency");
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Search resource when tracking the Azure Search dependency");
+            }
 
             LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -89,14 +89,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
-
-            LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Search Dependency.
@@ -121,10 +114,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(searchServiceName, nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Search operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(searchServiceName))
+            {
+                throw new ArgumentNullException(nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            }
+            if (string.IsNullOrWhiteSpace(operationName))
+            {
+                throw new ArgumentNullException(nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentException("Requires a positive time duration of the Azure Search operation", nameof(duration));
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerAzureSearchDependencyExtensions.cs
@@ -89,14 +89,16 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogAzureSearchDependency(logger, searchServiceName, operationName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Search Dependency.
         /// </summary>
         /// <param name="logger">The logger to track the telemetry.</param>
         /// <param name="searchServiceName">Name of the Azure Search service</param>
-        /// <param name="operationName">Name of the operation to execute on the Azure Search service</param>
+        /// <param name="operationName">Name of the operqation to execute on the Azure Search service</param>
         /// <param name="isSuccessful">Indication whether or not the operation was successful</param>
         /// <param name="startTime">Point in time when the interaction with the HTTP dependency was started</param>
         /// <param name="duration">Duration of the operation</param>
@@ -118,14 +120,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(searchServiceName))
             {
-                throw new ArgumentNullException(nameof(searchServiceName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+                throw new ArgumentException("Requires a non-blank name for the Azure Search service to track the Azure Service dependency", nameof(searchServiceName));
             }
+
             if (string.IsNullOrWhiteSpace(operationName))
             {
-                throw new ArgumentNullException(nameof(operationName), "Requires a non-blank name for the Azure Search service to track the Azure Service dependency");
+                throw new ArgumentException("Requires a non-blank name for the Azure Search service to track the Azure Service dependency", nameof(operationName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentException("Requires a positive time duration of the Azure Search operation", nameof(duration));

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Blob Storage Dependency.
@@ -119,15 +121,18 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(accountName))
             {
-                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
+                throw new ArgumentException("Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency", nameof(accountName));
             }
-            if(string.IsNullOrWhiteSpace(containerName))
+            
+            if (string.IsNullOrWhiteSpace(containerName))
             {
-                throw new ArgumentNullException(nameof(containerName), "Requires a non-blank container name in the Azure Blob storage resource to track an Azure Blob storage dependency");
+                throw new ArgumentException("Requires a non-blank container name in the Azure Blob storage resource to track an Azure Blob storage dependency", nameof(containerName));
             }
-            if(duration < TimeSpan.Zero)
+            
+            if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
             }

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerBlobStorageDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -32,10 +31,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Blob storage when tracking an Azure Blob storage dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Blob storage when tracking an Azure Blob storage dependency");
+            }
 
             LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,10 +60,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Blob storage when tracking an Azure Blob storage dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Blob storage when tracking an Azure Blob storage dependency");
+            }
 
             LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -90,14 +89,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
-
-            LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogBlobStorageDependency(logger, accountName, containerName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Blob Storage Dependency.
@@ -123,10 +115,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
-            Guard.NotNullOrWhitespace(containerName, nameof(containerName), "Requires a non-blank container name in the Azure BLob storage resource to track an Azure Blob storage dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name for the Azure Blob storage resource to track an Azure Blob storage dependency");
+            }
+            if(string.IsNullOrWhiteSpace(containerName))
+            {
+                throw new ArgumentNullException(nameof(containerName), "Requires a non-blank container name in the Azure Blob storage resource to track an Azure Blob storage dependency");
+            }
+            if(duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Blob storage operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
@@ -95,7 +95,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs a Cosmos SQL dependency.
@@ -127,18 +129,22 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(accountName))
             {
-                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track Cosmos SQL dependency");
+                throw new ArgumentException("Requires a non-blank account name of the Cosmos SQL storage to track Cosmos SQL dependency", nameof(accountName));
             }
+
             if (string.IsNullOrWhiteSpace(database))
             {
-                throw new ArgumentNullException(nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+                throw new ArgumentException("Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency", nameof(database));
             }
+
             if (string.IsNullOrWhiteSpace(container))
             {
-                throw new ArgumentNullException(nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+                throw new ArgumentException("Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency", nameof(container));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCosmosSqlDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -34,11 +33,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Cosmos SQL storage when tracking an Cosmos SQL dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Cosmos SQL storage when tracking an Cosmos SQL dependency");
+            }
 
             LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -66,11 +64,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Cosmos SQL storage when tracking an Cosmos SQL dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Cosmos SQL storage when tracking an Cosmos SQL dependency");
+            }
 
             LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -98,15 +95,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
-
-            LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogCosmosSqlDependency(logger, accountName, database, container, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs a Cosmos SQL dependency.
@@ -134,11 +123,26 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(database, nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotNullOrWhitespace(container, nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name of the Cosmos SQL storage to track Cosmos SQL dependency");
+            }
+            if (string.IsNullOrWhiteSpace(database))
+            {
+                throw new ArgumentNullException(nameof(database), "Requires a non-blank database name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            }
+            if (string.IsNullOrWhiteSpace(container))
+            {
+                throw new ArgumentNullException(nameof(container), "Requires a non-blank container name of the Cosmos SQL storage to track a Cosmos SQL dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Cosmos SQL operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             string data = $"{database}/{container}";

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
@@ -159,7 +159,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -186,7 +188,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, dependencyId, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -213,7 +217,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, dependencyName, startTime: startTime, duration: duration, context: context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, dependencyName, startTime: startTime, duration: duration, context: context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -242,7 +248,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, dependencyName, startTime, duration, dependencyId, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, dependencyName, startTime, duration, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -401,7 +409,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName: targetName, startTime, duration, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName: targetName, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -430,7 +440,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, targetName, startTime, duration, dependencyId, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, targetName, startTime, duration, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -459,7 +471,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, dependencyId: null, context);
+        {
+            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs a dependency.
@@ -477,7 +491,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="logger"/>, <paramref name="dependencyData"/> is <c>null</c>.
         /// </exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyData"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="dependencyType"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogDependency(
             this ILogger logger,
@@ -495,14 +509,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(dependencyType))
             {
-                throw new ArgumentNullException(nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+                throw new ArgumentException("Requires a non-blank custom dependency type when tracking the custom dependency", nameof(dependencyType));
             }
+
             if (dependencyData is null)
             {
                 throw new ArgumentNullException(nameof(dependencyData), "Requirs custom dependency data when tracking the custom dependency");
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the dependency operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerCustomDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -34,10 +33,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -65,10 +64,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -96,10 +95,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -129,10 +128,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -160,14 +159,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -194,14 +186,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, dependencyId, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, startTime, duration, dependencyId, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -228,14 +213,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, dependencyName, startTime: startTime, duration: duration, context: context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful: isSuccessful, dependencyName, startTime: startTime, duration: duration, context: context);
 
         /// <summary>
         /// Logs a dependency.
@@ -264,14 +242,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, dependencyName, startTime, duration, dependencyId, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName: null, isSuccessful, dependencyName, startTime, duration, dependencyId, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -296,10 +267,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -329,10 +300,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -362,10 +333,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -397,10 +368,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -430,14 +401,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName: targetName, startTime, duration, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName: targetName, startTime, duration, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -466,14 +430,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, targetName, startTime, duration, dependencyId, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, targetName, startTime, duration, dependencyId, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -502,14 +459,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
-            LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, dependencyId: null, context);
-        }
+                => LogDependency(logger, dependencyType, dependencyData, targetName, isSuccessful, dependencyName, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs a dependency.
@@ -541,11 +491,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotNull(dependencyData, nameof(dependencyData), "Requires custom dependency data when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(dependencyType))
+            {
+                throw new ArgumentNullException(nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            }
+            if (dependencyData is null)
+            {
+                throw new ArgumentNullException(nameof(dependencyData), "Requirs custom dependency data when tracking the custom dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the dependency operation");
+            }
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
@@ -42,9 +42,10 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instancen to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException("Requires a non-blank event name to track an custom event", nameof(name));
+                throw new ArgumentException("Requires a non-blank event name to track an custom event", nameof(name));
             }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -23,9 +22,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogSecurityEvent(this ILogger logger, string name, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name of the event to track an security event");
-
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context["EventType"] = "Security";
 
@@ -42,8 +38,14 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogCustomEvent(this ILogger logger, string name, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instancen to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("Requires a non-blank event name to track an custom event", nameof(name));
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Event Hub Dependency.
@@ -119,14 +121,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(namespaceName))
             {
-                throw new ArgumentNullException(nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
+                throw new ArgumentException("Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency", nameof(namespaceName));
             }
+
             if (string.IsNullOrWhiteSpace(eventHubName))
             {
-                throw new ArgumentNullException(nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
+                throw new ArgumentException("Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency", nameof(eventHubName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -32,10 +31,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Event Hub resource when tracking an Azure Event Hub dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,10 +60,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Event Hub resource when tracking an Azure Event Hub dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -90,14 +89,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
-
-            LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogEventHubsDependency(logger, namespaceName, eventHubName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Event Hub Dependency.
@@ -123,10 +115,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(namespaceName, nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(namespaceName))
+            {
+                throw new ArgumentNullException(nameof(namespaceName), "Requires a non-blank resource namespace of the Azure Event Hub to track an Azure Event Hub dependency");
+            }
+            if (string.IsNullOrWhiteSpace(eventHubName))
+            {
+                throw new ArgumentNullException(nameof(eventHubName), "Requires a non-blank Azure Event Hub name to track an Azure Event Hub dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Events Hubs operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
+        {
+            LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
+        }
 
         /// <summary>
         /// Logs an Azure EventHubs request.
@@ -127,18 +129,22 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires an logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(eventHubsNamespace))
             {
-                throw new ArgumentNullException(nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
+                throw new ArgumentException("Requires an Azure EventHubs namespace to track the request", nameof(eventHubsNamespace));
             }
+
             if (string.IsNullOrWhiteSpace(consumerGroup))
             {
-                throw new ArgumentNullException(nameof(consumerGroup), "Requires an Azure EventHubs consumer group to track the request");
+                throw new ArgumentException("Requires an Azure EventHubs consumer group to track the request", nameof(consumerGroup));
             }
+
             if (string.IsNullOrWhiteSpace(eventHubsName))
             {
-                throw new ArgumentNullException(nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
+                throw new ArgumentException("Requires an Azure EventHubs name to track the request", nameof(eventHubsName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure EventHubs request operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerEventHubsRequestExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -32,10 +31,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure EventHubs request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogEventHubsRequest(logger, eventHubsNamespace, eventHubsName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,14 +60,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure EventHubs request operation");
-
-            LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
-        }
+                => LogEventHubsRequest(logger, eventHubsNamespace, "$Default", eventHubsName, operationName: null, isSuccessful: isSuccessful, startTime: startTime, duration: duration, context: context);
 
         /// <summary>
         /// Logs an Azure EventHubs request.
@@ -95,11 +87,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
-            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to track the request");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure EventHubs request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the dependency when tracking the custom dependency");
+            }
 
             LogEventHubsRequest(logger, eventHubsNamespace, consumerGroup, eventHubsName, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -132,11 +123,26 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
-            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to track the request");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure EventHubs request operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires an logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(eventHubsNamespace))
+            {
+                throw new ArgumentNullException(nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to track the request");
+            }
+            if (string.IsNullOrWhiteSpace(consumerGroup))
+            {
+                throw new ArgumentNullException(nameof(consumerGroup), "Requires an Azure EventHubs consumer group to track the request");
+            }
+            if (string.IsNullOrWhiteSpace(eventHubsName))
+            {
+                throw new ArgumentNullException(nameof(eventHubsName), "Requires an Azure EventHubs name to track the request");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure EventHubs request operation");
+            }
 
             if (string.IsNullOrWhiteSpace(operationName))
             {

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -21,10 +20,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogInformation(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an informational message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an informational message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged informational message");
-
             if (logger.IsEnabled(LogLevel.Information))
             {
                 using (logger.BeginScope(context))
@@ -49,10 +44,6 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an informational message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an informational message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged informational message");
-
             if (logger.IsEnabled(LogLevel.Information))
             {
                 using (logger.BeginScope(context))
@@ -72,10 +63,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogError(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an error message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an error message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged error message");
-
             if (logger.IsEnabled(LogLevel.Error))
             {
                 using (logger.BeginScope(context))
@@ -100,10 +87,10 @@ namespace Microsoft.Extensions.Logging
             string message, 
             Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an error message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged error message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an error message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged error message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged critical message");
+            }
 
             if (logger.IsEnabled(LogLevel.Error))
             {
@@ -129,10 +116,6 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an error message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an error message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged error message");
-
             if (logger.IsEnabled(LogLevel.Error))
             {
                 using (logger.BeginScope(context))
@@ -159,10 +142,10 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an error message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged error message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an error message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged error message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged critical message");
+            }
 
             if (logger.IsEnabled(LogLevel.Error))
             {
@@ -183,10 +166,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogCritical(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an critical message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an critical message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged critical message");
-
             if (logger.IsEnabled(LogLevel.Critical))
             {
                 using (logger.BeginScope(context))
@@ -211,10 +190,10 @@ namespace Microsoft.Extensions.Logging
             string message, 
             Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an critical message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged critical message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an critical message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged critical message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged critical message");
+            }
 
             if (logger.IsEnabled(LogLevel.Critical))
             {
@@ -240,10 +219,6 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an critical message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an critical message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged critical message");
-
             if (logger.IsEnabled(LogLevel.Critical))
             {
                 using (logger.BeginScope(context))
@@ -270,10 +245,10 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an critical message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged critical message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an critical message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged critical message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged critical message");
+            }
 
             if (logger.IsEnabled(LogLevel.Critical))
             {
@@ -294,10 +269,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogWarning(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an warning message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an warning message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged warning message");
-
             if (logger.IsEnabled(LogLevel.Warning))
             {
                 using (logger.BeginScope(context))
@@ -322,10 +293,10 @@ namespace Microsoft.Extensions.Logging
             string message, 
             Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an warning message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged warning message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an warning message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged warning message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged warning message");
+            }
 
             if (logger.IsEnabled(LogLevel.Warning))
             {
@@ -351,10 +322,6 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an warning message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an warning message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged warning message");
-
             if (logger.IsEnabled(LogLevel.Warning))
             {
                 using (logger.BeginScope(context))
@@ -381,10 +348,10 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an warning message with a telemetry context");
-            Guard.NotNull(exception, nameof(exception), "Requires an exception to include with the logged warning message");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an warning message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged warning message");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception), "Requires an exception to include with the logged warning message");
+            }
 
             if (logger.IsEnabled(LogLevel.Warning))
             {
@@ -405,10 +372,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogTrace(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an trace message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an trace message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged trace message");
-
             if (logger.IsEnabled(LogLevel.Trace))
             {
                 using (logger.BeginScope(context))
@@ -433,10 +396,6 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an trace message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an trace message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged trace message");
-
             if (logger.IsEnabled(LogLevel.Trace))
             {
                 using (logger.BeginScope(context))
@@ -456,10 +415,6 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
         public static void LogDebug(this ILogger logger, string message, Dictionary<string, object> context)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an debug message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an debug message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged debug message");
-
             if (logger.IsEnabled(LogLevel.Debug))
             {
                 using (logger.BeginScope(context))
@@ -484,9 +439,18 @@ namespace Microsoft.Extensions.Logging
             Dictionary<string, object> context,
             params object[] args)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an debug message with a telemetry context");
-            Guard.NotNullOrWhitespace(message, nameof(message), "Requires an debug message to write to the logger with a telemetry context");
-            Guard.NotNull(context, nameof(context), "Requires a telemetry context to include with the logged debug message");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write a debug message with a telemetry context");
+            }
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentNullException(nameof(message), "Requires a debug message to write to the logger with a telemetry context");
+            }
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context), "Requires a telemetry context to include with the logged debug message");
+            }
 
             if (logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
@@ -443,10 +443,12 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to write a debug message with a telemetry context");
             }
+
             if (string.IsNullOrWhiteSpace(message))
             {
-                throw new ArgumentNullException(nameof(message), "Requires a debug message to write to the logger with a telemetry context");
+                throw new ArgumentException("Requires a debug message to write to the logger with a telemetry context", nameof(message));
             }
+
             if (context is null)
             {
                 throw new ArgumentNullException(nameof(context), "Requires a telemetry context to include with the logged debug message");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -30,9 +29,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+            }
 
             LogCustomRequest(logger, requestSource, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -56,13 +56,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the custom request operation");
-
-            LogCustomRequest(logger, requestSource, operationName: null, isSuccessful, startTime, duration, context);
-        }
+                => LogCustomRequest(logger, requestSource, operationName: null, isSuccessful, startTime, duration, context);
 
         /// <summary>
         /// Logs a custom request.
@@ -83,9 +77,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the custom request process latency duration");
+            }
 
             LogCustomRequest(logger, requestSource, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -112,9 +107,18 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the custom request operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(requestSource))
+            {
+                throw new ArgumentNullException(nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the custom request operation");
+            }
 
             if (string.IsNullOrWhiteSpace(operationName))
             {

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralRequestExtensions.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogCustomRequest(logger, requestSource, operationName: null, isSuccessful, startTime, duration, context);
+        {
+            LogCustomRequest(logger, requestSource, operationName: null, isSuccessful, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs a custom request.
@@ -111,10 +113,12 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(requestSource))
             {
-                throw new ArgumentNullException(nameof(requestSource), "Requires a non-blank request source to identify the caller");
+                throw new ArgumentException("Requires a non-blank request source to identify the caller", nameof(requestSource));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the custom request operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -34,9 +34,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            }
 
             LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -62,9 +63,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            }
 
             LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -90,9 +92,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the HTTP communication when tracking a HTTP dependency");
+            }
 
             LogHttpDependency(logger, request, statusCode, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -118,15 +121,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-            Guard.For(() => request.RequestUri is null, new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request)));
-            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request)));
-
-            LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
-        }
+                => LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -151,13 +146,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-
-            LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
-        }
+                => LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -183,13 +172,30 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request message to track a HTTP dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
-            Guard.For(() => request.RequestUri is null, new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request)));
-            Guard.For(() => request.Method is null, new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request)));
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request message to track a HTTP dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
+            }
+            if (request.RequestUri is null)
+            {
+                throw new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request));
+            }
+            if (request.Method is null)
+            {
+                throw new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request));
+            }
+            if (statusCode < 100 && statusCode > 599)
+            {
+                throw new ArgumentOutOfRangeException("Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive", nameof(statusCode));
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerHttpDependencyExtensions.cs
@@ -121,7 +121,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
+        {
+            LogHttpDependency(logger, request, statusCode, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -146,7 +148,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
+        {
+            LogHttpDependency(logger, request, (int)statusCode, startTime, duration, dependencyId, context);
+        }
 
         /// <summary>
         /// Logs an HTTP dependency
@@ -176,22 +180,27 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+            
             if (request is null)
             {
                 throw new ArgumentNullException(nameof(request), "Requires a HTTP request message to track a HTTP dependency");
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the HTTP dependency operation");
             }
+
             if (request.RequestUri is null)
             {
                 throw new ArgumentException("Requires a HTTP request URI to track a HTTP dependency", nameof(request));
             }
+
             if (request.Method is null)
             {
                 throw new ArgumentException("Requires a HTTP request method to track a HTTP dependency", nameof(request));
             }
+
             if (statusCode < 100 && statusCode > 599)
             {
                 throw new ArgumentOutOfRangeException("Requires a valid HTTP response status code that's within the range of 100 to 599, inclusive", nameof(statusCode));

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Iot;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -31,9 +30,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the IoT Hub resource when tracking a IoT Hub dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the IoT Hub resource when tracking a IoT Hub dependency");
+            }
 
             LogIotHubDependency(logger, iotHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -57,9 +57,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the IoT Hub resource when tracking a IoT Hub dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the IoT Hub resource when tracking a IoT Hub dependency");
+            }
 
             LogIotHubDependency(logger, iotHubName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -83,13 +84,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the IoT Hub operation");
-
-            LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Iot Hub Dependency.
@@ -111,9 +106,14 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
-            Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to measure the duration of interaction with the IoT Hub dependency");
+            if (string.IsNullOrWhiteSpace(iotHubConnectionString))
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
+            }
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to measure the duration of interaction with the IoT Hub dependency");
+            }
 
             LogIotHubDependencyWithConnectionString(logger, iotHubConnectionString, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -140,8 +140,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track the IoT Hub dependency");
-            Guard.NotNullOrWhitespace(iotHubConnectionString, nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
+            if (string.IsNullOrWhiteSpace(iotHubConnectionString))
+            {
+                throw new ArgumentNullException(nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
+            }
 
             var result = IotHubConnectionStringParser.Parse(iotHubConnectionString);
             LogIotHubDependency(logger, iotHubName: result.HostName, isSuccessful, startTime, duration, dependencyId, context);
@@ -169,9 +171,18 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(iotHubName, nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the IoT Hub operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(iotHubName))
+            {
+                throw new ArgumentNullException(nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the IoT Hub operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerIotHubDependencyExtensions.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogIotHubDependency(logger, iotHubName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Iot Hub Dependency.
@@ -110,6 +112,7 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(iotHubConnectionString), "Requires an IoT Hub connection string to retrieve the IoT host name to track the IoT Hub dependency");
             }
+
             if (measurement is null)
             {
                 throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to measure the duration of interaction with the IoT Hub dependency");
@@ -175,10 +178,12 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(iotHubName))
             {
-                throw new ArgumentNullException(nameof(iotHubName), "Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency");
+                throw new ArgumentException("Requires a non-blank resource name of the IoT Hub resource to track a IoT Hub dependency", nameof(iotHubName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the IoT Hub operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -23,12 +22,7 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogCustomMetric(this ILogger logger, string name, double value, Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
-
-            LogCustomMetric(logger, name, value, DateTimeOffset.UtcNow, context);
-        }
+            => LogCustomMetric(logger, name, value, DateTimeOffset.UtcNow, context);
 
         /// <summary>
         /// Logs a custom metric
@@ -42,8 +36,14 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public static void LogCustomMetric(this ILogger logger, string name, double value, DateTimeOffset timestamp, Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name), "Requires a non-blank name to track a metric");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerMetricExtensions.cs
@@ -40,9 +40,10 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException(nameof(name), "Requires a non-blank name to track a metric");
+                throw new ArgumentException("Requires a non-blank name to track a metric", nameof(name));
             }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, response.StatusCode, startTime, duration, context);
+        {
+            LogRequest(logger, request, response.StatusCode, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -138,7 +140,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
+        {
+            LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -195,7 +199,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        {
+            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
+        }
 
         /// <summary>
         /// Logs an HTTP request.
@@ -262,18 +268,31 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (request is null)
             {
                 throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance tot track a HTTP request");
             }
+
             if (request.RequestUri is null)
             {
-                throw new ArgumentNullException(nameof(request), "Requires a request URI to retrieve the necessary request information");
+                throw new ArgumentException("Requires a request URI to retrieve the necessary request information", nameof(request));
             }
-            if (duration < TimeSpan.Zero)
+
+            if (request.RequestUri.Scheme is null)
             {
-                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
+                throw new ArgumentException("Requires a valid request URI scheme", nameof(request));
             }
+
+            if (request.RequestUri.Host is null)
+            {
+                throw new ArgumentException("Requires a valid request host", nameof(request));
+            }
+
+            if (duration < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
+                }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerRequestExtensions.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -39,10 +38,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, response, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -75,14 +74,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            LogRequest(logger, request, response.StatusCode, startTime, duration, context);
-        }
+                => LogRequest(logger, request, response.StatusCode, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -110,10 +102,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, response, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -146,14 +138,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(response, nameof(response), "Requires a HTTP response instance to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
-        }
+                => LogRequest(logger, request, response.StatusCode, operationName, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -179,9 +164,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -209,13 +195,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
-        }
+                => LogRequest(logger, request, responseStatusCode, operationName: null, startTime, duration, context);
 
         /// <summary>
         /// Logs an HTTP request.
@@ -241,9 +221,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an measurement instance to time the duration of the HTTP request");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a measurement instance to time the duration of the HTTP request");
+            }
 
             LogRequest(logger, request, responseStatusCode, operationName, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -277,10 +258,22 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNull(request, nameof(request), "Requires a HTTP request instance to track a HTTP request");
-            Guard.NotNull(request.RequestUri, nameof(request), "Requires a request URI to retrieve the necessary request information");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a HTTP request instance tot track a HTTP request");
+            }
+            if (request.RequestUri is null)
+            {
+                throw new ArgumentNullException(nameof(request), "Requires a request URI to retrieve the necessary request information");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, queueName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Queue, context);
+        {
+            LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, queueName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Queue, context);
+        }
 
         /// <summary>
         /// Logs an Azure Service Bus Dependency.
@@ -118,7 +120,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-                => LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, topicName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Topic, context);
+        {
+            LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, topicName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Topic, context);
+        }
 
         /// <summary>
         /// Logs an Azure Service Bus Dependency.
@@ -164,7 +168,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="entityType">Type of the Service Bus entity.</param>
         /// <param name="context">The context that provides more insights on the dependency that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="entityName"/> or <paramref name="serviceBusNamespaceEndpoint"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogServiceBusDependency(
             this ILogger logger,
@@ -181,14 +185,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(serviceBusNamespaceEndpoint))
             {
-                throw new ArgumentNullException(nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
+                throw new ArgumentException("Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency", nameof(serviceBusNamespaceEndpoint));
             }
+
             if (string.IsNullOrWhiteSpace(entityName))
             {
-                throw new ArgumentNullException(nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+                throw new ArgumentException("Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency", nameof(entityName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -34,10 +33,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank Azure Service Bus Queue name to track an Azure Service Bus Queue dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus Queue when tracking the Azure Service Bus Queue dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
+            }
 
             LogServiceBusQueueDependency(logger, serviceBusNamespaceEndpoint, queueName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -65,14 +64,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank Azure Service Bus Queue name to track an Azure Service Bus Queue dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Queue operation");
-
-            LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, queueName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Queue, context);
-        }
+                => LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, queueName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Queue, context);
 
         /// <summary>
         /// Logs an Azure Service Bus Dependency.
@@ -95,10 +87,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name to track an Azure Service Bus Topic dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus Topic when tracking the Azure Service Bus Topic dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
+            }
 
             LogServiceBusTopicDependency(logger, serviceBusNamespaceEndpoint, topicName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -126,14 +118,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             string dependencyId,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name to track an Azure Service Bus Topic dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus Topic operation");
-
-            LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, topicName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Topic, context);
-        }
+                => LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, topicName, isSuccessful, startTime, duration, dependencyId, ServiceBusEntityType.Topic, context);
 
         /// <summary>
         /// Logs an Azure Service Bus Dependency.
@@ -158,10 +143,10 @@ namespace Microsoft.Extensions.Logging
             ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Service Bus when tracking the Azure Service Bus dependency");
+            }
 
             LogServiceBusDependency(logger, serviceBusNamespaceEndpoint, entityName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, entityType, context);
         }
@@ -192,10 +177,22 @@ namespace Microsoft.Extensions.Logging
             ServiceBusEntityType entityType = ServiceBusEntityType.Unknown,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceEndpoint, nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(serviceBusNamespaceEndpoint))
+            {
+                throw new ArgumentNullException(nameof(serviceBusNamespaceEndpoint), "Requires a non-blank namespace where the Azure Service Bus entity is located to track an Azure Service Bus dependency");
+            }
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentNullException(nameof(entityName), "Requires a non-blank Azure Service Bus entity name to track an Azure Service Bus dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Service Bus operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.DependencyTracking.ServiceBus.EntityType] = entityType;

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -40,12 +39,14 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the topic request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the topic request");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires an Azure Service Bus topic name to track the topic request");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus topic request process latency duration");
+            if (string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+            }
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusTopicRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, topicName, subscriptionName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
         }
@@ -75,11 +76,14 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the topic request");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires an Azure Service Bus topic name to track the topic request");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus topic request process latency duration");
+            if (string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+            }
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusTopicRequest(logger, serviceBusNamespace, topicName, subscriptionName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
         }
@@ -114,12 +118,10 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the topic request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the topic request");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires an Azure Service Bus topic name to track the topic request");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus topic request operation");
+            if (string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName] = subscriptionName;
@@ -153,12 +155,6 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the topic request");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires an Azure Service Bus topic name to track the topic request");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires an Azure Service Bus subscription name on the to track the topic request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus topic request operation");
-
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
             context[ContextProperties.RequestTracking.ServiceBus.Topic.SubscriptionName] = subscriptionName;
 
@@ -188,11 +184,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the queue request");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires an Azure Service Bus queue name to track the queue request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus queue request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusQueueRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, queueName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
         }
@@ -218,10 +213,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires an Azure Service Bus queue name to track the queue request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus queue request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusQueueRequest(logger, serviceBusNamespace, queueName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, context);
         }
@@ -251,15 +246,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the queue request");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires an Azure Service Bus queue name to track the queue request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus queue request operation");
-
-            LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
-        }
+                => LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
 
         /// <summary>
         /// Logs an Azure Service Bus queue request.
@@ -284,14 +271,7 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires an Azure Service Bus queue name to track the queue request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus queue request operation");
-
-            LogServiceBusRequest(logger, serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
-        }
+                => LogServiceBusRequest(logger, serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
 
         /// <summary>
         /// Logs an Azure Service Bus request.
@@ -318,11 +298,10 @@ namespace Microsoft.Extensions.Logging
             ServiceBusEntityType entityType,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the queue request");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires an Azure Service Bus name to track the request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, entityType, context);
         }
@@ -350,10 +329,10 @@ namespace Microsoft.Extensions.Logging
             ServiceBusEntityType entityType,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the queue request");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires an Azure Service Bus name to track the request");
-            Guard.NotNull(measurement, nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
+            }
 
             LogServiceBusRequest(logger, serviceBusNamespace, entityName, operationName, isSuccessful, measurement.Elapsed, measurement.StartTime, entityType, context);
         }
@@ -385,15 +364,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             ServiceBusEntityType entityType,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the request");
-            Guard.NotNullOrWhitespace(serviceBusNamespaceSuffix, nameof(serviceBusNamespaceSuffix), "Requires an Azure Service Bus namespace suffix to track the request");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires an Azure Service Bus name to track the request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus request operation");
-
-            LogServiceBusRequest(logger, serviceBusNamespace + serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, duration, startTime, entityType, context);
-        }
+                => LogServiceBusRequest(logger, serviceBusNamespace + serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, duration, startTime, entityType, context);
 
         /// <summary>
         /// Logs an Azure Service Bus request.
@@ -421,10 +392,22 @@ namespace Microsoft.Extensions.Logging
             ServiceBusEntityType entityType,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the request");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires an Azure Service Bus name to track the request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Service Bus request operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(serviceBusNamespace))
+            {
+                throw new ArgumentNullException(nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the request");
+            }
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentNullException(nameof(entityName), "Requires an Azure Service Bus name to track the request");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Service Bus request operation");
+            }
 
             if (string.IsNullOrWhiteSpace(operationName))
             {

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerServiceBusRequestExtensions.cs
@@ -41,8 +41,9 @@ namespace Microsoft.Extensions.Logging
         {
             if (string.IsNullOrWhiteSpace(subscriptionName))
             {
-                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+                throw new ArgumentException("Requires an Azure Service Bus subscription name to track the topic request", nameof(subscriptionName));
             }
+
             if (measurement is null)
             {
                 throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
@@ -78,8 +79,9 @@ namespace Microsoft.Extensions.Logging
         {
             if (string.IsNullOrWhiteSpace(subscriptionName))
             {
-                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+                throw new ArgumentException("Requires an Azure Service Bus subscription name to track the topic request", nameof(subscriptionName));
             }
+
             if (measurement is null)
             {
                 throw new ArgumentNullException(nameof(measurement), "Requires an instance to measure the Azure Service Bus request process latency duration");
@@ -120,7 +122,7 @@ namespace Microsoft.Extensions.Logging
         {
             if (string.IsNullOrWhiteSpace(subscriptionName))
             {
-                throw new ArgumentNullException(nameof(subscriptionName), "Requires an Azure Service Bus subscription name to track the topic request");
+                throw new ArgumentException("Requires an Azure Service Bus subscription name to track the topic request", nameof(subscriptionName));
             }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
@@ -246,7 +248,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
-                => LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
+        {
+            LogServiceBusRequestWithSuffix(logger, serviceBusNamespace, serviceBusNamespaceSuffix, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
+        }
 
         /// <summary>
         /// Logs an Azure Service Bus queue request.
@@ -271,7 +275,9 @@ namespace Microsoft.Extensions.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             Dictionary<string, object> context = null)
-                => LogServiceBusRequest(logger, serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
+        {
+            LogServiceBusRequest(logger, serviceBusNamespace, queueName, operationName, isSuccessful, duration, startTime, ServiceBusEntityType.Queue, context);
+        }
 
         /// <summary>
         /// Logs an Azure Service Bus request.
@@ -364,7 +370,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             ServiceBusEntityType entityType,
             Dictionary<string, object> context = null)
-                => LogServiceBusRequest(logger, serviceBusNamespace + serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, duration, startTime, entityType, context);
+        {
+            LogServiceBusRequest(logger, serviceBusNamespace + serviceBusNamespaceSuffix, entityName, operationName, isSuccessful, duration, startTime, entityType, context);
+        }
 
         /// <summary>
         /// Logs an Azure Service Bus request.
@@ -396,14 +404,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(serviceBusNamespace))
             {
-                throw new ArgumentNullException(nameof(serviceBusNamespace), "Requires an Azure Service Bus namespace to track the request");
+                throw new ArgumentException("Requires an Azure Service Bus namespace to track the request", nameof(serviceBusNamespace));
             }
+
             if (string.IsNullOrWhiteSpace(entityName))
             {
-                throw new ArgumentNullException(nameof(entityName), "Requires an Azure Service Bus name to track the request");
+                throw new ArgumentNullException("Requires an Azure Service Bus name to track the request", nameof(entityName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Service Bus request operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
@@ -149,9 +149,10 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
+                throw new ArgumentException("Requires a SQL connection string to retrieve database information while tracking the SQL dependency", nameof(connectionString));
             }
 
             var result = SqlConnectionStringParser.Parse(connectionString);

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerSqlDependencyExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Core.Sql;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -39,10 +38,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
-            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking a SQL dependency");
+            }
 
             LogSqlDependency(logger, serverName, databaseName, sqlCommand, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -75,11 +74,6 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(serverName, nameof(serverName), "Requires a non-blank SQL server name to track a SQL dependency");
-            Guard.NotNullOrWhitespace(databaseName, nameof(databaseName), "Requires a non-blank SQL database name to track a SQL dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the SQL dependency operation");
-
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 
             logger.LogWarning(MessageFormats.SqlDependencyFormat, new DependencyLogEntry(
@@ -118,9 +112,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking an SQL dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to measure the latency of the SQL storage when tracking a SQL dependency");
+            }
 
             LogSqlDependencyWithConnectionString(logger, connectionString, sqlCommand, operationName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -150,8 +145,14 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires a SQL connection string to retrieve database information while tracking the SQL dependency");
+            }
 
             var result = SqlConnectionStringParser.Parse(connectionString);
             

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Logging
@@ -32,10 +31,10 @@ namespace Microsoft.Extensions.Logging
             DurationMeasurement measurement,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Table storage when tracking an Azure Table storage dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Table storage when tracking an Azure Table storage dependency");
+            }
 
             LogTableStorageDependency(logger, accountName, tableName, isSuccessful, measurement.StartTime, measurement.Elapsed, context);
         }
@@ -61,10 +60,10 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNull(measurement, nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Table storage when tracking an Azure Table storage dependency");
+            if (measurement is null)
+            {
+                throw new ArgumentNullException(nameof(measurement), "Requires a dependency measurement instance to track the latency of the Azure Table storage when tracking an Azure Table storage dependency");
+            }
 
             LogTableStorageDependency(logger, accountName, tableName, isSuccessful, measurement.StartTime, measurement.Elapsed, dependencyId, context);
         }
@@ -90,14 +89,7 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-        {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
-
-            LogTableStorageDependency(logger, accountName, tableName, isSuccessful, startTime, duration, dependencyId: null, context);
-        }
+                => LogTableStorageDependency(logger, accountName, tableName, isSuccessful, startTime, duration, dependencyId: null, context);
 
         /// <summary>
         /// Logs an Azure Table Storage Dependency.
@@ -123,10 +115,22 @@ namespace Microsoft.Extensions.Logging
             string dependencyId,
             Dictionary<string, object> context = null)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track telemetry");
-            Guard.NotNullOrWhitespace(accountName, nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotNullOrWhitespace(tableName, nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
+            }
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
+            }
+            if (string.IsNullOrWhiteSpace(tableName))
+            {
+                throw new ArgumentNullException(nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Table storage operation");
+            }
 
             context = context is null ? new Dictionary<string, object>() : new Dictionary<string, object>(context);
 

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerTableStorageDependencyExtensions.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Extensions.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             Dictionary<string, object> context = null)
-                => LogTableStorageDependency(logger, accountName, tableName, isSuccessful, startTime, duration, dependencyId: null, context);
+        {
+            LogTableStorageDependency(logger, accountName, tableName, isSuccessful, startTime, duration, dependencyId: null, context);
+        }
 
         /// <summary>
         /// Logs an Azure Table Storage Dependency.
@@ -102,7 +104,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="duration">Duration of the operation</param>
         /// <param name="dependencyId">The ID of the dependency to link as parent ID.</param>
         /// <param name="context">Context that provides more insights on the dependency that was measured</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>nul</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or <paramref name="tableName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static void LogTableStorageDependency(
@@ -119,14 +121,17 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(logger), "Requires a logger instance to track telemetry");
             }
+
             if (string.IsNullOrWhiteSpace(accountName))
             {
-                throw new ArgumentNullException(nameof(accountName), "Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency");
+                throw new ArgumentException("Requires a non-blank account name for the Azure Table storage resource to track an Azure Table storage dependency", nameof(accountName));
             }
+
             if (string.IsNullOrWhiteSpace(tableName))
             {
-                throw new ArgumentNullException(nameof(tableName), "Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency");
+                throw new ArgumentException("Requires a non-blank table name in the Azure Table storage resource to track an Azure Table storage dependency", nameof(tableName));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the Azure Table storage operation");

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
@@ -1,5 +1,4 @@
-﻿using GuardNet;
-
+﻿
 // ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
@@ -16,7 +15,10 @@ namespace System.Collections.Generic
         /// <param name="propertyKey">Key of the dictionary entry to return</param>
         public static TValue GetValueOrDefault<TValue>(this IReadOnlyDictionary<string, TValue> dictionary, string propertyKey)
         {
-            Guard.NotNull(dictionary, nameof(dictionary));
+            if (dictionary is null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
 
             if (dictionary.TryGetValue(propertyKey, out TValue foundValue))
             {

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
@@ -13,6 +13,7 @@ namespace System.Collections.Generic
         /// </summary>
         /// <param name="dictionary">Dictionary containing data</param>
         /// <param name="propertyKey">Key of the dictionary entry to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="dictionary"/> is <c>null</c></exception>
         public static TValue GetValueOrDefault<TValue>(this IReadOnlyDictionary<string, TValue> dictionary, string propertyKey)
         {
             if (dictionary is null)

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
@@ -13,18 +13,19 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         /// </summary>
         /// <param name="connectionString">The connection string based on the hostname of the IoT Hub service.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        /// <exception cref="FormatException">Thrown when the <c>HostName</c> of the connection string is blank.</exception>
         internal static IotHubConnectionStringParserResult Parse(string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires a non-blank connection string based on the hostname of the IoT Hub service");
+                throw new ArgumentException("Requires a non-blank connection string based on the hostname of the IoT Hub service", nameof(connectionString));
             }
 
             string hostNameProperty =
                 connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
                                 .FirstOrDefault(part => part.StartsWith("HostName", StringComparison.OrdinalIgnoreCase));
 
-            if (hostNameProperty is null)
+            if (string.IsNullOrWhiteSpace(hostNameProperty))
             {
                 throw new FormatException(
                     "Cannot parse IoT Hub connection string because cannot find 'HostName' in IoT Hub connection string");

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Iot
 {
@@ -16,7 +15,10 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         internal static IotHubConnectionStringParserResult Parse(string connectionString)
         {
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank connection string based on the hostname of the IoT Hub service");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires a non-blank connection string based on the hostname of the IoT Hub service");
+            }
 
             string hostNameProperty =
                 connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
@@ -16,8 +16,9 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         {
             if (string.IsNullOrWhiteSpace(hostName))
             {
-                throw new ArgumentNullException(nameof(hostName), "Requires a non-blank fully-qualified DNS hostname of the IoT Hub service");
+                throw new ArgumentException("Requires a non-blank fully-qualified DNS hostname of the IoT Hub service", nameof(hostName));
             }
+            
             HostName = hostName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Iot
 {
@@ -15,7 +14,10 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         /// <exception cref="ArgumentException">Thrown when the <paramref name="hostName"/> is blank.</exception>
         internal IotHubConnectionStringParserResult(string hostName)
         {
-            Guard.NotNullOrWhitespace(hostName, nameof(hostName), "Requires a non-blank fully-qualified DNS hostname of the IoT Hub service");
+            if (string.IsNullOrWhiteSpace(hostName))
+            {
+                throw new ArgumentNullException(nameof(hostName), "Requires a non-blank fully-qualified DNS hostname of the IoT Hub service");
+            }
             HostName = hostName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -36,9 +35,6 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             bool isSuccessful,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-            
             DependencyType = dependencyType;
             DependencyName = dependencyName;
             DependencyData = dependencyData;
@@ -80,8 +76,14 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             bool isSuccessful,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+            if (string.IsNullOrWhiteSpace(dependencyType))
+            {
+                throw new ArgumentNullException(nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the dependency operation");
+            }
 
             DependencyId = dependencyId;
             DependencyType = dependencyType;

--- a/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
@@ -78,8 +78,9 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         {
             if (string.IsNullOrWhiteSpace(dependencyType))
             {
-                throw new ArgumentNullException(nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
+                throw new ArgumentException("Requires a non-blank custom dependency type when tracking the custom dependency", nameof(dependencyType));
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the dependency operation");

--- a/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
@@ -19,7 +19,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException(nameof(name), "Requires a non-blank event name to track a custom event");
+                throw new ArgumentException("Requires a non-blank event name to track a custom event", nameof(name));
             }
 
             EventName = name;

--- a/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -18,7 +17,10 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public EventLogEntry(string name, IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name), "Requires a non-blank event name to track a custom event");
+            }
 
             EventName = name;
             Context = context ?? new Dictionary<string, object>();

--- a/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
@@ -22,7 +22,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException(nameof(name), "Requires a non-blank name to track a metric");
+                throw new ArgumentException("Requires a non-blank name to track a metric", nameof(name));
             }
             
             MetricName = name;

--- a/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -21,7 +20,10 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public MetricLogEntry(string name, double value, DateTimeOffset timestamp, IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name), "Requires a non-blank name to track a metric");
+            }
             
             MetricName = name;
             MetricValue = value;

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -39,14 +39,17 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             {
                 throw new ArgumentException("Requires a HTTP request host name without whitespace", nameof(host));
             }
+
             if (string.IsNullOrWhiteSpace(operationName))
             {
-                throw new ArgumentNullException(nameof(operationName), "Requires a non-blank operation name");
+                throw new ArgumentException("Requires a non-blank operation name", nameof(operationName));
             }
+
             if (statusCode < 100 || statusCode > 599)
             {
                 throw new ArgumentOutOfRangeException(nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
             }
+
             if (duration < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
@@ -76,6 +79,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <param name="startTime">The time the request was received.</param>
         /// <param name="duration">The duration of the processing of the request.</param>
         /// <param name="context">The context that provides more insights on the HTTP request that was tracked.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the <paramref name="statusCode"/> is outside the 0-999 range inclusively,
         ///     or the <paramref name="duration"/> is a negative time range.
@@ -90,16 +94,18 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             IDictionary<string, object> context)
-                => new RequestLogEntry(
-                    method,
-                    $"{scheme}://{host}",
-                    uri,
-                    operationName ?? $"{method} {uri}",
-                    statusCode,
-                    RequestSourceSystem.Http,
-                    startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
-                    duration,
-                    context);
+        {
+            return new RequestLogEntry(
+                            method,
+                            $"{scheme}://{host}",
+                            uri,
+                            operationName ?? $"{method} {uri}",
+                            statusCode,
+                            RequestSourceSystem.Http,
+                            startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
+                            duration,
+                            context);
+        }
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for Azure Service Bus requests.
@@ -109,6 +115,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <param name="duration">The duration it took to process the Azure Service Bus request.</param>
         /// <param name="startTime">The time when the request was received.</param>
         /// <param name="context">The telemetry context that provides more insights on the Azure Service Bus request.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static RequestLogEntry CreateForServiceBus(
             string operationName,
@@ -116,7 +123,9 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-                => CreateWithoutHttpRequest(RequestSourceSystem.AzureServiceBus, operationName, isSuccessful, duration, startTime, context);
+        {
+            return CreateWithoutHttpRequest(RequestSourceSystem.AzureServiceBus, operationName, isSuccessful, duration, startTime, context);
+        }
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for Azure EventHubs requests.
@@ -126,6 +135,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <param name="duration">The duration it took to process the Azure EventHubs request.</param>
         /// <param name="startTime">The time when the request was received.</param>
         /// <param name="context">The telemetry context that provides more insights on the Azure EventHubs request.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static RequestLogEntry CreateForEventHubs(
             string operationName,
@@ -133,7 +143,9 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-                => CreateWithoutHttpRequest(RequestSourceSystem.AzureEventHubs, operationName, isSuccessful, duration, startTime, context);
+        {
+            return CreateWithoutHttpRequest(RequestSourceSystem.AzureEventHubs, operationName, isSuccessful, duration, startTime, context);
+        }
 
         private static RequestLogEntry CreateWithoutHttpRequest(
             RequestSourceSystem source,
@@ -142,16 +154,18 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-                => new RequestLogEntry(
-                    method: "<not-applicable>",
-                    host: "<not-applicable>",
-                    uri: "<not-applicable>",
-                    operationName: operationName,
-                    statusCode: isSuccessful ? 200 : 500,
-                    sourceSystem: source,
-                    requestTime: startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
-                    duration: duration,
-                    context: context);
+        {
+            return new RequestLogEntry(
+                            method: "<not-applicable>",
+                            host: "<not-applicable>",
+                            uri: "<not-applicable>",
+                            operationName: operationName,
+                            statusCode: isSuccessful ? 200 : 500,
+                            sourceSystem: source,
+                            requestTime: startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
+                            duration: duration,
+                            context: context);
+        }
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for custom requests.
@@ -162,6 +176,8 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <param name="duration">The duration it took to process the custom request.</param>
         /// <param name="startTime">The time when the request was received.</param>
         /// <param name="context">The telemetry context that provides more insights on the custom request.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="requestSource"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="operationName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public static RequestLogEntry CreateForCustomRequest(
             string requestSource,
@@ -173,7 +189,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         {
             if (string.IsNullOrWhiteSpace(requestSource))
             {
-                throw new ArgumentNullException(nameof(requestSource), "Requires a non-blank request source to identify the caller");
+                throw new ArgumentException("Requires a non-blank request source to identify the caller", nameof(requestSource));
             }
 
             return CreateWithoutHttpRequest(requestSource, operationName, isSuccessful, duration, startTime, context);

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -36,11 +35,22 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             IDictionary<string, object> context)
         {
-            Guard.For<ArgumentException>(() => host?.Contains(" ") is true, "Requires a HTTP request host name without whitespace");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            if (host?.Contains(" ") is true)
+            {
+                throw new ArgumentException("Requires a HTTP request host name without whitespace", nameof(host));
+            }
+            if (string.IsNullOrWhiteSpace(operationName))
+            {
+                throw new ArgumentNullException(nameof(operationName), "Requires a non-blank operation name");
+            }
+            if (statusCode < 100 || statusCode > 599)
+            {
+                throw new ArgumentOutOfRangeException(nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
+            }
+            if (duration < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(duration), "Requires a positive time duration of the request operation");
+            }
 
             RequestMethod = method;
             RequestHost = host;
@@ -80,22 +90,16 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             TimeSpan duration,
             IDictionary<string, object> context)
-        {
-            Guard.NotLessThan(statusCode, 0, nameof(statusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(statusCode, 999, nameof(statusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            return new RequestLogEntry(
-                method,
-                $"{scheme}://{host}",
-                uri,
-                operationName ?? $"{method} {uri}",
-                statusCode,
-                RequestSourceSystem.Http,
-                startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
-                duration,
-                context);
-        }
+                => new RequestLogEntry(
+                    method,
+                    $"{scheme}://{host}",
+                    uri,
+                    operationName ?? $"{method} {uri}",
+                    statusCode,
+                    RequestSourceSystem.Http,
+                    startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
+                    duration,
+                    context);
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for Azure Service Bus requests.
@@ -112,11 +116,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-        {
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-            
-            return CreateWithoutHttpRequest(RequestSourceSystem.AzureServiceBus, operationName, isSuccessful, duration, startTime, context);
-        }
+                => CreateWithoutHttpRequest(RequestSourceSystem.AzureServiceBus, operationName, isSuccessful, duration, startTime, context);
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for Azure EventHubs requests.
@@ -133,12 +133,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-        {
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-
-            return CreateWithoutHttpRequest(RequestSourceSystem.AzureEventHubs, operationName, isSuccessful, duration, startTime, context);
-        }
+                => CreateWithoutHttpRequest(RequestSourceSystem.AzureEventHubs, operationName, isSuccessful, duration, startTime, context);
 
         private static RequestLogEntry CreateWithoutHttpRequest(
             RequestSourceSystem source,
@@ -147,18 +142,16 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             DateTimeOffset startTime,
             IDictionary<string, object> context)
-        {
-            return new RequestLogEntry(
-                method: "<not-applicable>",
-                host: "<not-applicable>",
-                uri: "<not-applicable>",
-                operationName: operationName,
-                statusCode: isSuccessful ? 200 : 500,
-                sourceSystem: source,
-                requestTime: startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
-                duration: duration,
-                context: context);
-        }
+                => new RequestLogEntry(
+                    method: "<not-applicable>",
+                    host: "<not-applicable>",
+                    uri: "<not-applicable>",
+                    operationName: operationName,
+                    statusCode: isSuccessful ? 200 : 500,
+                    sourceSystem: source,
+                    requestTime: startTime.ToString(FormatSpecifiers.InvariantTimestampFormat),
+                    duration: duration,
+                    context: context);
 
         /// <summary>
         /// Creates an <see cref="RequestLogEntry"/> instance for custom requests.
@@ -178,9 +171,10 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request duration");
+            if (string.IsNullOrWhiteSpace(requestSource))
+            {
+                throw new ArgumentNullException(nameof(requestSource), "Requires a non-blank request source to identify the caller");
+            }
 
             return CreateWithoutHttpRequest(requestSource, operationName, isSuccessful, duration, startTime, context);
         }
@@ -209,27 +203,27 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the HTTP method of the request.
         /// </summary>
         public string RequestMethod { get; }
-        
+
         /// <summary>
         /// Gets the host that was requested.
         /// </summary>
         public string RequestHost { get; }
-        
+
         /// <summary>
         /// Gets ths URI of the request.
         /// </summary>
         public string RequestUri { get; }
-        
+
         /// <summary>
         /// Gets the HTTP response status code that was returned by the service.
         /// </summary>
         public int ResponseStatusCode { get; }
-        
+
         /// <summary>
         /// Gets the duration of the processing of the request.
         /// </summary>
         public TimeSpan RequestDuration { get; }
-        
+
         /// <summary>
         /// Gets the date when the request occurred.
         /// </summary>
@@ -262,7 +256,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         public override string ToString()
         {
             var contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
-            
+
             if (SourceSystem is RequestSourceSystem.Http)
             {
                 return $"{RequestMethod} {RequestHost}/{RequestUri} from {OperationName} completed with {ResponseStatusCode} in {RequestDuration} at {RequestTime} - (Context: {contextFormatted})";
@@ -270,7 +264,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
 
             string source = DetermineSource();
             bool isSuccessful = ResponseStatusCode is 200;
-            
+
             return $"{source} from {OperationName} completed in {RequestDuration} at {RequestTime} - (IsSuccessful: {isSuccessful}, Context: {contextFormatted})";
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
@@ -20,7 +20,7 @@ namespace Arcus.Observability.Telemetry.Core.Sql
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires a non-blank SQL connection string to retrieve specific SQL properties");
+                throw new ArgumentException("Requires a non-blank SQL connection string to retrieve specific SQL properties", nameof(connectionString));
             }
 
             string[] parts = 

--- a/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Sql
 {
@@ -19,7 +18,10 @@ namespace Arcus.Observability.Telemetry.Core.Sql
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         internal static SqlConnectionStringParserResult Parse(string connectionString)
         {
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank SQL connection string to retrieve specific SQL properties");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires a non-blank SQL connection string to retrieve specific SQL properties");
+            }
 
             string[] parts = 
                 connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)

--- a/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParserResult.cs
@@ -1,6 +1,4 @@
-﻿using GuardNet;
-
-namespace Arcus.Observability.Telemetry.Core.Sql
+﻿namespace Arcus.Observability.Telemetry.Core.Sql
 {
     /// <summary>
     /// Represents the result of the <see cref="SqlConnectionStringParser"/> when parsing a SQL connection string.

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/ApplicationEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/ApplicationEnricher.cs
@@ -34,11 +34,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         {
             if (string.IsNullOrWhiteSpace(componentName))
             {
-                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank application component name");
+                throw new ArgumentException("Requires a non-blank application component name", nameof(componentName));
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the component name", nameof(propertyName));
             }
 
             _componentValue = componentName;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/ApplicationEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/ApplicationEnricher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Enrichers;
 using Serilog.Events;
@@ -33,8 +32,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <exception cref="ArgumentException">Thrown when the <paramref name="componentName"/> or <paramref name="propertyName"/> is blank.</exception>
         public ApplicationEnricher(string componentName, string propertyName)
         {
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank application component name");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+            if (string.IsNullOrWhiteSpace(componentName))
+            {
+                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank application component name");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+            }
 
             _componentValue = componentName;
             _propertyName = propertyName;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
 {
@@ -22,7 +21,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             get => _operationIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information operation ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information operation ID");
+                }
+
                 _operationIdPropertyName = value;
             }
         }
@@ -36,7 +39,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information transaction ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information transaction ID");
+                }
+
                 _transactionIdPropertyName = value;
             }
         }
@@ -50,7 +57,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             get => _operationParentIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information parent operation ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information parent operation ID");
+                }
+
                 _operationParentIdPropertyName = value;
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Configuration/CorrelationInfoEnricherOptions.cs
@@ -23,7 +23,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information operation ID");
+                    throw new ArgumentException("Requires a non-blank property name to enrich the log event with the correlation information operation ID", nameof(value));
                 }
 
                 _operationIdPropertyName = value;
@@ -41,7 +41,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information transaction ID");
+                    throw new ArgumentException("Requires a non-blank property name to enrich the log event with the correlation information transaction ID", nameof(value));
                 }
 
                 _transactionIdPropertyName = value;
@@ -59,7 +59,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information parent operation ID");
+                    throw new ArgumentException("Requires a non-blank property name to enrich the log event with the correlation information parent operation ID", nameof(value));
                 }
 
                 _operationParentIdPropertyName = value;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
@@ -2,7 +2,6 @@
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -53,7 +52,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor, 
             CorrelationInfoEnricherOptions options)
         {
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to enrich the log events with correlation information");
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requres a correlation accessor to enrich the log events with correlation information");
+            }
 
             Options = options ?? new CorrelationInfoEnricherOptions();
             CorrelationInfoAccessor = correlationInfoAccessor;
@@ -77,8 +79,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logEvent"/> or the <paramref name="propertyFactory"/> is <c>null</c>.</exception>
         public virtual void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
-            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
+            }
+            if (propertyFactory is null)
+            {
+                throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            }
 
             TCorrelationInfo correlationInfo = CorrelationInfoAccessor.GetCorrelationInfo();
             if (correlationInfo is null)
@@ -100,9 +108,18 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// </exception>
         protected virtual void EnrichCorrelationInfo(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, TCorrelationInfo correlationInfo)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
-            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires the correlation information to enrich the log event");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
+            }
+            if (propertyFactory is null)
+            {
+                throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            }
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo), "Requires the correlation information to enrich the log event");
+            }
             
             EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.OperationIdPropertyName, correlationInfo.OperationId);
             EnrichLogPropertyIfPresent(logEvent, propertyFactory, Options.TransactionIdPropertyName, correlationInfo.TransactionId);
@@ -120,9 +137,18 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
         protected void EnrichLogPropertyIfPresent(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, string propertyName, string propertyValue)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a log event to enrich the correlation information");
-            Guard.NotNull(propertyFactory, nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank name for the correlation log property");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
+            }
+            if (propertyFactory is null)
+            {
+                throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank name for the correlation log property");
+            }
             
             if (!String.IsNullOrEmpty(propertyValue))
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/CorrelationInfoEnricher.cs
@@ -83,6 +83,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
             }
+
             if (propertyFactory is null)
             {
                 throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
@@ -112,10 +113,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
             }
+
             if (propertyFactory is null)
             {
                 throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
             }
+
             if (correlationInfo is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfo), "Requires the correlation information to enrich the log event");
@@ -141,10 +144,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a log event to enrich the correlation information");
             }
+            
             if (propertyFactory is null)
             {
                 throw new ArgumentNullException(nameof(propertyFactory), "Requires a log event property factory to create properties for the correlation information");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank name for the correlation log property");

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventExtensions.cs
@@ -1,6 +1,6 @@
-﻿using GuardNet;
+﻿// ReSharper disable once CheckNamespace
+using System;
 
-// ReSharper disable once CheckNamespace
 namespace Serilog.Events
 {
     /// <summary>
@@ -19,7 +19,10 @@ namespace Serilog.Events
         /// </returns>
         public static bool ContainsProperty(this LogEvent logEvent, string name, string value)
         {
-            Guard.NotNull(logEvent, nameof(logEvent));
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent));
+            }
 
             if (logEvent.Properties.TryGetValue(name, out LogEventPropertyValue actual))
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventExtensions.cs
@@ -14,6 +14,7 @@ namespace Serilog.Events
         /// <param name="logEvent">The event on which the property should be present.</param>
         /// <param name="name">The unique name of the property that should be present in the <paramref name="logEvent"/>.</param>
         /// <param name="value">The simple value of the property that should be present for the given <paramref name="name"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="logEvent"/> is <c>null</c></exception>
         /// <returns>
         ///     [true] if the specified <paramref name="logEvent"/> contains the log property with the specified <paramref name="name"/> and the simple <paramref name="value"/>; [false] otherwise.
         /// </returns>

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Serilog.Events
@@ -23,7 +22,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">Key of the property to return</param>
         public static string GetAsRawString(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
             return logEventPropertyValue?.ToDecentString();
@@ -37,7 +39,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">The key of the property to return.</param>
         public static double GetAsDouble(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
             string rawDouble = logEventPropertyValue?.ToDecentString();
@@ -59,7 +64,10 @@ namespace Serilog.Events
         /// <param name="propertyDictionaryValues">Found information for the given property key</param>
         public static bool TryGetAsDictionary(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey, out IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> propertyDictionaryValues)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var propertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
             if (propertyValue == null || propertyValue is DictionaryValue == false)
@@ -80,7 +88,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">Key of the property to return</param>
         public static IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> GetAsDictionary(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var valueFound = TryGetAsDictionary(eventPropertyValues, propertyKey, out var propertyDictionaryValues);
             if (valueFound == false)
@@ -108,8 +119,14 @@ namespace Serilog.Events
         public static TEnum? GetAsEnum<TEnum>(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
             where TEnum : struct
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues), "Requires a series of event properties to retrieve a Serilog event property as a enumeration representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a enumeration representation");
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues), "Requires a series of event properties to retrieve a Serilog event property as a enumeration representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentNullException(nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a enumeration representation");
+            }
 
             LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
             if (logEventPropertyValue is null)
@@ -141,7 +158,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">Key of the property to return</param>
         public static DateTimeOffset GetAsDateTimeOffset(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var logEventPropertyValue = eventPropertyValues.GetAsRawString(propertyKey);
             var value = DateTimeOffset.Parse(logEventPropertyValue, CultureInfo.InvariantCulture);
@@ -155,7 +175,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">Key of the property to return</param>
         public static TimeSpan GetAsTimeSpan(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var logEventPropertyValue = eventPropertyValues.GetAsRawString(propertyKey);
             var value = TimeSpan.Parse(logEventPropertyValue);
@@ -169,7 +192,10 @@ namespace Serilog.Events
         /// <param name="propertyKey">Key of the property to return</param>
         public static bool GetAsBool(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
-            Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
+            if (eventPropertyValues is null)
+            {
+                throw new ArgumentNullException(nameof(eventPropertyValues));
+            }
 
             var logEventPropertyValue = eventPropertyValues.GetAsRawString(propertyKey);
             var value = bool.Parse(logEventPropertyValue);
@@ -187,7 +213,10 @@ namespace Serilog.Events
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         public static StructureValue GetAsStructureValue(this IReadOnlyDictionary<string, LogEventPropertyValue> properties, string propertyKey)
         {
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve the structure value from the log event");
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentNullException(nameof(propertyKey), "Requires a non-blank property key to retrieve the structure value from the log event");
+            }
             
             if (properties is null)
             {
@@ -210,7 +239,10 @@ namespace Serilog.Events
         /// <param name="logEventPropertyValue">Event property value to provide a string representation</param>
         public static string ToDecentString(this LogEventPropertyValue logEventPropertyValue)
         {
-            Guard.NotNull(logEventPropertyValue, nameof(logEventPropertyValue));
+            if (logEventPropertyValue is null)
+            {
+                throw new ArgumentNullException(nameof(logEventPropertyValue));
+            }
 
             if (logEventPropertyValue is ScalarValue scalar)
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -20,6 +20,7 @@ namespace Serilog.Events
         /// <remarks>The built-in <c>ToString</c> wraps the string with quotes</remarks>
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c></exception>
         public static string GetAsRawString(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -37,6 +38,7 @@ namespace Serilog.Events
         /// <remarks>The built-in <c>ToString</c> wraps the <c>string</c> with quotes.</remarks>
         /// <param name="eventPropertyValues">The Event property values to provide as a <c>string</c> representation.</param>
         /// <param name="propertyKey">The key of the property to return.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c></exception>
         public static double GetAsDouble(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -62,6 +64,7 @@ namespace Serilog.Events
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
         /// <param name="propertyDictionaryValues">Found information for the given property key</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c></exception>
         public static bool TryGetAsDictionary(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey, out IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> propertyDictionaryValues)
         {
             if (eventPropertyValues is null)
@@ -86,6 +89,8 @@ namespace Serilog.Events
         /// <remarks>The built-in <c>ToString</c> wraps the string with quotes</remarks>
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c></exception>
+        /// <exception cref="NotSupportedException">Thrown when the value found with <paramref name="propertyKey"/> is <c>null</c> or not of type <see cref="DictionaryValue"/></exception>
         public static IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> GetAsDictionary(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -123,9 +128,10 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(eventPropertyValues), "Requires a series of event properties to retrieve a Serilog event property as a enumeration representation");
             }
+
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
-                throw new ArgumentNullException(nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a enumeration representation");
+                throw new ArgumentException("Requires a non-blank property to retrieve a Serilog event property as a enumeration representation", nameof(propertyKey));
             }
 
             LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
@@ -156,6 +162,7 @@ namespace Serilog.Events
         /// </summary>
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c>.</exception>
         public static DateTimeOffset GetAsDateTimeOffset(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -173,6 +180,7 @@ namespace Serilog.Events
         /// </summary>
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c>.</exception>
         public static TimeSpan GetAsTimeSpan(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -190,6 +198,7 @@ namespace Serilog.Events
         /// </summary>
         /// <param name="eventPropertyValues">Event property value to provide a string representation</param>
         /// <param name="propertyKey">Key of the property to return</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="eventPropertyValues"/> is <c>null</c>.</exception>
         public static bool GetAsBool(this IReadOnlyDictionary<string, LogEventPropertyValue> eventPropertyValues, string propertyKey)
         {
             if (eventPropertyValues is null)
@@ -215,7 +224,7 @@ namespace Serilog.Events
         {
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
-                throw new ArgumentNullException(nameof(propertyKey), "Requires a non-blank property key to retrieve the structure value from the log event");
+                throw new ArgumentException("Requires a non-blank property key to retrieve the structure value from the log event", nameof(propertyKey));
             }
             
             if (properties is null)
@@ -237,6 +246,7 @@ namespace Serilog.Events
         /// </summary>
         /// <remarks>The built-in <c>ToString</c> wraps the string with quotes</remarks>
         /// <param name="logEventPropertyValue">Event property value to provide a string representation</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="logEventPropertyValue"/> is <c>null</c>.</exception>
         public static string ToDecentString(this LogEventPropertyValue logEventPropertyValue)
         {
             if (logEventPropertyValue is null)

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Reflection.Metadata;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Configuration;
 
@@ -25,8 +25,14 @@ namespace Serilog
         /// <exception cref="InvalidOperationException">Thrown when the process executable in the default application domain cannot be retrieved.</exception>
         public static LoggerConfiguration WithVersion(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName = VersionEnricher.DefaultPropertyName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            }
 
             return enrichmentConfiguration.With(new VersionEnricher(propertyName));
         }
@@ -44,9 +50,18 @@ namespace Serilog
             IAppVersion appVersion,
             string propertyName = VersionEnricher.DefaultPropertyName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
-            Guard.NotNull(appVersion, nameof(appVersion), "Requires an application version implementation to enrich the log event with the application version");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
+            }
+            if (appVersion is null)
+            {
+                throw new ArgumentNullException(nameof(appVersion), "Requires an application version implementation to enrich the log event with the application version");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            }
 
             return enrichmentConfiguration.With(new VersionEnricher(appVersion, propertyName));
         }
@@ -64,10 +79,19 @@ namespace Serilog
             IServiceProvider serviceProvider,
             string propertyName = VersionEnricher.DefaultPropertyName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppVersion)}' implementations");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
-
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppVersion)}' implementations");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            }
+            
             IAppVersion appVersion = serviceProvider.GetService<IAppVersion>() ?? new AssemblyAppVersion();
             return enrichmentConfiguration.With(new VersionEnricher(appVersion, propertyName));
         }
@@ -85,9 +109,18 @@ namespace Serilog
             string componentName, 
             string propertyName = ApplicationEnricher.ComponentName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Require an enrichment configuration to add the application component enricher");
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank application component name");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Require an enrichment configuration to add the application component enricher");
+            }
+            if (string.IsNullOrWhiteSpace(componentName))
+            {
+                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank application component name");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+            }
 
             return enrichmentConfiguration.With(new ApplicationEnricher(componentName, propertyName));
         }
@@ -107,9 +140,18 @@ namespace Serilog
             IServiceProvider serviceProvider,
             string propertyName = ApplicationEnricher.ComponentName)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the application enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppName)}' implementations");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current application's name");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the application enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppName)}' implementations");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current application's name");
+            }
 
             var appName = serviceProvider.GetService<IAppName>();
             if (appName is null)
@@ -137,10 +179,22 @@ namespace Serilog
             string podNamePropertyName = ContextProperties.Kubernetes.PodName,
             string namespacePropertyName = ContextProperties.Kubernetes.Namespace)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the Kubernetes enricher");
-            Guard.NotNullOrWhitespace(nodeNamePropertyName, nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
-            Guard.NotNullOrWhitespace(podNamePropertyName, nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
-            Guard.NotNullOrWhitespace(namespacePropertyName, nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the Kubernetes enricher");
+            }
+            if (string.IsNullOrWhiteSpace(nodeNamePropertyName))
+            {
+                throw new ArgumentNullException(nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
+            }
+            if (string.IsNullOrWhiteSpace(podNamePropertyName))
+            {
+                throw new ArgumentNullException(nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
+            }
+            if (string.IsNullOrWhiteSpace(namespacePropertyName))
+            {
+                throw new ArgumentNullException(nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+            }
 
             return enrichmentConfiguration.With(new KubernetesEnricher(nodeNamePropertyName, podNamePropertyName, namespacePropertyName));
         }
@@ -163,10 +217,22 @@ namespace Serilog
             string operationIdPropertyName = ContextProperties.Correlation.OperationId,
             string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
-            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            }
+            if (string.IsNullOrWhiteSpace(operationIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a provider to retrieve the correlation information accessor instance");
+            }
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
@@ -184,8 +250,14 @@ namespace Serilog
             IServiceProvider serviceProvider,
             Action<CorrelationInfoEnricherOptions> configureOptions)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, configureOptions);
@@ -210,10 +282,22 @@ namespace Serilog
             string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
-            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation informatoin enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            }
+            if (string.IsNullOrWhiteSpace(operationIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            }
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, operationIdPropertyName, transactionIdPropertyName);
@@ -232,8 +316,14 @@ namespace Serilog
             Action<CorrelationInfoEnricherOptions> configureOptions)
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
+            }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
             return WithCorrelationInfo(enrichmentConfiguration, accessor, configureOptions);
@@ -257,10 +347,22 @@ namespace Serilog
             string operationIdPropertyName = ContextProperties.Correlation.OperationId,
             string transactionIdPropertyName = ContextProperties.Correlation.TransactionId)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
-            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            }
+            if (string.IsNullOrWhiteSpace(operationIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            }
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            }
 
             return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName);
         }
@@ -277,8 +379,14 @@ namespace Serilog
             ICorrelationInfoAccessor correlationInfoAccessor,
             Action<CorrelationInfoEnricherOptions> configureOptions)
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information accessor");
+            }
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            }
 
             return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, configureOptions);
         }
@@ -304,10 +412,22 @@ namespace Serilog
             string transactionIdPropertyName = ContextProperties.Correlation.TransactionId) 
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
-            Guard.NotNullOrWhitespace(operationIdPropertyName, nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            }
+            if (string.IsNullOrWhiteSpace(operationIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+            }
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+            }
 
             return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName));
         }
@@ -326,8 +446,14 @@ namespace Serilog
             Action<CorrelationInfoEnricherOptions> configureOptions) 
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires an correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (correlationInfoAccessor is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
+            }
 
             var options = new CorrelationInfoEnricherOptions();
             configureOptions?.Invoke(options);
@@ -347,8 +473,14 @@ namespace Serilog
             CorrelationInfoEnricher<TCorrelationInfo> correlationInfoEnricher) 
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(enrichmentConfiguration, nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
-            Guard.NotNull(correlationInfoEnricher, nameof(correlationInfoEnricher), "Requires an correlation enricher to enrich the log events with correlation information");
+            if (enrichmentConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
+            }
+            if (correlationInfoEnricher is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfoEnricher), "Requires a correlation enricher to enrich the log events with correlation information");
+            }
 
             return enrichmentConfiguration.With(correlationInfoEnricher);
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LoggerEnrichmentConfigurationExtensions.cs
@@ -29,6 +29,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
@@ -54,13 +55,15 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
             }
+
             if (appVersion is null)
             {
                 throw new ArgumentNullException(nameof(appVersion), "Requires an application version implementation to enrich the log event with the application version");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the current runtime version", nameof(propertyName));
             }
 
             return enrichmentConfiguration.With(new VersionEnricher(appVersion, propertyName));
@@ -83,13 +86,15 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the version enricher");
             }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppVersion)}' implementations");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the current runtime version", nameof(propertyName));
             }
             
             IAppVersion appVersion = serviceProvider.GetService<IAppVersion>() ?? new AssemblyAppVersion();
@@ -113,13 +118,15 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Require an enrichment configuration to add the application component enricher");
             }
+
             if (string.IsNullOrWhiteSpace(componentName))
             {
-                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank application component name");
+                throw new ArgumentException("Requires a non-blank application component name", nameof(componentName));
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the component name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the component name", nameof(propertyName));
             }
 
             return enrichmentConfiguration.With(new ApplicationEnricher(componentName, propertyName));
@@ -144,13 +151,15 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the application enricher");
             }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), $"Requires a services provider collection to look for registered '{nameof(IAppName)}' implementations");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current application's name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the current application's name", nameof(propertyName));
             }
 
             var appName = serviceProvider.GetService<IAppName>();
@@ -183,17 +192,20 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the Kubernetes enricher");
             }
+
             if (string.IsNullOrWhiteSpace(nodeNamePropertyName))
             {
-                throw new ArgumentNullException(nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes node name", nameof(nodeNamePropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(podNamePropertyName))
             {
-                throw new ArgumentNullException(nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes pod name", nameof(podNamePropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(namespacePropertyName))
             {
-                throw new ArgumentNullException(nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes namespace name", nameof(namespacePropertyName));
             }
 
             return enrichmentConfiguration.With(new KubernetesEnricher(nodeNamePropertyName, podNamePropertyName, namespacePropertyName));
@@ -221,17 +233,20 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
             }
+
             if (string.IsNullOrWhiteSpace(operationIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a provider to retrieve the correlation information accessor instance");
+                throw new ArgumentException("Requires a provider to retrieve the correlation information accessor instance", nameof(operationIdPropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation transaction ID", nameof(transactionIdPropertyName));
             }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor>();
@@ -254,6 +269,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
@@ -286,17 +302,20 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation informatoin enricher");
             }
+            
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
             }
+
             if (string.IsNullOrWhiteSpace(operationIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation operation ID", nameof(operationIdPropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation transaction ID", nameof(transactionIdPropertyName));
             }
 
             var accessor = serviceProvider.GetRequiredService<ICorrelationInfoAccessor<TCorrelationInfo>>();
@@ -320,6 +339,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider), "Requires a provider to retrieve the correlation information accessor instance");
@@ -351,17 +371,20 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (correlationInfoAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
             }
+
             if (string.IsNullOrWhiteSpace(operationIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation operation ID", nameof(operationIdPropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation transaction ID", nameof(transactionIdPropertyName));
             }
 
             return WithCorrelationInfo<CorrelationInfo>(enrichmentConfiguration, correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName);
@@ -383,6 +406,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information accessor");
             }
+
             if (correlationInfoAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
@@ -416,17 +440,20 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (correlationInfoAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
             }
+
             if (string.IsNullOrWhiteSpace(operationIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(operationIdPropertyName), "Requires a property name to enrich the log event with the correlation operation ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation operation ID", nameof(operationIdPropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
             {
-                throw new ArgumentNullException(nameof(transactionIdPropertyName), "Requires a property name to enrich the log event with the correlation transaction ID");
+                throw new ArgumentException("Requires a property name to enrich the log event with the correlation transaction ID", nameof(transactionIdPropertyName));
             }
 
             return enrichmentConfiguration.With(new CorrelationInfoEnricher<TCorrelationInfo>(correlationInfoAccessor, operationIdPropertyName, transactionIdPropertyName));
@@ -450,6 +477,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+
             if (correlationInfoAccessor is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information during the enrichment of the log events");
@@ -477,6 +505,7 @@ namespace Serilog
             {
                 throw new ArgumentNullException(nameof(enrichmentConfiguration), "Requires an enrichment configuration to add the correlation information enricher");
             }
+            
             if (correlationInfoEnricher is null)
             {
                 throw new ArgumentNullException(nameof(correlationInfoEnricher), "Requires a correlation enricher to enrich the log events with correlation information");

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
@@ -8,6 +8,9 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
     /// <summary>
     /// Enrichment on log events that automatically adds Kubernetes information from the environment.
     /// </summary>
+    /// <remarks>
+    /// The default Kubernetes environment variable property names; <c>KUBERNETES_NODE_NAME</c>, <c>KUBERNETES_POD_NAME</c> AND<c>KUBERNETES_NAMESPACE</c> are used to fetch the Kubernetes information.
+    /// </remarks>
     public class KubernetesEnricher : ILogEventEnricher
     {
         /// <summary>
@@ -38,23 +41,25 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <summary>
         /// Initializes a new instance of the <see cref="KubernetesEnricher"/> class.
         /// </summary>
-        /// <param name="nodeNamePropertyName">The name of the property to enrich the log event with the Kubernetes node name.</param>
-        /// <param name="podNamePropertyName">The name of the property to enrich the log event with the Kubernetes pod name.</param>
-        /// <param name="namespacePropertyName">The name of the property to enrich the log event with the Kubernetes namespace.</param>
+        /// <param name="nodeNamePropertyName">The name of the property as it's logged to enrich the log event with the Kubernetes node name.</param>
+        /// <param name="podNamePropertyName">The name of the property as it's logged to enrich the log event with the Kubernetes pod name.</param>
+        /// <param name="namespacePropertyName">The name of the property as it's logged to enrich the log event with the Kubernetes namespace.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="nodeNamePropertyName"/>, <paramref name="podNamePropertyName"/>, or <paramref name="namespacePropertyName"/> is blank.</exception>
         public KubernetesEnricher(string nodeNamePropertyName, string podNamePropertyName, string namespacePropertyName)
         {
             if (string.IsNullOrWhiteSpace(nodeNamePropertyName))
             {
-                throw new ArgumentNullException(nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes node name", nameof(nodeNamePropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(podNamePropertyName))
             {
-                throw new ArgumentNullException(nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes pod name", nameof(podNamePropertyName));
             }
+
             if (string.IsNullOrWhiteSpace(namespacePropertyName))
             {
-                throw new ArgumentNullException(nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the Kubernetes namespace name", nameof(namespacePropertyName));
             }
 
             _nodeNamePropertyName = nodeNamePropertyName;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/KubernetesEnricher.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -45,9 +44,18 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <exception cref="ArgumentException">Thrown when the <paramref name="nodeNamePropertyName"/>, <paramref name="podNamePropertyName"/>, or <paramref name="namespacePropertyName"/> is blank.</exception>
         public KubernetesEnricher(string nodeNamePropertyName, string podNamePropertyName, string namespacePropertyName)
         {
-            Guard.NotNullOrWhitespace(nodeNamePropertyName, nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
-            Guard.NotNullOrWhitespace(podNamePropertyName, nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
-            Guard.NotNullOrWhitespace(namespacePropertyName, nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+            if (string.IsNullOrWhiteSpace(nodeNamePropertyName))
+            {
+                throw new ArgumentNullException(nameof(nodeNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes node name");
+            }
+            if (string.IsNullOrWhiteSpace(podNamePropertyName))
+            {
+                throw new ArgumentNullException(nameof(podNamePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes pod name");
+            }
+            if (string.IsNullOrWhiteSpace(namespacePropertyName))
+            {
+                throw new ArgumentNullException(nameof(namespacePropertyName), "Requires a non-blank property name to enrich the log event with the Kubernetes namespace name");
+            }
 
             _nodeNamePropertyName = nodeNamePropertyName;
             _podNamePropertyName = podNamePropertyName;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -55,8 +54,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyName"/> is blank.</exception>
         public VersionEnricher(IAppVersion appVersion, string propertyName)
         {
-            Guard.NotNull(appVersion, nameof(appVersion), "Requires an application version implementation to enrich the log event with the application version");
-            Guard.NotNullOrWhitespace(propertyName, nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            if (appVersion is null)
+            {
+                throw new ArgumentNullException(nameof(appVersion), "Requires an application version implementation to enricht the log event with the application version");
+            }
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+            }
 
             _appVersion = appVersion;
             _propertyName = propertyName;

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/VersionEnricher.cs
@@ -58,9 +58,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Enrichers
             {
                 throw new ArgumentNullException(nameof(appVersion), "Requires an application version implementation to enricht the log event with the application version");
             }
+
             if (string.IsNullOrWhiteSpace(propertyName))
             {
-                throw new ArgumentNullException(nameof(propertyName), "Requires a non-blank property name to enrich the log event with the current runtime version");
+                throw new ArgumentException("Requires a non-blank property name to enrich the log event with the current runtime version", nameof(propertyName));
             }
 
             _appVersion = appVersion;

--- a/src/Arcus.Observability.Telemetry.Serilog.Filters/TelemetryTypeFilter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Filters/TelemetryTypeFilter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -13,8 +12,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Filters
     {
         private TelemetryTypeFilter(TelemetryType telemetryType, bool? isTrackingEnabled)
         {
-            Guard.For(() => !Enum.IsDefined(typeof(TelemetryType), telemetryType),
-                new ArgumentOutOfRangeException(nameof(telemetryType), telemetryType, "Requires a type of telemetry that's within the supported value range of the enumeration"));
+            if (!Enum.IsDefined(typeof(TelemetryType), telemetryType))
+            {
+                throw new ArgumentOutOfRangeException(nameof(telemetryType), "Requires a type of telemetry that's within the supported value range of the enumeration");
+            }
 
             TelemetryType = telemetryType;
             IsTrackingEnabled = isTrackingEnabled;
@@ -37,11 +38,16 @@ namespace Arcus.Observability.Telemetry.Serilog.Filters
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="telemetryType"/> is outside the bounds of the enumeration.</exception>
         public static TelemetryTypeFilter On(TelemetryType telemetryType)
         {
-            Guard.For(() => !Enum.IsDefined(typeof(TelemetryType), telemetryType),
-                new ArgumentOutOfRangeException(nameof(telemetryType), telemetryType, "Requires a type of telemetry that's within the supported value range of the enumeration"));
+            if (!Enum.IsDefined(typeof(TelemetryType), telemetryType))
+            {
+                throw new ArgumentOutOfRangeException(nameof(telemetryType), telemetryType, "Requires a type of telemetry that's within the supported value range of the enumeration");
+            }
 
             // We cannot identify traces properly, so we do not allow Trace filters
-            Guard.For<ArgumentException>(() => telemetryType == TelemetryType.Trace, "Filtering out traces is not supported");
+            if (telemetryType is TelemetryType.Trace)
+            {
+                throw new ArgumentException("Filtering out traces is not suppported");
+            }
 
             return new TelemetryTypeFilter(telemetryType, isTrackingEnabled: null);
         }
@@ -54,11 +60,17 @@ namespace Arcus.Observability.Telemetry.Serilog.Filters
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="telemetryType"/> is outside the bounds of the enumeration.</exception>
         public static TelemetryTypeFilter On(TelemetryType telemetryType, bool isTrackingEnabled)
         {
-            Guard.For(() => !Enum.IsDefined(typeof(TelemetryType), telemetryType),
-                new ArgumentOutOfRangeException(nameof(telemetryType), telemetryType, "Requires a type of telemetry that's within the supported value range of the enumeration"));
+            if (!Enum.IsDefined(typeof(TelemetryType), telemetryType))
+            {
+                throw new ArgumentOutOfRangeException(nameof(telemetryType), telemetryType, "Requires a type of telemetry that's within the supported value range of the enumeration");
+            }
+
 
             // We cannot identify traces properly, so we do not allow Trace filters
-            Guard.For<ArgumentException>(() => telemetryType == TelemetryType.Trace, "Filtering out traces is not supported");
+            if (telemetryType is TelemetryType.Trace)
+            {
+                throw new ArgumentException("Filtering out traces is not supported");
+            }
 
             return new TelemetryTypeFilter(telemetryType, isTrackingEnabled);
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
@@ -23,7 +23,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation ID");
+                    throw new ArgumentException("Requires a non-blank Serilog application property name to locate the correlation operation ID", nameof(value));
                 }
 
                 _operationIdPropertyName = value;
@@ -41,7 +41,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation transaction ID");
+                    throw new ArgumentException("Requires a non-blank Serilog application property name to locate the correlation transaction ID", nameof(value));
                 }
 
                 _transactionIdPropertyName = value;
@@ -59,7 +59,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation parent ID");
+                    throw new ArgumentException("Requires a non-blank Serilog application property name to locate the correlation operation parent ID", nameof(value));
                 }
 
                 _operationParentIdPropertyName = value;

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -22,7 +21,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _operationIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation ID");
+                }
+
                 _operationIdPropertyName = value;
             }
         }
@@ -36,7 +39,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation transaction ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation transaction ID");
+                }
+
                 _transactionIdPropertyName = value;
             }
         }
@@ -50,7 +57,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _operationParentIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation parent ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation parent ID");
+                }
+
                 _operationParentIdPropertyName = value;
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
@@ -38,11 +38,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentNullException(nameof(value), "Requires a non-blank string format to track (public) exception properties");
+                    throw new ArgumentException("Requires a non-blank string format to track (public) exception properties", nameof(value));
                 }
                 if (PropertyFormatRegex.Matches(value).Count != 3)
                 {
-                    throw new FormatException(nameof(value), "Requires a single occurrence of the substring '{0}' in the exception property format");
+                    throw new FormatException("Requires a single occurrence of the substring '{0}' in the exception property format");
                 }
 
                 _propertyFormat = value;

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -37,8 +36,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _propertyFormat;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank string format to track (public) exception properties");
-                Guard.For<FormatException>(() => PropertyFormatRegex.Matches(value).Count != 3, "Requires a single occurrence of the substring '{0}' in the exception property format");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a non-blank string format to track (public) exception properties");
+                }
+                if (PropertyFormatRegex.Matches(value).Count != 3)
+                {
+                    throw new FormatException(nameof(value), "Requires a single occurrence of the substring '{0}' in the exception property format");
+                }
 
                 _propertyFormat = value;
             }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -20,7 +19,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _generatedId;
             set
             {
-                Guard.NotNull(value, nameof(value), "Requires a function to generate the request ID of the telemetry model while tracking requests");
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value), "Requires a function to generate the request ID of the telemetry model while tracking requests");
+                }
+
                 _generatedId = value;
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationNameTelemetryInitializer.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationNameTelemetryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
@@ -20,7 +19,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationName"/> is <c>null</c>.</exception>
         public ApplicationNameTelemetryInitializer(IAppName applicationName)
         {
-            Guard.NotNull(applicationName, nameof(applicationName), $"Requires an application name ({nameof(IAppName)}) implementation to retrieve the application name to initialize in the telemetry");
+            if (applicationName is null)
+            {
+                throw new ArgumentNullException(nameof(applicationName), $"Requires an application name ({nameof(IAppName)}) implementation to retrieve the application name to initialize in the telemetry");
+            }
+            
             _applicationName = applicationName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationVersionTelemetryInitializer.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationVersionTelemetryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
@@ -20,7 +19,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationVersion"/> is <c>null</c>.</exception>
         public ApplicationVersionTelemetryInitializer(IAppVersion applicationVersion)
         {
-            Guard.NotNull(applicationVersion, nameof(applicationVersion), $"Requires an application version ({nameof(IAppVersion)}) implementation to retrieve the application version to initialize in the telemetry");
+            if (applicationVersion is null)
+            {
+                throw new ArgumentNullException(nameof(applicationVersion), $"Requires an application version ({nameof(IAppVersion)}) implementation to retrieve the application version to initialize in the telemetry");
+            }
             _applicationVersion = applicationVersion;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
@@ -23,7 +22,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
         private ApplicationInsightsTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence how to track to Application Insights");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of options to influence how to track to Application Insights");
+            }
 
             _requestTelemetryConverter = new RequestTelemetryConverter(options);
             _exceptionTelemetryConverter = new ExceptionTelemetryConverter(options);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
@@ -27,7 +26,10 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         protected CustomTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            }
             
             _operationContextConverter = new OperationContextConverter(options);
             Options = options;
@@ -45,8 +47,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="formatProvider">The instance to control formatting.</param>
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights telemetry instance");
+            }
 
             TEntry telemetryEntry = CreateTelemetryEntry(logEvent, formatProvider);
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,8 +30,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override DependencyTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Dependency telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Dependency telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Dependency telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Dependency telemetry instance");
+            }
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
             string dependencyId = logEntry.Properties.GetAsRawString(nameof(DependencyLogEntry.DependencyId));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
@@ -34,6 +34,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Dependency telemetry instance");
             }
+
             if (logEvent.Properties is null)
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Dependency telemetry instance");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
@@ -34,6 +34,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Event telemetry instance");
             }
+            
             if (logEvent.Properties is null)
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Event telemetry instance");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,8 +30,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override EventTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Event telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Event telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Event telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Event telemetry instance");
+            }
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.EventTracking.EventLogEntry);
             string eventName = logEntry.Properties.GetAsRawString(nameof(EventLogEntry.EventName));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -29,9 +28,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override ExceptionTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an exception telemetry entry");
-            Guard.For(() => logEvent.Exception is null, new ArgumentException(
-                "Requires a log event that tracks an exception to create an exception telemetry entry", nameof(logEvent)));
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an exception telemetry entry");
+            }
+            if (logEvent.Exception is null)
+            {
+                throw new ArgumentException("Requires a log event that tracks an exception to create an exception telemetry entry", nameof(logEvent));
+            }
             
             var exceptionTelemetry = new ExceptionTelemetry(logEvent.Exception);
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ExceptionTelemetryConverter.cs
@@ -32,6 +32,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an exception telemetry entry");
             }
+            
             if (logEvent.Exception is null)
             {
                 throw new ArgumentException("Requires a log event that tracks an exception to create an exception telemetry entry", nameof(logEvent));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,8 +30,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override MetricTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Metric telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Metric telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Metric telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Metric telemetry instance");
+            }
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.MetricTracking.MetricLogEntry);
             string metricName = logEntry.Properties.GetAsRawString(nameof(MetricLogEntry.MetricName));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
@@ -34,6 +34,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Metric telemetry instance");
             }
+
             if (logEvent.Properties is null)
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Metric telemetry instance");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -4,7 +4,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using System;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
 {
@@ -22,7 +21,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public OperationContextConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            }
+
             _options = options;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -34,6 +34,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Request telemetry instance");
             }
+            
             if (logEvent.Properties is null)
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Request telemetry instance");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,8 +30,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override RequestTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Request telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Request telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Request telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Request telemetry instance");
+            }
             
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.RequestTracking.RequestLogEntry);
             string requestMethod = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestMethod));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
@@ -41,6 +41,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights trace telemetry instance");
             }
+            
             if (logEvent.Properties is null)
             {
                 throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights trace telemetry instance");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
@@ -23,7 +22,11 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public TraceTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            }
+
             _operationContextConverter = new OperationContextConverter(options);
         }
 
@@ -34,8 +37,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="formatProvider">The instance to control formatting.</param>
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights trace telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights trace telemetry instance");
+            if (logEvent is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights trace telemetry instance");
+            }
+            if (logEvent.Properties is null)
+            {
+                throw new ArgumentNullException(nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights trace telemetry instance");
+            }
 
             foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
@@ -1,5 +1,4 @@
-﻿using GuardNet;
-
+﻿
 // ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
@@ -17,8 +16,14 @@ namespace System.Collections.Generic
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="items"/> or <paramref name="additionalItems"/> is <c>null</c>.</exception>
         internal static void AddRange(this IDictionary<string, string> items, IDictionary<string, string> additionalItems)
         {
-            Guard.NotNull(items, nameof(items), "Requires a base dictionary to add the additional items to");
-            Guard.NotNull(additionalItems, nameof(additionalItems), "Requires an additional set of items to add to the base dictionary");
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items), "Requires a base dictionary to add the additional items to");
+            }
+            if (additionalItems is null)
+            {
+                throw new ArgumentNullException(nameof(additionalItems), "Requires an additional set of items to add to the base dictionary");
+            }
             
             foreach (KeyValuePair<string, string> property in additionalItems)
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
@@ -20,6 +20,7 @@ namespace System.Collections.Generic
             {
                 throw new ArgumentNullException(nameof(items), "Requires a base dictionary to add the additional items to");
             }
+            
             if (additionalItems is null)
             {
                 throw new ArgumentNullException(nameof(additionalItems), "Requires an additional set of items to add to the base dictionary");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.Logging
             {
                 throw new ArgumentNullException(nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
             }
+            
             if (implementationFactory is null)
             {
                 throw new ArgumentNullException(nameof(implementationFactory), "Requires an implementation factory to build up the Serilog logger");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Extensions.Logging;
 
@@ -22,8 +21,14 @@ namespace Microsoft.Extensions.Logging
             this ILoggingBuilder builder,
             Func<IServiceProvider, Serilog.ILogger> implementationFactory)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires an implementation factory to build up the Serilog logger");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
+            }
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory), "Requires an implementation factory to build up the Serilog logger");
+            }
 
             builder.Services.AddSingleton<ILoggerProvider>(provider =>
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Extensibility;
 
 // ReSharper disable once CheckNamespace
@@ -24,8 +23,14 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             string componentName)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank functional name to identity the application");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
+            }
+            if (string.IsNullOrWhiteSpace(componentName))
+            {
+                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank functional name to identity the application");
+            }
 
             return AddAppName(services, provider => new DefaultAppName(componentName));
         }
@@ -40,8 +45,14 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Func<IServiceProvider, IAppName> implementationFactory)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), $"Requires a factory function to create the '{nameof(IAppName)}' implementation");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
+            }
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory), $"Requires a factory function to create the '{nameof(IAppName)}' implementation");
+            }
 
             return services.AddSingleton(implementationFactory)
                            .AddSingleton<ITelemetryInitializer, ApplicationNameTelemetryInitializer>();
@@ -55,7 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAssemblyAppVersion<TConsumerType>(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
+            }
 
             return AddAppVersion(services, provider => new AssemblyAppVersion(typeof(TConsumerType)));
         }
@@ -68,8 +82,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="consumerType"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAssemblyAppVersion(this IServiceCollection services, Type consumerType)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
-            Guard.NotNull(consumerType, nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
+            }
+            if (consumerType is null)
+            {
+                throw new ArgumentNullException(nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
+            }
 
             return AddAppVersion(services, provider => new AssemblyAppVersion(consumerType));
         }
@@ -82,7 +102,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAppVersion<TAppVersion>(this IServiceCollection services) where TAppVersion : class, IAppVersion
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
+            }
+
             return AddAppVersion(services, provider => ActivatorUtilities.CreateInstance<TAppVersion>(provider));
         }
 
@@ -96,8 +120,14 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Func<IServiceProvider, IAppVersion> createImplementation)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
-            Guard.NotNull(createImplementation, nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
+            }
+            if (createImplementation is null)
+            {
+                throw new ArgumentNullException(nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");
+            }
 
             return services.AddSingleton(createImplementation)
                            .AddSingleton<ITelemetryInitializer, ApplicationVersionTelemetryInitializer>();

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
             }
+
             if (string.IsNullOrWhiteSpace(componentName))
             {
-                throw new ArgumentNullException(nameof(componentName), "Requires a non-blank functional name to identity the application");
+                throw new ArgumentException("Requires a non-blank functional name to identity the application", nameof(componentName));
             }
 
             return AddAppName(services, provider => new DefaultAppName(componentName));
@@ -49,6 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
             }
+
             if (implementationFactory is null)
             {
                 throw new ArgumentNullException(nameof(implementationFactory), $"Requires a factory function to create the '{nameof(IAppName)}' implementation");
@@ -86,6 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
             }
+
             if (consumerType is null)
             {
                 throw new ArgumentNullException(nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
@@ -124,6 +127,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
             }
+            
             if (createImplementation is null)
             {
                 throw new ArgumentNullException(nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -30,6 +30,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a raw string representation");
             }
+            
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a raw string representation", nameof(propertyKey));
@@ -97,6 +98,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a DateTimeOffset representation");
             }
+
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a DateTimeOffset representation", nameof(propertyKey));
@@ -132,6 +134,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a IDictionary<string, string> representation");
             }
+
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a IDictionary<string, string> represenation", nameof(propertyKey));
@@ -167,6 +170,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a Double representation");
             }
+
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a Double representation", nameof(propertyKey));
@@ -204,6 +208,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Boolean representation");
             }
+
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property to retrieve a Serilog event property as a Boolean representation", nameof(propertyKey));
@@ -236,6 +241,7 @@ namespace Serilog.Events
             {
                 throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an object representation");
             }
+            
             if (string.IsNullOrWhiteSpace(propertyKey))
             {
                 throw new ArgumentException("Requires a non-blank property to retrieve a Serilog event property as an object representation", nameof(propertyKey));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Serilog.Events
@@ -27,8 +26,14 @@ namespace Serilog.Events
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         internal static string GetAsRawString(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a raw string representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a raw string representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a raw string representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a raw string representation", nameof(propertyKey));
+            }
             
             LogEventProperty propertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (propertyValue?.Value is null 
@@ -55,8 +60,14 @@ namespace Serilog.Events
         /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="TimeSpan"/> duration.</exception>
         internal static TimeSpan GetAsTimeSpan(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a TimeSpan representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a TimeSpan representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a TimeSpan representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a TimeSpan representation", nameof(propertyKey));
+            }
             
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
@@ -82,8 +93,14 @@ namespace Serilog.Events
         /// <exception cref="FormatException">Throw when the property value cannot be parsed as a <see cref="DateTimeOffset"/> due to its format.</exception>
         internal static DateTimeOffset GetAsDateTimeOffset(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a DateTimeOffset representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a DateTimeOffset representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a DateTimeOffset representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a DateTimeOffset representation", nameof(propertyKey));
+            }
             
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
@@ -111,8 +128,14 @@ namespace Serilog.Events
             this IReadOnlyList<LogEventProperty> properties, 
             string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a IDictionary<string, string> representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a IDictionary<string, string> represenation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a IDictionary<string, string> representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a IDictionary<string, string> represenation", nameof(propertyKey));
+            }
             
             LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (property?.Value is DictionaryValue dictionary)
@@ -140,8 +163,14 @@ namespace Serilog.Events
         /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="Double"/> range.</exception>
         internal static double GetAsDouble(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Double representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property as a Double representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a Double representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property key to retrieve a Serilog event property value as a Double representation", nameof(propertyKey));
+            }
             
             LogEventProperty logEventPropertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (logEventPropertyValue is null)
@@ -171,8 +200,14 @@ namespace Serilog.Events
         /// <exception cref="FormatException">Thrown when the property value cannot be parsed as a <see cref="Boolean"/> due to its format.</exception>
         internal static bool GetAsBool(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Boolean representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a Boolean representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Boolean representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property to retrieve a Serilog event property as a Boolean representation", nameof(propertyKey));
+            }
             
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
@@ -197,8 +232,14 @@ namespace Serilog.Events
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         internal static TValue GetAsObject<TValue>(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an enumeration representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as an enumeration representation");
+            if (properties is null)
+            {
+                throw new ArgumentNullException(nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an object representation");
+            }
+            if (string.IsNullOrWhiteSpace(propertyKey))
+            {
+                throw new ArgumentException("Requires a non-blank property to retrieve a Serilog event property as an object representation", nameof(propertyKey));
+            }
 
             LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (property != null 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -32,9 +32,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose);
@@ -60,9 +61,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose, configureOptions);
@@ -88,9 +90,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
@@ -118,9 +121,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             var options = new ApplicationInsightsSinkOptions();
@@ -152,9 +156,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose);
@@ -185,9 +190,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose, configureOptions);
@@ -218,9 +224,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
@@ -253,9 +260,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(instrumentationKey));
             }
 
             var options = new ApplicationInsightsSinkOptions();
@@ -284,7 +292,7 @@ namespace Serilog.Configuration
             }
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, configureOptions: null);
@@ -310,9 +318,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, LogEventLevel.Verbose, configureOptions);
@@ -338,9 +347,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, restrictedToMinimumLevel, configureOptions: null);
@@ -368,9 +378,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             var options = new ApplicationInsightsSinkOptions();
@@ -405,9 +416,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, configureOptions: null);
@@ -438,9 +450,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, LogEventLevel.Verbose, configureOptions);
@@ -471,9 +484,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, restrictedToMinimumLevel, configureOptions: null);
@@ -506,9 +520,10 @@ namespace Serilog.Configuration
             {
                 throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
             }
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+                throw new ArgumentException("Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry", nameof(connectionString));
             }
 
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,8 +28,14 @@ namespace Serilog.Configuration
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string instrumentationKey)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose);
         }
@@ -51,8 +56,14 @@ namespace Serilog.Configuration
             string instrumentationKey,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose, configureOptions);
         }
@@ -73,8 +84,14 @@ namespace Serilog.Configuration
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
         }
@@ -97,8 +114,14 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -125,8 +148,14 @@ namespace Serilog.Configuration
             IServiceProvider serviceProvider,
             string instrumentationKey)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose);
         }
@@ -152,8 +181,14 @@ namespace Serilog.Configuration
             string instrumentationKey,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose, configureOptions);
         }
@@ -179,8 +214,14 @@ namespace Serilog.Configuration
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
         }
@@ -208,8 +249,14 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                throw new ArgumentNullException(nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -231,8 +278,14 @@ namespace Serilog.Configuration
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string connectionString)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, configureOptions: null);
         }
@@ -253,8 +306,14 @@ namespace Serilog.Configuration
             string connectionString,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, LogEventLevel.Verbose, configureOptions);
         }
@@ -275,8 +334,14 @@ namespace Serilog.Configuration
             string connectionString,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, restrictedToMinimumLevel, configureOptions: null);
         }
@@ -299,8 +364,14 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -330,8 +401,14 @@ namespace Serilog.Configuration
             IServiceProvider serviceProvider,
             string connectionString)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, configureOptions: null);
         }
@@ -357,8 +434,14 @@ namespace Serilog.Configuration
             string connectionString,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, LogEventLevel.Verbose, configureOptions);
         }
@@ -384,8 +467,14 @@ namespace Serilog.Configuration
             string connectionString,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
 
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, restrictedToMinimumLevel, configureOptions: null);
         }
@@ -413,8 +502,15 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            if (loggerSinkConfiguration is null)
+            {
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
+            }
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            }
+
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.Observability.Tests.Core/Arcus.Observability.Tests.Core.csproj
+++ b/src/Arcus.Observability.Tests.Core/Arcus.Observability.Tests.Core.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Arcus.Observability.Tests.Core/TemporaryEnvironmentVariable.cs
+++ b/src/Arcus.Observability.Tests.Core/TemporaryEnvironmentVariable.cs
@@ -13,7 +13,7 @@ namespace Arcus.Observability.Tests.Core
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException(nameof(name));
+                throw new ArgumentException(nameof(name));
             }
 
 
@@ -30,11 +30,11 @@ namespace Arcus.Observability.Tests.Core
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentNullException(nameof(name));
+                throw new ArgumentException(nameof(name));
             }
             if (string.IsNullOrWhiteSpace(value))
             {
-                throw new ArgumentNullException(nameof(value));
+                throw new ArgumentException(nameof(value));
             }
 
             Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process);

--- a/src/Arcus.Observability.Tests.Core/TemporaryEnvironmentVariable.cs
+++ b/src/Arcus.Observability.Tests.Core/TemporaryEnvironmentVariable.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Tests.Core
 {
@@ -12,7 +11,11 @@ namespace Arcus.Observability.Tests.Core
 
         private TemporaryEnvironmentVariable(string name)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name));
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
 
             _name = name;
         }
@@ -25,8 +28,14 @@ namespace Arcus.Observability.Tests.Core
         /// <param name="value">The value of the environment variable.</param>
         public static TemporaryEnvironmentVariable Create(string name, string value)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name));
-            Guard.NotNullOrWhitespace(value, nameof(value));
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
 
             Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process);
             return new TemporaryEnvironmentVariable(name);

--- a/src/Arcus.Observability.Tests.Integration/AssertX.cs
+++ b/src/Arcus.Observability.Tests.Integration/AssertX.cs
@@ -26,6 +26,7 @@ namespace Xunit
             {
                 throw new ArgumentNullException(nameof(collection), "Requires collection of elements to find a single element that matches the assertion");
             }
+            
             if (assertion is null)
             {
                 throw new ArgumentNullException(nameof(assertion), "Requires an element assertion to verify if an single element in the collection matches");

--- a/src/Arcus.Observability.Tests.Integration/AssertX.cs
+++ b/src/Arcus.Observability.Tests.Integration/AssertX.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using GuardNet;
 using Xunit.Sdk;
 
 // ReSharper disable once CheckNamespace
@@ -23,8 +22,14 @@ namespace Xunit
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or <paramref name="assertion"/> is <c>null</c>.</exception>
         public static void Any<T>(IEnumerable<T> collection, Action<T> assertion)
         {
-            Guard.NotNull(collection, nameof(collection), "Requires collection of elements to find a single element that matches the assertion");
-            Guard.NotNull(assertion, nameof(assertion), "Requires an element assertion to verify if an single element in the collection matches");
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection), "Requires collection of elements to find a single element that matches the assertion");
+            }
+            if (assertion is null)
+            {
+                throw new ArgumentNullException(nameof(assertion), "Requires an element assertion to verify if an single element in the collection matches");
+            }
 
             Assert.NotEmpty(collection);
 

--- a/src/Arcus.Observability.Tests.Integration/Configuration/ServicePrincipal.cs
+++ b/src/Arcus.Observability.Tests.Integration/Configuration/ServicePrincipal.cs
@@ -1,5 +1,5 @@
-﻿using Arcus.Testing;
-using GuardNet;
+﻿using System;
+using Arcus.Testing;
 
 namespace Arcus.Observability.Tests.Integration.Configuration
 {
@@ -13,9 +13,18 @@ namespace Arcus.Observability.Tests.Integration.Configuration
         /// </summary>
         public ServicePrincipal(string tenantId, string clientId, string clientSecret)
         {
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId));
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId));
-            Guard.NotNullOrWhitespace(clientSecret, nameof(clientSecret));
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new ArgumentNullException(nameof(tenantId));
+            }
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentNullException(nameof(clientId));
+            }
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new ArgumentNullException(nameof(clientSecret));
+            }
 
             TenantId = tenantId;
             ClientId = clientId;

--- a/src/Arcus.Observability.Tests.Integration/Configuration/ServicePrincipal.cs
+++ b/src/Arcus.Observability.Tests.Integration/Configuration/ServicePrincipal.cs
@@ -15,15 +15,17 @@ namespace Arcus.Observability.Tests.Integration.Configuration
         {
             if (string.IsNullOrWhiteSpace(tenantId))
             {
-                throw new ArgumentNullException(nameof(tenantId));
+                throw new ArgumentException(nameof(tenantId));
             }
+            
             if (string.IsNullOrWhiteSpace(clientId))
             {
-                throw new ArgumentNullException(nameof(clientId));
+                throw new ArgumentException(nameof(clientId));
             }
+
             if (string.IsNullOrWhiteSpace(clientSecret))
             {
-                throw new ArgumentNullException(nameof(clientSecret));
+                throw new ArgumentException(nameof(clientSecret));
             }
 
             TenantId = tenantId;

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkTests.cs
@@ -6,7 +6,6 @@ using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configurat
 using Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights.Fixture;
 using Arcus.Testing;
 using Bogus;
-using GuardNet;
 using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -127,7 +126,10 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         /// <exception cref="InvalidOperationException">Thrown when the <paramref name="config"/> already has created the logger.</exception>
         protected ILogger CreateLogger(LoggerConfiguration config)
         {
-            Guard.NotNull(config, nameof(config), "Requires a Serilog logger configuration instance to setup the test logger used during the test");
+            if (config is null)
+            {
+                throw new ArgumentNullException(nameof(config), "Requires a Serilog logger configuration instance to setup the test logger used during the test");
+            }
 
             _telemetrySink.Options = ApplicationInsightsSinkOptions;
             config.WriteTo.ApplicationInsights(_telemetrySink);
@@ -162,7 +164,10 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         /// <exception cref="TimeoutException">Thrown when the <paramref name="assertion"/> failed to be verified within the configured timeout.</exception>
         protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<ITelemetryQueryClient, Task> assertion)
         {
-            Guard.NotNull(assertion, nameof(assertion));
+            if (assertion is null)
+            {
+                throw new ArgumentNullException(nameof(assertion));
+            }
 
             if (TestLocation is TestLocation.Remote)
             {

--- a/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/Fixture/InMemoryTelemetryQueryClient.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/Sinks/ApplicationInsights/Fixture/InMemoryTelemetryQueryClient.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Azure.ApplicationInsights.Query.Models;
 
 namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsights.Fixture
@@ -17,7 +17,11 @@ namespace Arcus.Observability.Tests.Integration.Serilog.Sinks.ApplicationInsight
         /// </summary>
         public InMemoryTelemetryQueryClient(InMemoryApplicationInsightsTelemetryConverter telemetrySink)
         {
-            Guard.NotNull(telemetrySink, nameof(telemetrySink));
+            if (telemetrySink is null)
+            {
+                throw new ArgumentNullException(nameof(telemetrySink));
+            }
+
             _telemetrySink = telemetrySink;
         }
 

--- a/src/Arcus.Observability.Tests.Integration/Serilog/XunitLogEventSink.cs
+++ b/src/Arcus.Observability.Tests.Integration/Serilog/XunitLogEventSink.cs
@@ -1,4 +1,4 @@
-﻿using GuardNet;
+﻿using System;
 using Serilog.Core;
 using Serilog.Events;
 using Xunit.Abstractions;
@@ -17,7 +17,11 @@ namespace Arcus.Observability.Tests.Integration.Serilog
         /// </summary>
         public XunitLogEventSink(ITestOutputHelper outputWriter)
         {
-            Guard.NotNull(outputWriter, nameof(outputWriter));
+            if (outputWriter is null)
+            {
+                throw new ArgumentNullException(nameof(outputWriter));
+            }
+
             _outputWriter = outputWriter;
         }
 

--- a/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
+++ b/src/Arcus.Observability.Tests.Unit/Extensions/TestLoggerExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
-using GuardNet;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
@@ -27,7 +26,10 @@ namespace Arcus.Observability.Tests.Unit
         /// <exception cref="InvalidOperationException">Thrown when no test message was written to the test <paramref name="logger"/>.</exception>
         public static DependencyLogEntry GetMessageAsDependency(this TestLogger logger)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a test logger to retrieve the written log message");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a test logger to retrieve the written log message");
+            }
 
             if (logger.WrittenMessage is null)
             {
@@ -73,7 +75,10 @@ namespace Arcus.Observability.Tests.Unit
         /// <exception cref="InvalidOperationException">Thrown when no test message was written to the test <paramref name="logger"/>.</exception>
         public static RequestLogEntry GetMessageAsRequest(this TestLogger logger)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a test logger to retrieve the written log message");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a test logger to retrieve the written log message");
+            }
 
             if (logger.WrittenMessage is null)
             {
@@ -142,7 +147,10 @@ namespace Arcus.Observability.Tests.Unit
         /// <exception cref="InvalidOperationException">Thrown when no test message was written to the test <paramref name="logger"/>.</exception>
         public static MetricLogEntry GetMessageAsMetric(this TestLogger logger)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a test logger to retrieve the written log message");
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger), "Requires a test logger to retrieve the written log message");
+            }
 
             if (logger.WrittenMessage is null)
             {


### PR DESCRIPTION
As per issue 577. This PR removes all dependency on Guard.NET. All checks done by Guard.NET have been replaced with if checks.

Closes #577