### PR TITLE
chore(ci): use custom myget publish

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,6 +33,7 @@ resources:
 variables:
   - group: 'Arcus - GitHub Package Registry'
   - group: 'Build Configuration'
+  - group: 'MyGet'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
 
@@ -118,4 +119,9 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: nuget/publish-preview-package.yml@templates
+          - task: DotNetCoreCLI@2
+            displayName: 'Push to MyGet.org'
+            inputs:
+              command: 'custom'
+              custom: 'nuget'
+              arguments: 'push src/**/*.nupkg --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'


### PR DESCRIPTION
Since the latest `ubuntu` image does not include the necessary `nuget` commands, we have to do the push manually. This is similar to other PR's being done on Messaging and Testing.

This PR uses the custom `dotnet` task to do the push to MyGet in the CI pipeline.