### PR TITLE
chore(deps): remove guard.net references in core project

### DIFF
--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Iot
 {
@@ -16,7 +15,7 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         internal static IotHubConnectionStringParserResult Parse(string connectionString)
         {
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank connection string based on the hostname of the IoT Hub service");
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             string hostNameProperty =
                 connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -28,7 +27,7 @@ namespace Arcus.Observability.Telemetry.Core.Iot
                     "Cannot parse IoT Hub connection string because cannot find 'HostName' in IoT Hub connection string");
             }
 
-            string hostName = 
+            string hostName =
                 string.Join("", hostNameProperty.SkipWhile(ch => ch != '=').Skip(1));
 
             return new IotHubConnectionStringParserResult(hostName);

--- a/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Iot/IotHubConnectionStringParserResult.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Iot
 {
@@ -15,7 +14,7 @@ namespace Arcus.Observability.Telemetry.Core.Iot
         /// <exception cref="ArgumentException">Thrown when the <paramref name="hostName"/> is blank.</exception>
         internal IotHubConnectionStringParserResult(string hostName)
         {
-            Guard.NotNullOrWhitespace(hostName, nameof(hostName), "Requires a non-blank fully-qualified DNS hostname of the IoT Hub service");
+            ArgumentException.ThrowIfNullOrWhiteSpace(hostName);
             HostName = hostName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/DependencyLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -29,16 +28,16 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             string dependencyType,
             string dependencyName,
             object dependencyData,
-            string targetName, 
+            string targetName,
             TimeSpan duration,
             DateTimeOffset startTime,
             int? resultCode,
             bool isSuccessful,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
-            
+            ArgumentException.ThrowIfNullOrWhiteSpace(dependencyType);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
+
             DependencyType = dependencyType;
             DependencyName = dependencyName;
             DependencyData = dependencyData;
@@ -72,7 +71,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             string dependencyType,
             string dependencyName,
             object dependencyData,
-            string targetName, 
+            string targetName,
             string dependencyId,
             TimeSpan duration,
             DateTimeOffset startTime,
@@ -80,8 +79,8 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             bool isSuccessful,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(dependencyType, nameof(dependencyType), "Requires a non-blank custom dependency type when tracking the custom dependency");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the dependency operation");
+            ArgumentException.ThrowIfNullOrWhiteSpace(dependencyType);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
 
             DependencyId = dependencyId;
             DependencyType = dependencyType;
@@ -96,7 +95,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             Context = context;
             Context[ContextProperties.General.TelemetryType] = TelemetryType.Dependency;
         }
-        
+
         /// <summary>
         /// Gets the ID of the dependency to link as parent ID.
         /// </summary>
@@ -106,42 +105,42 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the custom type of the dependency.
         /// </summary>
         public string DependencyType { get; }
-        
+
         /// <summary>
         /// Gets the name of the dependency.
         /// </summary>
         public string DependencyName { get; }
-        
+
         /// <summary>
         /// Gets the custom data of the dependency.
         /// </summary>
         public object DependencyData { get; }
-        
+
         /// <summary>
         /// Gets the name of the dependency target.
         /// </summary>
         public string TargetName { get; }
-        
+
         /// <summary>
         /// Gets the code of the result of the interaction with the dependency.
         /// </summary>
         public int? ResultCode { get; }
-        
+
         /// <summary>
         /// Gets the indication whether or not the operation was successful.
         /// </summary>
         public bool IsSuccessful { get; }
-        
+
         /// <summary>
         /// Gets the point in time when the interaction with the HTTP dependency was started.
         /// </summary>
         public string StartTime { get; }
-        
+
         /// <summary>
         /// Gets the duration of the operation.
         /// </summary>
         public TimeSpan Duration { get; }
-        
+
         /// <summary>
         /// Gets the context that provides more insights on the dependency that was measured.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/EventLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -18,7 +17,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public EventLogEntry(string name, IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank event name to track an custom event");
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
             EventName = name;
             Context = context ?? new Dictionary<string, object>();
@@ -29,7 +28,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the name of the event.
         /// </summary>
         public string EventName { get; }
-        
+
         /// <summary>
         /// Gets the context that provides more insights on the event that occurred.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/MetricLogEntry.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -21,8 +20,8 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         public MetricLogEntry(string name, double value, DateTimeOffset timestamp, IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to track a metric");
-            
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
             MetricName = name;
             MetricValue = value;
             Timestamp = timestamp.ToString(FormatSpecifiers.InvariantTimestampFormat);
@@ -34,17 +33,17 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the name of the metric.
         /// </summary>
         public string MetricName { get; }
-        
+
         /// <summary>
         /// Gets the value of the metric.
         /// </summary>
         public double MetricValue { get; }
-        
+
         /// <summary>
         /// Gets the timestamp of the metric.
         /// </summary>
         public string Timestamp { get; }
-        
+
         /// <summary>
         /// Gets the context that provides more insights on the event that occurred.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Logging/RequestLogEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Logging
 {
@@ -36,11 +35,10 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             IDictionary<string, object> context)
         {
-            Guard.For<ArgumentException>(() => host?.Contains(" ") is true, "Requires a HTTP request host name without whitespace");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(statusCode, 100, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotGreaterThan(statusCode, 599, nameof(statusCode), "Requires a HTTP response status code that's within the 100-599 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+            ArgumentOutOfRangeException.ThrowIfLessThan(statusCode, 100);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(statusCode, 599);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
 
             RequestMethod = method;
             RequestHost = host;
@@ -81,9 +79,9 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             TimeSpan duration,
             IDictionary<string, object> context)
         {
-            Guard.NotLessThan(statusCode, 0, nameof(statusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotGreaterThan(statusCode, 999, nameof(statusCode), "Requires a HTTP response status code that's within the 0-999 range to track a HTTP request");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            ArgumentOutOfRangeException.ThrowIfLessThan(statusCode, 100);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(statusCode, 599);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
 
             return new RequestLogEntry(
                 method,
@@ -113,8 +111,8 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             IDictionary<string, object> context)
         {
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
-            
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
+
             return CreateWithoutHttpRequest(RequestSourceSystem.AzureServiceBus, operationName, isSuccessful, duration, startTime, context);
         }
 
@@ -134,8 +132,8 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request operation");
+            ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
 
             return CreateWithoutHttpRequest(RequestSourceSystem.AzureEventHubs, operationName, isSuccessful, duration, startTime, context);
         }
@@ -178,9 +176,9 @@ namespace Arcus.Observability.Telemetry.Core.Logging
             DateTimeOffset startTime,
             IDictionary<string, object> context)
         {
-            Guard.NotNullOrWhitespace(requestSource, nameof(requestSource), "Requires a non-blank request source to identify the caller");
-            Guard.NotNullOrWhitespace(operationName, nameof(operationName), "Requires a non-blank operation name");
-            Guard.NotLessThan(duration, TimeSpan.Zero, nameof(duration), "Requires a positive time duration of the request duration");
+            ArgumentException.ThrowIfNullOrWhiteSpace(requestSource);
+            ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
 
             return CreateWithoutHttpRequest(requestSource, operationName, isSuccessful, duration, startTime, context);
         }
@@ -209,27 +207,27 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         /// Gets the HTTP method of the request.
         /// </summary>
         public string RequestMethod { get; }
-        
+
         /// <summary>
         /// Gets the host that was requested.
         /// </summary>
         public string RequestHost { get; }
-        
+
         /// <summary>
         /// Gets ths URI of the request.
         /// </summary>
         public string RequestUri { get; }
-        
+
         /// <summary>
         /// Gets the HTTP response status code that was returned by the service.
         /// </summary>
         public int ResponseStatusCode { get; }
-        
+
         /// <summary>
         /// Gets the duration of the processing of the request.
         /// </summary>
         public TimeSpan RequestDuration { get; }
-        
+
         /// <summary>
         /// Gets the date when the request occurred.
         /// </summary>
@@ -262,7 +260,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
         public override string ToString()
         {
             var contextFormatted = $"{{{String.Join("; ", Context.Select(item => $"[{item.Key}, {item.Value}]"))}}}";
-            
+
             if (SourceSystem is RequestSourceSystem.Http)
             {
                 return $"{RequestMethod} {RequestHost}/{RequestUri} from {OperationName} completed with {ResponseStatusCode} in {RequestDuration} at {RequestTime} - (Context: {contextFormatted})";
@@ -270,7 +268,7 @@ namespace Arcus.Observability.Telemetry.Core.Logging
 
             string source = DetermineSource();
             bool isSuccessful = ResponseStatusCode is 200;
-            
+
             return $"{source} from {OperationName} completed in {RequestDuration} at {RequestTime} - (IsSuccessful: {isSuccessful}, Context: {contextFormatted})";
         }
 

--- a/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParser.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Core.Sql
 {
@@ -19,9 +18,9 @@ namespace Arcus.Observability.Telemetry.Core.Sql
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         internal static SqlConnectionStringParserResult Parse(string connectionString)
         {
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires a non-blank SQL connection string to retrieve specific SQL properties");
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
-            string[] parts = 
+            string[] parts =
                 connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
                                 .Select(part => part.Trim())
                                 .ToArray();
@@ -53,7 +52,7 @@ namespace Arcus.Observability.Telemetry.Core.Sql
             switch (propertyName)
             {
                 case SqlProperties.DataSource: return new[] { "Data Source", "Server", "Addr", "Address", "Network Address" };
-                case SqlProperties.InitialCatalog: return new [] { "Initial Catalog", "Database" };
+                case SqlProperties.InitialCatalog: return new[] { "Initial Catalog", "Database" };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown keyword with no known SQL property aliases");
             }

--- a/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParserResult.cs
+++ b/src/Arcus.Observability.Telemetry.Core/Sql/SqlConnectionStringParserResult.cs
@@ -1,6 +1,4 @@
-﻿using GuardNet;
-
-namespace Arcus.Observability.Telemetry.Core.Sql
+﻿namespace Arcus.Observability.Telemetry.Core.Sql
 {
     /// <summary>
     /// Represents the result of the <see cref="SqlConnectionStringParser"/> when parsing a SQL connection string.
@@ -69,7 +67,7 @@ namespace Arcus.Observability.Telemetry.Core.Sql
         ///  ]]></format>
         ///             </remarks>
         /// <exception cref="T:System.ArgumentNullException">To set the value to null, use <see cref="F:System.DBNull.Value" />.</exception>
-        internal string DataSource {get;}
+        internal string DataSource { get; }
 
         /// <summary>Gets or sets the name of the database associated with the connection.</summary>
         /// <value>The value of the <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.InitialCatalog" /> property, or <see langword="String.Empty" /> if none has been supplied.</value>


### PR DESCRIPTION
In preperation of removing the Guard.NET dependency, we can start replacing usages in the .Core project with the built-in argument checking.

Relates to #577 