### PR TITLE
chore(deps): remove guard.net references in serilog app-insights sink project

### DIFF
--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkCorrelationOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -22,7 +21,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _operationIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation ID");
+                ArgumentException.ThrowIfNullOrWhiteSpace(value);
                 _operationIdPropertyName = value;
             }
         }
@@ -36,7 +35,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation transaction ID");
+                ArgumentException.ThrowIfNullOrWhiteSpace(value);
                 _transactionIdPropertyName = value;
             }
         }
@@ -50,7 +49,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _operationParentIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Serilog application property name to locate the correlation operation parent ID");
+                ArgumentException.ThrowIfNullOrWhiteSpace(value);
                 _operationParentIdPropertyName = value;
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkExceptionOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -19,7 +18,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
         ///     Only the current-level properties are considered during the exception tracking; inherited properties will be excluded.
         /// </remarks>
         public bool IncludeProperties { get; set; } = false;
-        
+
         /// <summary>
         /// <para>Gets or sets the string format to track (public) exception properties.</para>
         /// <para>Default: <code>Exception-{0}</code></para>
@@ -37,8 +36,12 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _propertyFormat;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank string format to track (public) exception properties");
-                Guard.For<FormatException>(() => PropertyFormatRegex.Matches(value).Count != 3, "Requires a single occurrence of the substring '{0}' in the exception property format");
+                ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+                if (PropertyFormatRegex.Count(value) != 3)
+                {
+                    throw new FormatException("Requires a single occurrence of the substring '{0}' in the exception property format");
+                }
 
                 _propertyFormat = value;
             }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationInsightsSinkRequestOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration
 {
@@ -20,7 +19,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
             get => _generatedId;
             set
             {
-                Guard.NotNull(value, nameof(value), "Requires a function to generate the request ID of the telemetry model while tracking requests");
+                ArgumentNullException.ThrowIfNull(value);
                 _generatedId = value;
             }
         }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationNameTelemetryInitializer.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationNameTelemetryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
@@ -20,7 +19,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationName"/> is <c>null</c>.</exception>
         public ApplicationNameTelemetryInitializer(IAppName applicationName)
         {
-            Guard.NotNull(applicationName, nameof(applicationName), $"Requires an application name ({nameof(IAppName)}) implementation to retrieve the application name to initialize in the telemetry");
+            ArgumentNullException.ThrowIfNull(applicationName);
             _applicationName = applicationName;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationVersionTelemetryInitializer.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Configuration/ApplicationVersionTelemetryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
@@ -20,7 +19,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Config
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationVersion"/> is <c>null</c>.</exception>
         public ApplicationVersionTelemetryInitializer(IAppVersion applicationVersion)
         {
-            Guard.NotNull(applicationVersion, nameof(applicationVersion), $"Requires an application version ({nameof(IAppVersion)}) implementation to retrieve the application version to initialize in the telemetry");
+            ArgumentNullException.ThrowIfNull(applicationVersion);
             _applicationVersion = applicationVersion;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/ApplicationInsightsTelemetryConverter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
@@ -23,7 +22,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
 
         private ApplicationInsightsTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence how to track to Application Insights");
+            ArgumentNullException.ThrowIfNull(options);
 
             _requestTelemetryConverter = new RequestTelemetryConverter(options);
             _exceptionTelemetryConverter = new ExceptionTelemetryConverter(options);
@@ -32,7 +31,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             _metricTelemetryConverter = new MetricTelemetryConverter(options);
             _dependencyTelemetryConverter = new DependencyTelemetryConverter(options);
         }
-        
+
         /// <summary>
         ///     Convert the given <paramref name="logEvent"/> to a series of <see cref="ITelemetry"/> instances.
         /// </summary>

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/CustomTelemetryConverter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
@@ -27,8 +26,8 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         protected CustomTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
-            
+            ArgumentNullException.ThrowIfNull(options);
+
             _operationContextConverter = new OperationContextConverter(options);
             Options = options;
         }
@@ -45,8 +44,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="formatProvider">The instance to control formatting.</param>
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights telemetry instance");
+            ArgumentNullException.ThrowIfNull(logEvent);
 
             TEntry telemetryEntry = CreateTelemetryEntry(logEvent, formatProvider);
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/DependencyTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,8 +30,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override DependencyTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Dependency telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Dependency telemetry instance");
+            ArgumentNullException.ThrowIfNull(logEvent);
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.DependencyTracking.DependencyLogEntry);
             string dependencyId = logEntry.Properties.GetAsRawString(nameof(DependencyLogEntry.DependencyId));

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/EventTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,16 +30,15 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override EventTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Event telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Event telemetry instance");
+            ArgumentNullException.ThrowIfNull(logEvent);
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.EventTracking.EventLogEntry);
             string eventName = logEntry.Properties.GetAsRawString(nameof(EventLogEntry.EventName));
             IDictionary<string, string> context = logEntry.Properties.GetAsDictionary(nameof(EventLogEntry.Context));
-            
+
             var eventTelemetry = new EventTelemetry(eventName);
             eventTelemetry.Properties.AddRange(context);
-            
+
             return eventTelemetry;
         }
     }

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/MetricTelemetryConverter.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
-namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters 
+namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
 {
     /// <summary>
     /// Represents a conversion from a Serilog <see cref="LogEvent"/> to a Application Insights <see cref="MetricTelemetry"/> instance.
@@ -31,15 +30,14 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override MetricTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Metric telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Metric telemetry instance");
+            ArgumentNullException.ThrowIfNull(logEvent);
 
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.MetricTracking.MetricLogEntry);
             string metricName = logEntry.Properties.GetAsRawString(nameof(MetricLogEntry.MetricName));
             double metricValue = logEntry.Properties.GetAsDouble(nameof(MetricLogEntry.MetricValue));
             DateTimeOffset timestamp = logEntry.Properties.GetAsDateTimeOffset(nameof(MetricLogEntry.Timestamp));
             IDictionary<string, string> context = logEntry.Properties.GetAsDictionary(nameof(MetricLogEntry.Context));
-            
+
             var metricTelemetry = new MetricTelemetry(metricName, metricValue)
             {
                 Timestamp = timestamp

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/OperationContextConverter.cs
@@ -1,10 +1,8 @@
-﻿using Arcus.Observability.Telemetry.Core;
+﻿using System;
+using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using System;
-using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 
 namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters
 {
@@ -22,7 +20,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public OperationContextConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            ArgumentNullException.ThrowIfNull(options);
             _options = options;
         }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/RequestTelemetryConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
 
@@ -31,9 +30,8 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <returns>Telemetry entry to emit to Azure Application Insights</returns>
         protected override RequestTelemetry CreateTelemetryEntry(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights Request telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights Request telemetry instance");
-            
+            ArgumentNullException.ThrowIfNull(logEvent);
+
             StructureValue logEntry = logEvent.Properties.GetAsStructureValue(ContextProperties.RequestTracking.RequestLogEntry);
             string requestMethod = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestMethod));
             string requestHost = logEntry.Properties.GetAsRawString(nameof(RequestLogEntry.RequestHost));
@@ -91,7 +89,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 string entityName = context[ContextProperties.RequestTracking.ServiceBus.EntityName];
                 string namespaceEndpoint = context[ContextProperties.RequestTracking.ServiceBus.Endpoint];
-                
+
                 return $"type:Azure Service Bus | name:{entityName} | endpoint:sb://{namespaceEndpoint}/";
             }
 
@@ -99,7 +97,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
             {
                 string name = context[ContextProperties.RequestTracking.EventHubs.Name];
                 string namespaceEndpoint = context[ContextProperties.RequestTracking.EventHubs.Namespace];
-                
+
                 return $"{namespaceEndpoint}.servicebus.windows.net/{name}";
             }
 

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Converters/TraceTelemetryConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Serilog.Events;
@@ -23,7 +22,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public TraceTelemetryConverter(ApplicationInsightsSinkOptions options)
         {
-            Guard.NotNull(options, nameof(options), "Requires a set of options to influence the behavior of the Application Insights Serilog sink");
+            ArgumentNullException.ThrowIfNull(options);
             _operationContextConverter = new OperationContextConverter(options);
         }
 
@@ -34,8 +33,7 @@ namespace Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Conver
         /// <param name="formatProvider">The instance to control formatting.</param>
         public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
         {
-            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to create an Azure Application Insights trace telemetry instance");
-            Guard.NotNull(logEvent.Properties, nameof(logEvent), "Requires a Serilog event with a set of properties to create an Azure Application Insights trace telemetry instance");
+            ArgumentNullException.ThrowIfNull(logEvent);
 
             foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IDictionaryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using GuardNet;
-
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
     /// <summary>
@@ -17,9 +15,9 @@ namespace System.Collections.Generic
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="items"/> or <paramref name="additionalItems"/> is <c>null</c>.</exception>
         internal static void AddRange(this IDictionary<string, string> items, IDictionary<string, string> additionalItems)
         {
-            Guard.NotNull(items, nameof(items), "Requires a base dictionary to add the additional items to");
-            Guard.NotNull(additionalItems, nameof(additionalItems), "Requires an additional set of items to add to the base dictionary");
-            
+            ArgumentNullException.ThrowIfNull(items);
+            ArgumentNullException.ThrowIfNull(additionalItems);
+
             foreach (KeyValuePair<string, string> property in additionalItems)
             {
                 items.Add(property);

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/ILoggingBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Extensions.Logging;
 
@@ -22,8 +21,8 @@ namespace Microsoft.Extensions.Logging
             this ILoggingBuilder builder,
             Func<IServiceProvider, Serilog.ILogger> implementationFactory)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a logging builder instance to add the Serilog logger provider");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires an implementation factory to build up the Serilog logger");
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(implementationFactory);
 
             builder.Services.AddSingleton<ILoggerProvider>(provider =>
             {

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Core;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
-using GuardNet;
 using Microsoft.ApplicationInsights.Extensibility;
 
 // ReSharper disable once CheckNamespace
@@ -13,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection
     // ReSharper disable once InconsistentNaming
     public static class IServiceCollectionExtensions
     {
-         /// <summary>
+        /// <summary>
         /// Adds an <see cref="IAppName"/> implementation to the application which can be used to retrieve the current application's name.
         /// </summary>
         /// <param name="services">The collection of registered services to add the <see cref="IAppName"/> implementation to.</param>
@@ -24,9 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             string componentName)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
-            Guard.NotNullOrWhitespace(componentName, nameof(componentName), "Requires a non-blank functional name to identity the application");
-
+            ArgumentException.ThrowIfNullOrWhiteSpace(componentName);
             return AddAppName(services, provider => new DefaultAppName(componentName));
         }
 
@@ -40,8 +37,8 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Func<IServiceProvider, IAppName> implementationFactory)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppName)}' implementation");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), $"Requires a factory function to create the '{nameof(IAppName)}' implementation");
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(implementationFactory);
 
             return services.AddSingleton(implementationFactory)
                            .AddSingleton<ITelemetryInitializer, ApplicationNameTelemetryInitializer>();
@@ -55,8 +52,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAssemblyAppVersion<TConsumerType>(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
-
             return AddAppVersion(services, provider => new AssemblyAppVersion(typeof(TConsumerType)));
         }
 
@@ -68,9 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="consumerType"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAssemblyAppVersion(this IServiceCollection services, Type consumerType)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the assembly version '{nameof(IAppVersion)}' implementation");
-            Guard.NotNull(consumerType, nameof(consumerType), "Requires a consumer type to retrieve the assembly where the project runs");
-
+            ArgumentNullException.ThrowIfNull(consumerType);
             return AddAppVersion(services, provider => new AssemblyAppVersion(consumerType));
         }
 
@@ -82,7 +75,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static IServiceCollection AddAppVersion<TAppVersion>(this IServiceCollection services) where TAppVersion : class, IAppVersion
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
             return AddAppVersion(services, provider => ActivatorUtilities.CreateInstance<TAppVersion>(provider));
         }
 
@@ -96,8 +88,8 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Func<IServiceProvider, IAppVersion> createImplementation)
         {
-            Guard.NotNull(services, nameof(services), $"Requires a collection of services to add the '{nameof(IAppVersion)}' implementation");
-            Guard.NotNull(createImplementation, nameof(createImplementation), $"Requires a factory function to create the '{nameof(IAppVersion)}' implementation");
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(createImplementation);
 
             return services.AddSingleton(createImplementation)
                            .AddSingleton<ITelemetryInitializer, ApplicationVersionTelemetryInitializer>();

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LogEventPropertyExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Serilog.Events
@@ -13,7 +12,7 @@ namespace Serilog.Events
     internal static class LogEventPropertyExtensions
     {
         private static readonly IDictionary<string, string> EmptyContext = new Dictionary<string, string>();
-        
+
         /// <summary>
         /// Gets a raw string representation for a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -27,20 +26,20 @@ namespace Serilog.Events
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         internal static string GetAsRawString(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property value as a raw string representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a raw string representation");
-            
+            ArgumentNullException.ThrowIfNull(propertyKey);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             LogEventProperty propertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
-            if (propertyValue?.Value is null 
-                || (propertyValue.Value is ScalarValue scalarValue 
+            if (propertyValue?.Value is null
+                || (propertyValue.Value is ScalarValue scalarValue
                     && scalarValue.Value is null))
             {
                 return null;
             }
-            
+
             return propertyValue.Value.ToDecentString();
         }
-        
+
         /// <summary>
         /// Gets a <see cref="TimeSpan"/> representation for a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -55,19 +54,19 @@ namespace Serilog.Events
         /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="TimeSpan"/> duration.</exception>
         internal static TimeSpan GetAsTimeSpan(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a TimeSpan representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a TimeSpan representation");
-            
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
             {
                 return TimeSpan.Zero;
             }
-            
+
             TimeSpan value = TimeSpan.Parse(propertyValue);
             return value;
         }
-        
+
         /// <summary>
         /// Gets a <see cref="DateTimeOffset"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -82,19 +81,19 @@ namespace Serilog.Events
         /// <exception cref="FormatException">Throw when the property value cannot be parsed as a <see cref="DateTimeOffset"/> due to its format.</exception>
         internal static DateTimeOffset GetAsDateTimeOffset(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a DateTimeOffset representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a DateTimeOffset representation");
-            
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
             {
                 return default(DateTimeOffset);
             }
-            
+
             DateTimeOffset value = DateTimeOffset.Parse(propertyValue, CultureInfo.InvariantCulture);
             return value;
         }
-        
+
         /// <summary>
         /// Gets a <see cref="IDictionary{TKey,TValue}"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -108,12 +107,12 @@ namespace Serilog.Events
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         internal static IDictionary<string, string> GetAsDictionary(
-            this IReadOnlyList<LogEventProperty> properties, 
+            this IReadOnlyList<LogEventProperty> properties,
             string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a IDictionary<string, string> representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property value as a IDictionary<string, string> represenation");
-            
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (property?.Value is DictionaryValue dictionary)
             {
@@ -124,7 +123,7 @@ namespace Serilog.Events
 
             return EmptyContext;
         }
-        
+
         /// <summary>
         /// Gets a <see cref="Double"/> representation of a property value in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -140,16 +139,16 @@ namespace Serilog.Events
         /// <exception cref="OverflowException">Thrown when the property value is lesser or greater than the supported <see cref="Double"/> range.</exception>
         internal static double GetAsDouble(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Double representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property key to retrieve a Serilog event property as a Double representation");
-            
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             LogEventProperty logEventPropertyValue = properties.FirstOrDefault(prop => prop.Name == propertyKey);
             if (logEventPropertyValue is null)
             {
                 return double.NaN;
             }
 
-            if (logEventPropertyValue.Value is ScalarValue scalarValue 
+            if (logEventPropertyValue.Value is ScalarValue scalarValue
                 && scalarValue.Value is double value)
             {
                 return value;
@@ -157,7 +156,7 @@ namespace Serilog.Events
 
             return double.NaN;
         }
-        
+
         /// <summary>
         /// Gets a <see cref="Boolean"/> representation of a property in the <paramref name="properties"/> associated with the <paramref name="propertyKey"/>.
         /// </summary>
@@ -171,15 +170,15 @@ namespace Serilog.Events
         /// <exception cref="FormatException">Thrown when the property value cannot be parsed as a <see cref="Boolean"/> due to its format.</exception>
         internal static bool GetAsBool(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as a Boolean representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as a Boolean representation");
-            
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
+
             string propertyValue = properties.GetAsRawString(propertyKey);
             if (propertyValue is null)
             {
                 return false;
             }
-            
+
             bool value = bool.Parse(propertyValue);
             return value;
         }
@@ -197,12 +196,12 @@ namespace Serilog.Events
         /// <exception cref="ArgumentException">Thrown when the <paramref name="propertyKey"/> is blank.</exception>
         internal static TValue GetAsObject<TValue>(this IReadOnlyList<LogEventProperty> properties, string propertyKey)
         {
-            Guard.NotNull(properties, nameof(properties), "Requires a series of event properties to retrieve a Serilog event property as an enumeration representation");
-            Guard.NotNullOrWhitespace(propertyKey, nameof(propertyKey), "Requires a non-blank property to retrieve a Serilog event property as an enumeration representation");
+            ArgumentNullException.ThrowIfNull(properties);
+            ArgumentException.ThrowIfNullOrWhiteSpace(propertyKey);
 
             LogEventProperty property = properties.FirstOrDefault(prop => prop.Name == propertyKey);
-            if (property != null 
-                && property.Value is ScalarValue scalarValue 
+            if (property != null
+                && property.Value is ScalarValue scalarValue
                 && scalarValue.Value is TValue value)
             {
                 return value;

--- a/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Configuration;
 using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.Converters;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,9 +28,6 @@ namespace Serilog.Configuration
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string instrumentationKey)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose);
         }
 
@@ -51,9 +47,6 @@ namespace Serilog.Configuration
             string instrumentationKey,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, LogEventLevel.Verbose, configureOptions);
         }
 
@@ -73,9 +66,6 @@ namespace Serilog.Configuration
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
         }
 
@@ -97,8 +87,8 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            ArgumentNullException.ThrowIfNull(loggerSinkConfiguration);
+            ArgumentException.ThrowIfNullOrWhiteSpace(instrumentationKey);
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -125,9 +115,6 @@ namespace Serilog.Configuration
             IServiceProvider serviceProvider,
             string instrumentationKey)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose);
         }
 
@@ -152,9 +139,6 @@ namespace Serilog.Configuration
             string instrumentationKey,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, LogEventLevel.Verbose, configureOptions);
         }
 
@@ -179,9 +163,6 @@ namespace Serilog.Configuration
             string instrumentationKey,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithInstrumentationKey(loggerSinkConfiguration, serviceProvider, instrumentationKey, restrictedToMinimumLevel, configureOptions: null);
         }
 
@@ -208,8 +189,8 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            ArgumentNullException.ThrowIfNull(loggerSinkConfiguration);
+            ArgumentException.ThrowIfNullOrWhiteSpace(instrumentationKey);
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -231,9 +212,6 @@ namespace Serilog.Configuration
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string connectionString)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, configureOptions: null);
         }
 
@@ -253,9 +231,6 @@ namespace Serilog.Configuration
             string connectionString,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, LogEventLevel.Verbose, configureOptions);
         }
 
@@ -275,9 +250,6 @@ namespace Serilog.Configuration
             string connectionString,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, connectionString, restrictedToMinimumLevel, configureOptions: null);
         }
 
@@ -299,8 +271,8 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            ArgumentNullException.ThrowIfNull(loggerSinkConfiguration);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -330,9 +302,6 @@ namespace Serilog.Configuration
             IServiceProvider serviceProvider,
             string connectionString)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, configureOptions: null);
         }
 
@@ -357,9 +326,6 @@ namespace Serilog.Configuration
             string connectionString,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, LogEventLevel.Verbose, configureOptions);
         }
 
@@ -384,9 +350,6 @@ namespace Serilog.Configuration
             string connectionString,
             LogEventLevel restrictedToMinimumLevel)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
-
             return AzureApplicationInsightsWithConnectionString(loggerSinkConfiguration, serviceProvider, connectionString, restrictedToMinimumLevel, configureOptions: null);
         }
 
@@ -413,8 +376,8 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel,
             Action<ApplicationInsightsSinkOptions> configureOptions)
         {
-            Guard.NotNull(loggerSinkConfiguration, nameof(loggerSinkConfiguration), "Requires a logger configuration to add the Azure Application Insights sink to");
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString), "Requires an instrumentation key to authenticate with Azure Application Insights while sinking telemetry");
+            ArgumentNullException.ThrowIfNull(loggerSinkConfiguration);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             var options = new ApplicationInsightsSinkOptions();
             configureOptions?.Invoke(options);
@@ -423,7 +386,7 @@ namespace Serilog.Configuration
             if (client is null)
             {
                 throw new InvalidOperationException(
-                    "Could not retrieve Microsoft telemetry client from the application registered services, this happens when the Application Insights services are not registered in the application services," 
+                    "Could not retrieve Microsoft telemetry client from the application registered services, this happens when the Application Insights services are not registered in the application services,"
                     + "please use one of Arcus' extensions like 'services.AddHttpCorrelation()' to automatically register the Application Insights when using the W3C correlation system, "
                     + $"when using the Hierarchical correlation system, use the {nameof(AzureApplicationInsightsWithConnectionString)} extension without the service provider instead");
             }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkExceptionOptionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/ApplicationInsightsSinkExceptionOptionsTests.cs
@@ -7,17 +7,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
     public class ApplicationInsightsSinkExceptionOptionsTests
     {
         [Theory]
-        [ClassData(typeof(Blanks))]
-        public void SetPropertyFormat_WithBlankValue_Fails(string propertyFormat)
-        {
-            // Arrange
-            var options = new ApplicationInsightsSinkExceptionOptions();
-            
-            // Act / Assert
-            Assert.Throws<ArgumentException>(() => options.PropertyFormat = propertyFormat);
-        }
-
-        [Theory]
         [InlineData("Exception-{0}-{1}")]
         [InlineData("Exception.{0}.Inner.{0}")]
         [InlineData("Exception-")]
@@ -25,7 +14,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
         {
             // Arrange
             var options = new ApplicationInsightsSinkExceptionOptions();
-            
+
             // Act / Assert
             Assert.Throws<FormatException>(() => options.PropertyFormat = propertyFormat);
         }
@@ -38,7 +27,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
         {
             // Arrange
             var options = new ApplicationInsightsSinkExceptionOptions();
-            
+
             // Act / Assert
             options.PropertyFormat = propertyFormat;
         }

--- a/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
+++ b/src/Arcus.Observability.Tests.Unit/Serilog/Sinks/ApplicationInsights/LoggerConfigurationExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
                 () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(provider, "<key>", level, options => { }));
         }
 
-         [Fact]
+        [Fact]
         public void AzureApplicationInsightsWithConnectionString_WithoutTelemetryClient_Fails()
         {
             // Arrange
@@ -118,102 +118,6 @@ namespace Arcus.Observability.Tests.Unit.Serilog.Sinks.ApplicationInsights
             // Act / Assert
             Assert.ThrowsAny<InvalidOperationException>(
                 () => config.WriteTo.AzureApplicationInsightsWithConnectionString(provider, "<connection-string>", level, options => { }));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithInstrumentationKey_WithoutInstrumentationKey_Fails(string instrumentationKey)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(instrumentationKey));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithInstrumentationKeyWithConfigOptions_WithoutInstrumentationKey_Fails(string instrumentationKey)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(instrumentationKey, options => { }));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithInstrumentationKeyWithMinLogLevel_WithoutInstrumentationKey_Fails(string instrumentationKey)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(instrumentationKey, LogEventLevel.Debug));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithInstrumentationKeyWithMinLogLevelWithConfigOptions_WithoutInstrumentationKey_Fails(string instrumentationKey)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithInstrumentationKey(instrumentationKey, LogEventLevel.Debug, options => { }));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithConnectionString_WithoutInstrumentationKey_Fails(string connectionString)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithConnectionStringWithConfigOptions_WithoutInstrumentationKey_Fails(string connectionString)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString, options => { }));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithConnectionStringWithMinLogLevel_WithoutInstrumentationKey_Fails(string connectionString)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString, LogEventLevel.Debug));
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AzureApplicationInsightsWithConnectionStringWithMinLogLevelWithConfigOptions_WithoutInstrumentationKey_Fails(string connectionString)
-        {
-            // Arrange
-            var config = new LoggerConfiguration();
-
-            // Act / Assert
-            Assert.Throws<ArgumentException>(
-                () => config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString, LogEventLevel.Debug, options => { }));
         }
     }
 }


### PR DESCRIPTION
Removes the usages of the Guard.NET package in the Serilog Application Insights sink project, so we can later remove the dependency in the .Core package.

Relates to #577 