### PR TITLE
chore(deprecate): logging extensions w/ logging scope

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/ILoggerGeneralExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogInformation(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an informational message with a telemetry context");
@@ -43,6 +44,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogInformation(
             this ILogger logger,
             string message,
@@ -70,6 +72,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogError(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an error message with a telemetry context");
@@ -94,6 +97,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogError(
             this ILogger logger, 
             Exception exception, 
@@ -123,6 +127,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogError(
             this ILogger logger,
             string message,
@@ -152,6 +157,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogError(
             this ILogger logger, 
             Exception exception, 
@@ -181,6 +187,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogCritical(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an critical message with a telemetry context");
@@ -205,6 +212,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogCritical(
             this ILogger logger, 
             Exception exception, 
@@ -234,6 +242,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")
         public static void LogCritical(
             this ILogger logger,
             string message,
@@ -263,6 +272,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogCritical(
             this ILogger logger, 
             Exception exception, 
@@ -292,6 +302,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogWarning(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an warning message with a telemetry context");
@@ -316,6 +327,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogWarning(
             this ILogger logger, 
             Exception exception,
@@ -345,6 +357,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")
         public static void LogWarning(
             this ILogger logger,
             string message,
@@ -374,6 +387,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/>, <paramref name="exception"/>, or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogWarning(
             this ILogger logger, 
             Exception exception,
@@ -403,6 +417,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogTrace(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an trace message with a telemetry context");
@@ -427,6 +442,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogTrace(
             this ILogger logger,
             string message,
@@ -454,6 +470,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="context">The context that provides more insights on the message that was measured.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogDebug(this ILogger logger, string message, Dictionary<string, object> context)
         {
             Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write an debug message with a telemetry context");
@@ -478,6 +495,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> or <paramref name="context"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="message"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0 in favor of using logging scopes to track telemetry contexts across logs")]
         public static void LogDebug(
             this ILogger logger,
             string message,


### PR DESCRIPTION
Logging scopes are supported in OpenTelemetry as well, we have some methods that starts the log scope, but since it's recommended to use another type (`IReadOnlyList<KeyValue<string, object?>>`) AND the implemented code is too little to provide value while it has unnecessary support costs (see also discussion #587), this PR deprecates these extensions.