### PR TITLE
chore(deps): remove guard.net references in correlation project

### DIFF
--- a/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
+++ b/src/Arcus.Observability.Correlation/Arcus.Observability.Correlation.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>

--- a/src/Arcus.Observability.Correlation/CorrelationInfo.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Correlation
 {
@@ -28,7 +27,7 @@ namespace Arcus.Observability.Correlation
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationId"/> is blank.</exception>
         public CorrelationInfo(string operationId, string transactionId, string operationParentId)
         {
-            Guard.NotNullOrEmpty(operationId, nameof(operationId), "Requires a non-blank operation ID to create a correlation instance");
+            ArgumentException.ThrowIfNullOrWhiteSpace(operationId);
 
             OperationId = operationId;
             TransactionId = transactionId;
@@ -44,7 +43,7 @@ namespace Arcus.Observability.Correlation
         /// Gets the unique ID information of the request.
         /// </summary>
         public string OperationId { get; }
-        
+
         /// <summary>
         /// Gets the ID of the original service that initiated this request.
         /// </summary>

--- a/src/Arcus.Observability.Correlation/CorrelationInfoAccessorProxy.cs
+++ b/src/Arcus.Observability.Correlation/CorrelationInfoAccessorProxy.cs
@@ -1,4 +1,4 @@
-﻿using GuardNet;
+﻿using System;
 
 namespace Arcus.Observability.Correlation
 {
@@ -16,7 +16,7 @@ namespace Arcus.Observability.Correlation
         /// </summary>
         internal CorrelationInfoAccessorProxy(ICorrelationInfoAccessor<TCorrelationInfo> correlationInfoAccessor)
         {
-            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor));
+            ArgumentNullException.ThrowIfNull(correlationInfoAccessor);
 
             _correlationInfoAccessor = correlationInfoAccessor;
         }

--- a/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Correlation/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -18,8 +17,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the default correlation accessor to the application services");
-
             return AddCorrelation<CorrelationInfo>(services);
         }
 
@@ -30,13 +27,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The services collection containing the dependency injection services.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation<TCorrelationInfo>(
-            this IServiceCollection services) 
+            this IServiceCollection services)
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the default correlation accessor to the application services");
-
             return AddCorrelation<DefaultCorrelationInfoAccessor<TCorrelationInfo>, TCorrelationInfo>(
-                services, 
+                services,
                 provider => new DefaultCorrelationInfoAccessor<TCorrelationInfo>());
         }
 
@@ -48,13 +43,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="createCustomCorrelationAccessor">The custom <see cref="ICorrelationInfoAccessor"/> implementation factory to retrieve the <see cref="CorrelationInfo"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="createCustomCorrelationAccessor"/> is <c>null</c>.</exception>
         public static IServiceCollection AddCorrelation<TAccessor>(
-            this IServiceCollection services, 
+            this IServiceCollection services,
             Func<IServiceProvider, TAccessor> createCustomCorrelationAccessor)
             where TAccessor : class, ICorrelationInfoAccessor
         {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
-            Guard.NotNull(createCustomCorrelationAccessor, nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");
-
             return AddCorrelation<TAccessor, CorrelationInfo>(services, createCustomCorrelationAccessor);
         }
 
@@ -72,8 +64,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAccessor : class, ICorrelationInfoAccessor<TCorrelationInfo>
             where TCorrelationInfo : CorrelationInfo
         {
-            Guard.NotNull(services, nameof(services), "Requires a service collection to register the custom correlation accessor to the application services");
-            Guard.NotNull(createCustomCorrelationAccessor, nameof(createCustomCorrelationAccessor), "Requires a factory function to create a custom correlation accessor");
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(createCustomCorrelationAccessor);
 
             services.AddScoped<ICorrelationInfoAccessor<TCorrelationInfo>>(createCustomCorrelationAccessor);
             services.AddScoped<ICorrelationInfoAccessor>(serviceProvider =>

--- a/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Correlation/CorrelationInfoTests.cs
@@ -43,7 +43,7 @@ namespace Arcus.Observability.Tests.Unit.Correlation
             var transactionId = Guid.NewGuid().ToString();
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => new CorrelationInfo(operationId: null, transactionId: transactionId));
+            Assert.ThrowsAny<ArgumentException>(() => new CorrelationInfo(operationId: null, transactionId: transactionId));
         }
     }
 }


### PR DESCRIPTION
Removes all Guard.NET references from the .Correlation project in favor of using the built-in argument checking.

Relates to #577 