### PR TITLE
chore(core): deprecate unnecessary 'get or default' dic extension

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
@@ -14,6 +14,7 @@ namespace System.Collections.Generic
         /// </summary>
         /// <param name="dictionary">Dictionary containing data</param>
         /// <param name="propertyKey">Key of the dictionary entry to return</param>
+        [Obsolete("Already available in standard .NET SDK")]
         public static TValue GetValueOrDefault<TValue>(this IReadOnlyDictionary<string, TValue> dictionary, string propertyKey)
         {
             Guard.NotNull(dictionary, nameof(dictionary));

--- a/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Extensions/IReadOnlyDictionaryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using GuardNet;
-
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
     /// <summary>
@@ -17,14 +15,7 @@ namespace System.Collections.Generic
         [Obsolete("Already available in standard .NET SDK")]
         public static TValue GetValueOrDefault<TValue>(this IReadOnlyDictionary<string, TValue> dictionary, string propertyKey)
         {
-            Guard.NotNull(dictionary, nameof(dictionary));
-
-            if (dictionary.TryGetValue(propertyKey, out TValue foundValue))
-            {
-                return foundValue;
-            }
-
-            return default;
+            return dictionary.GetValueOrDefault(key: propertyKey);
         }
     }
 }

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using GuardNet;
 
 // ReSharper disable once CheckNamespace
@@ -14,7 +12,7 @@ namespace Serilog.Events
     public static class LogEventPropertyValueExtensions
     {
         private static readonly StructureValue EmptyStructureValue = new StructureValue(new LogEventProperty[0]);
-        
+
         /// <summary>
         ///     Provide a string representation for a property key
         /// </summary>
@@ -25,7 +23,7 @@ namespace Serilog.Events
         {
             Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
 
-            var logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
+            var logEventPropertyValue = eventPropertyValues.GetValueOrDefault(key: propertyKey);
             return logEventPropertyValue?.ToDecentString();
         }
 
@@ -39,7 +37,7 @@ namespace Serilog.Events
         {
             Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
 
-            LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
+            LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(key: propertyKey);
             string rawDouble = logEventPropertyValue?.ToDecentString();
 
             if (rawDouble != null)
@@ -61,7 +59,7 @@ namespace Serilog.Events
         {
             Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues));
 
-            var propertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
+            var propertyValue = eventPropertyValues.GetValueOrDefault(key: propertyKey);
             if (propertyValue == null || propertyValue is DictionaryValue == false)
             {
                 propertyDictionaryValues = null;
@@ -111,14 +109,14 @@ namespace Serilog.Events
             Guard.NotNull(eventPropertyValues, nameof(eventPropertyValues), "Requires a series of event properties to retrieve a Serilog event property as a enumeration representation");
             Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a enumeration representation");
 
-            LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(propertyKey);
+            LogEventPropertyValue logEventPropertyValue = eventPropertyValues.GetValueOrDefault(key: propertyKey);
             if (logEventPropertyValue is null)
             {
                 return null;
             }
-            
+
             string rawEnum = logEventPropertyValue.ToDecentString();
-            
+
             try
             {
                 if (Enum.TryParse(rawEnum, out TEnum enumRepresentation))
@@ -175,7 +173,7 @@ namespace Serilog.Events
             var value = bool.Parse(logEventPropertyValue);
             return value;
         }
-        
+
         /// <summary>
         /// Provide a <see cref="StructureValue"/> representation for a property value associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -188,12 +186,12 @@ namespace Serilog.Events
         public static StructureValue GetAsStructureValue(this IReadOnlyDictionary<string, LogEventPropertyValue> properties, string propertyKey)
         {
             Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve the structure value from the log event");
-            
+
             if (properties is null)
             {
                 return EmptyStructureValue;
             }
-            
+
             if (properties.TryGetValue(propertyKey, out LogEventPropertyValue propertyValue)
                 && propertyValue is StructureValue value)
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Enrichers/Extensions/LogEventPropertyValueExtensions.cs
@@ -11,7 +11,7 @@ namespace Serilog.Events
     /// </summary>
     public static class LogEventPropertyValueExtensions
     {
-        private static readonly StructureValue EmptyStructureValue = new StructureValue(new LogEventProperty[0]);
+        private static readonly StructureValue EmptyStructureValue = new StructureValue(Array.Empty<LogEventProperty>());
 
         /// <summary>
         ///     Provide a string representation for a property key
@@ -218,12 +218,12 @@ namespace Serilog.Events
             else
             {
                 string propertyValueAsString = logEventPropertyValue.ToString().Trim();
-                if (propertyValueAsString.StartsWith("\""))
+                if (propertyValueAsString.StartsWith('\"'))
                 {
                     propertyValueAsString = propertyValueAsString.Remove(0, 1);
                 }
 
-                if (propertyValueAsString.EndsWith("\""))
+                if (propertyValueAsString.EndsWith('\"'))
                 {
                     propertyValueAsString = propertyValueAsString.Remove(propertyValueAsString.Length - 1);
                 }


### PR DESCRIPTION
The standard .NET SDK already has an extension on dictionaries to provide a default value in case a key/value-pair is missing. We can therefore deprecate/later remove our own version.

Relates to #587 